### PR TITLE
Github actions

### DIFF
--- a/.github/workflows/build_docs.sh
+++ b/.github/workflows/build_docs.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Adapted from:
+# https://tech.michaelaltfield.net/2020/07/18/sphinx-rtd-github-pages-1/
+
+set -x
+pwd
+ls -lah
+export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
+
+#######################
+# Update GitHub Pages #
+#######################
+
+git config --global user.name "${GITHUB_ACTOR}"
+git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
+docroot=`mktemp -d`
+rsync -av "docs/_build/html/" "${docroot}/"
+
+pushd "${docroot}"
+
+# don't bother maintaining history; just generate fresh
+git init
+git remote add deploy "https://token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+git checkout -b gh-pages
+
+
+# copy the resulting html pages built from sphinx above to our new git repo
+git add .
+
+# commit all the new files
+msg="Updating Docs for commit ${GITHUB_SHA} made on `date -d"@${SOURCE_DATE_EPOCH}" --iso-8601=seconds` from ${GITHUB_REF} by ${GITHUB_ACTOR}"
+git commit -am "${msg}"
+
+# overwrite the contents of the gh-pages branch on our github.com repo
+git push deploy gh-pages --force
+
+popd # return to main repo sandbox root

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,7 +107,7 @@ jobs:
           uses: imciner2/run-lcov@v1
           with:
             input_directory: '${{ runner.workspace }}/osqp/build'
