### PR TITLE
Initial citation file to use GitHub's built-in citation tool

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,39 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite the article from the preferred-citation below."
+title: "OSQP Solver"
+authors:
+  - family-names: "Stellato"
+    given-names: "Bartolomeo"
+  - family-names: "Banjac"
+    given-names: "Goran"
+  - family-names: "Goulart"
+    given-names: "Paul"
+  - family-names: "Bemporad"
+    given-names: "Alberto"
+  - family-names: "Boyd"
+    given-names: "Stephen"
+url: "https://github.com/osqp/osqp"
+
+# This is the main OSQP paper that describes the algorithm
+preferred-citation:
+  type: article
+  authors:
+  - family-names: "Stellato"
+    given-names: "Bartolomeo"
+  - family-names: "Banjac"
+    given-names: "Goran"
+  - family-names: "Goulart"
+    given-names: "Paul"
+  - family-names: "Bemporad"
+    given-names: "Alberto"
+  - family-names: "Boyd"
+    given-names: "Stephen"
+  title: "OSQP: an operator splitting solver for quadratic programs"
+  journal: "Mathematical Programming Computation"
+  start: 637 # First page number
+  end: 672 # Last page number
+  volume: 12
+  issue: 4
+  year: 2020
+  doi: 10.1007/s12532-020-00179-2
+  url: https://doi.org/10.1007/s12532-020-00179-2


### PR DESCRIPTION
GitHub has recently added the ability for the sidebar of the main repo to display information about how to cite a repository and its software. They use the CFF (citation file format) as their basis (although they did add bibtex support, but it isn't as featured), so we need to add a CITATION.cff file to use this. This format allows for specifying the preferred thing to cite, so we can specify the published paper as what people should cite.

More information about this: https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-citation-files and https://twitter.com/natfriedman/status/1420122675813441540?s=20