### PR TITLE
Update Gemfile

### DIFF
--- a/site/Gemfile
+++ b/site/Gemfile
@@ -30,5 +30,5 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 # gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-gem 'bootstrap', "~> 4.1.3"
+gem "bootstrap", ">= 4.3.1"
 gem 'jquery-rails'


### PR DESCRIPTION
Update bootstrap to >= 4.3.1 as suggested by dependabot. The packaged bootstrap css files are all version 4.3.1 anyway. Since this line seems to have no effect (till issue #325 is resolved) this should not break anything with the static website creation.