-            exclude: '"$GITHUB_WORKSPACE/tests/*" "$GITHUB_WORKSPACE/lin_sys/direct/qdldl/amd/*" "$GITHUB_WORKSPACE/lin_sys/direct/qdldl/qdldl_sources/*"" "/usr/include/*"'
+            exclude: '"$GITHUB_WORKSPACE/tests/*" "$GITHUB_WORKSPACE/lin_sys/direct/qdldl/amd/*" "$GITHUB_WORKSPACE/lin_sys/direct/qdldl/qdldl_sources/*" "/usr/include/*"'
             output_file: '${{ runner.workspace }}/osqp/build/coverage.info'
           if: ${{ runner.os == 'Linux' && matrix.cmake_flags == '-DUNITTESTS=ON -DCOVERAGE=ON' && matrix.cmake_flags_extra == '' }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,15 +106,15 @@ jobs:
         - name: Generate coverage
           uses: imciner2/run-lcov@v1
           with:
-            input_directory: '${{ runner.workspace }}/build'
+            input_directory: '${{ runner.workspace }}/osqp/build'
             exclude: '"$GITHUB_WORKSPACE/tests/*" "$GITHUB_WORKSPACE/lin_sys/direct/qdldl/amd/*" "$GITHUB_WORKSPACE/lin_sys/direct/qdldl/qdldl_sources/*"" "/usr/include/*"'
-            output_file: '${{ runner.workspace }}/build/coverage.info'
-            if: ${{ runner.os == 'Linux' && matrix.cmake_flags == '-DUNITTESTS=ON -DCOVERAGE=ON' && matrix.cmake_flags_extra == '' }}
+            output_file: '${{ runner.workspace }}/osqp/build/coverage.info'
+          if: ${{ runner.os == 'Linux' && matrix.cmake_flags == '-DUNITTESTS=ON -DCOVERAGE=ON' && matrix.cmake_flags_extra == '' }}
 
         - name: Coveralls
           uses: coverallsapp/github-action@master
           with:
-            path-to-lcov: '${{ runner.workspace }}/build/coverage.info'
+            path-to-lcov: '${{ runner.workspace }}/osqp/build/coverage.info'
             github-token: ${{ secrets.GITHUB_TOKEN }}
           if: ${{ runner.os == 'Linux' && matrix.cmake_flags == '-DUNITTESTS=ON -DCOVERAGE=ON' && matrix.cmake_flags_extra == '' }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,7 @@ jobs:
 
         - name: Build
           run: |
-            cmake -G ${{ matrix.cmake_generator }} -S . -B build ${{ matrix.cmake_flags }} ${{ matrix.cmake_flags_extra }}
+            cmake -G "${{ matrix.cmake_generator }}" -S . -B build ${{ matrix.cmake_flags }} ${{ matrix.cmake_flags_extra }}
             cmake --build build
 
         - name: Test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,12 +104,12 @@ jobs:
           if: ${{ runner.os == 'Linux' && matrix.cmake_flags == '-DUNITTESTS=ON -DCOVERAGE=ON' && matrix.cmake_flags_extra == '-DENABLE_MKL_PARDISO=OFF' }}
 
         - name: Generate coverage
-        uses: imciner2/run-lcov@v1
-        with:
-          input_directory: '${{ runner.workspace }}/build'
-          exclude: '"$GITHUB_WORKSPACE/tests/*" "$GITHUB_WORKSPACE/lin_sys/direct/qdldl/amd/*" "$GITHUB_WORKSPACE/lin_sys/direct/qdldl/qdldl_sources/*"" "/usr/include/*"'
-          output_file: '${{ runner.workspace }}/build/coverage.info'
-          if: ${{ runner.os == 'Linux' && matrix.cmake_flags == '-DUNITTESTS=ON -DCOVERAGE=ON' && matrix.cmake_flags_extra == '' }}
+          uses: imciner2/run-lcov@v1
+          with:
+            input_directory: '${{ runner.workspace }}/build'
+            exclude: '"$GITHUB_WORKSPACE/tests/*" "$GITHUB_WORKSPACE/lin_sys/direct/qdldl/amd/*" "$GITHUB_WORKSPACE/lin_sys/direct/qdldl/qdldl_sources/*"" "/usr/include/*"'
+            output_file: '${{ runner.workspace }}/build/coverage.info'
+            if: ${{ runner.os == 'Linux' && matrix.cmake_flags == '-DUNITTESTS=ON -DCOVERAGE=ON' && matrix.cmake_flags_extra == '' }}
 
         - name: Coveralls
           uses: coverallsapp/github-action@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,8 @@
-name: CI
+name: Main
 
 on:
   push:
-    branches: [ master, develop, gh-actions ]
+    branches: [ master, develop, ci ]
   pull_request:
     branches: [ master, develop ]
 
@@ -12,7 +12,7 @@ jobs:
       runs-on: ${{ matrix.os }}
 
       strategy:
-        fail-fast: true
+        fail-fast: false
 
         matrix:
           os: [ubuntu-latest, macos-latest, windows-latest]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,154 @@
+name: CI
+
+on:
+  push:
+    branches: [ master, develop, gh-actions ]
+  pull_request:
+    branches: [ master, develop ]
+
+jobs:
+
+  build_and_test:
+      runs-on: ${{ matrix.os }}
+
+      strategy:
+        fail-fast: true
+
+        matrix:
+          os: [ubuntu-latest, macos-latest, windows-latest]
+          python-version: [3.9]
+          cmake_flags: ['', '-DUNITTESTS=ON -DCOVERAGE=ON']
+          cmake_flags_extra: ['', '-DENABLE_MKL_PARDISO=OFF', '-DDFLOAT=ON', '-DDLONG=OFF', '-DEMBEDDED=1',
+                              '-DEMBEDDED=2', '-DPROFILING=OFF', '-DCTRLC=OFF', '-DPRINTING=OFF']
+          exclude:
+            - cmake_flags: '-DUNITTESTS=ON -DCOVERAGE=ON'
+              cmake_flags_extra: '-DEMBEDDED=1'
+            - cmake_flags: '-DUNITTESTS=ON -DCOVERAGE=ON'
+              cmake_flags_extra: '-DEMBEDDED=2'
+
+      defaults:
+        run:
+          # Required when using an activated conda environment in steps
+          # See https://github.com/conda-incubator/setup-miniconda#IMPORTANT
+          shell: bash -l {0}
+
+      steps:
+        - uses: actions/checkout@v2
+          with:
+            lfs: false
+            submodules: true
+
+        - name: Set up conda
+          uses: conda-incubator/setup-miniconda@v2
+          with:
+            auto-update-conda: true
+            python-version: ${{ matrix.python-version }}
+
+        # -----------------
+        # OS-specific setup
+        # -----------------
+        - name: Setup (Linux)
+          if: runner.os == 'Linux'
+          run: |
+            echo "CMAKE_GENERATOR=Unix Makefiles" >> $GITHUB_ENV
+            echo "LD_LIBRARY_PATH=$CONDA_PREFIX/lib" >> $GITHUB_ENV
+
+        - name: Setup (macOS)
+          if: runner.os == 'macOS'
+          # Newer versions of MacOS effectively block DYLD_LIBRARY_PATH being set (System Integrity Protection)
+          # Explicitly setting RPATH using `install_name_tool -add_rpath $CONDA_PREFIX/lib ./build/out/osqp_tester`
+          #   doesn't work either.
+          # Here we get around it by using a standard non-root location for .dylib files as a soft link
+          run: |
+            echo "CMAKE_GENERATOR=Unix Makefiles" >> $GITHUB_ENV
+            echo "DYLD_LIBRARY_PATH=$CONDA_PREFIX/lib" >> $GITHUB_ENV
+            ln -s $CONDA_PREFIX/lib ~/lib
+
+        - name: Setup (Windows)
+          if: runner.os == 'Windows'
+          run: |
+            echo "CMAKE_GENERATOR=MinGW Makefiles" >> $GITHUB_ENV
+            echo "$CONDA_PREFIX/Library/bin" >> $GITHUB_PATH
+        # -----------------
+
+        # Fetching mkl from the anaconda channel instead of defaults gives us the MKL runtime dynamic libraries
+        # as well (mkl_rt.<dll/so>), required during the runtime testing steps.
+        # MKL on Anaconda 2021.* seems to have inexplicably renamed mkl_rt.dll to mkl_rt.1.dll, so we insist on
+        # a version earlier than 2021
+        - name: Install python dependencies
+          run: |
+            conda install -c anaconda "mkl<2021" numpy scipy
+            conda info
+            conda list
+
+        - name: Build
+          run: |
+            cmake -S . -B build ${{ matrix.cmake_flags }} ${{ matrix.cmake_flags_extra }}
+            cmake --build build
+
+        - name: Test
+          run: |
+            ./build/out/osqp_tester
+          if: ${{ matrix.cmake_flags == '-DUNITTESTS=ON -DCOVERAGE=ON' }}
+
+        - name: Valgrid check
+          run: |
+            sudo apt-get install valgrind
+            valgrind --suppressions=.valgrind-suppress.supp --leak-check=full --gen-suppressions=all \
+              --track-origins=yes --error-exitcode=1 build/out/osqp_tester
+          if: ${{ runner.os == 'Linux' && matrix.cmake_flags == '-DUNITTESTS=ON -DCOVERAGE=ON' && matrix.cmake_flags_extra == '-DENABLE_MKL_PARDISO=OFF' }}
+
+        - name: Generate coverage
+          run: |
+            sudo apt-get install lcov
+            sudo gem install coveralls-lcov
+            lcov --directory build/ --capture -o coverage.info
+            lcov --remove coverage.info \
+              "$(pwd)/tests/*" \
+              "$(pwd)/lin_sys/direct/qdldl/amd/*" \
+              "$(pwd)/lin_sys/direct/qdldl/qdldl_sources/*" \
+              "/usr/include/*" \
+              -o coverage.info
+            lcov --list coverage.info
+          if: ${{ runner.os == 'Linux' && matrix.cmake_flags == '-DUNITTESTS=ON -DCOVERAGE=ON' && matrix.cmake_flags_extra == '' }}
+
+        - name: Coveralls
+          uses: coverallsapp/github-action@master
+          with:
+            path-to-lcov: coverage.info
+            github-token: ${{ secrets.GITHUB_TOKEN }}
+          if: ${{ runner.os == 'Linux' && matrix.cmake_flags == '-DUNITTESTS=ON -DCOVERAGE=ON' && matrix.cmake_flags_extra == '' }}
+
+  build_docs:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: [3.9]
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          lfs: false
+
+      - name: Install OS dependencies
+        run: |
+          sudo apt-get install doxygen
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install Python dependencies
+        run: |
+          pip install sphinx sphinx-rtd-theme breathe
+
+      - name: Build docs
+        run: |
+          cd docs && make html && touch _build/html/.nojekyll
+
+      - name: Update gh-pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ".github/workflows/build_docs.sh"
+        shell: bash

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # The Operator Splitting QP Solver
 
-[![Build status of the master branch on Linux/OSX](https://img.shields.io/travis/oxfordcontrol/osqp/master.svg?label=Linux%20%2F%20OSX%20build)](https://travis-ci.org/oxfordcontrol/osqp)
-[![Build status of the master branch on Windows](https://img.shields.io/appveyor/ci/bstellato/osqp/master.svg?label=Windows%20build)](https://ci.appveyor.com/project/bstellato/osqp/branch/master)
+[![CI](https://github.com/osqp/osqp/actions/workflows/main.yml/badge.svg)](https://github.com/osqp/osqp/actions/workflows/main.yml)
 [![Code coverage](https://coveralls.io/repos/github/oxfordcontrol/osqp/badge.svg?branch=master)](https://coveralls.io/github/oxfordcontrol/osqp?branch=master)
 ![License](https://img.shields.io/badge/License-Apache%202.0-brightgreen.svg)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -115,7 +115,7 @@ on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 if not on_rtd:  # only import and set the theme if we're building docs locally
     # Override default css to get a larger width for local build
     def setup(app):
-        app.add_stylesheet('css/osqp_theme.css')
+        app.add_css_file('css/osqp_theme.css')
 else:
     html_context = {
         'css_files': [


### PR DESCRIPTION
All steps I found in the old shell scripts for Travis/Appveyor seem to work fine with this setup, on all 3 platforms.
I'm using a matrix of cmake flags across all platforms, but certain steps (valgrind/coveralls etc.) are only performed only on certain matrix values of the variables.

  - Build
  - Test (if `-DUNITTESTS=ON -DCOVERAGE=ON` in the build step).
  - Valgrind/Coveralls in the case when using Linux + base cmake case with `-DUNITTESTS=ON -DCOVERAGE=ON`
  - Building Sphinx Docs

For the last step, the `.html` pages are deployed in a branch called `gh-pages`. To integrate this with Github pages, someone in charge of the repo would have to go to 'Settings -> Github Pages -> Source -> select `gh-pages` as the branch, with `/` as the folder. The live site (minus the current landing pages which seem to be generated from outside the source tree), should then be available at https://osqp.github.io/osqp/, which can be linked from somewhere in the README.