### PR TITLE
Rename the global namespace literal DELTA to avoid clashes with other libraries

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -73,7 +73,7 @@ extern const char * OSQP_ERROR_MESSAGE[];
 
 
 # ifndef EMBEDDED
-#  define DELTA (1E-6)
+#  define OSQP_DELTA (1E-6)
 #  define POLISH (0)
 #  define POLISH_REFINE_ITER (3)
 #  define VERBOSE (1)

--- a/src/osqp.c
+++ b/src/osqp.c
@@ -50,7 +50,7 @@ void osqp_set_default_settings(OSQPSettings *settings) {
   settings->linsys_solver = LINSYS_SOLVER;           /* relaxation parameter */
 
 #ifndef EMBEDDED
-  settings->delta              = DELTA;              /* regularization parameter
+  settings->delta              = OSQP_DELTA;              /* regularization parameter
                                                         for polish */
   settings->polish             = POLISH;             /* ADMM solution polish: 1
                                                       */


### PR DESCRIPTION
I ran into issues using osqp with https://gtsam.org/ since it uses "DELTA" as a constant that was being replaced by #define DELTA in osqp code. 

I think this minor change does not affect anything in osqp, but should avoid clashes with other libraries.

If you don't mind this change, perhaps "VERBOSE" should be renamed as well since it also seems like a common name (though I did not have any particular issue with this).