### PR TITLE
Replaced oxfordcontrol/Bintray references

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lin_sys/direct/qdldl/qdldl_sources"]
 	path = lin_sys/direct/qdldl/qdldl_sources
-	url = https://github.com/oxfordcontrol/qdldl.git
+	url = https://github.com/osqp/qdldl.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Version 0.6.0 (30 August 2019)
 Version 0.5.0 (10 December 2018)
 ----------------
 * Added `update_time` to the info structure.
-* Fixed [#101](https://github.com/oxfordcontrol/osqp/issues/101).
+* Fixed [#101](https://github.com/osqp/osqp/issues/101).
 
 
 Version 0.4.1 (25 September 2018)
@@ -33,15 +33,15 @@ Version 0.4.1 (25 September 2018)
 Version 0.4.0 (23 July 2018)
 ----------------------------
 * Added check for nonconvex cost function (non-positive semidefinite `P`).
-* Removed SuiteSparse LDL in favor of [QDLDL](https://github.com/oxfordcontrol/qdldl).
+* Removed SuiteSparse LDL in favor of [QDLDL](https://github.com/osqp/qdldl).
 * Static library `libosqpstatic` now renamed as `libosqp`.
 
 
 Version 0.3.1 (10 June 2018)
 ----------------------------
-* Fixed [#62](https://github.com/oxfordcontrol/osqp/issues/62).
+* Fixed [#62](https://github.com/osqp/osqp/issues/62).
 * Moved interfaces to separate repositories
-* Fixed [#54](https://github.com/oxfordcontrol/osqp/issues/54).
+* Fixed [#54](https://github.com/osqp/osqp/issues/54).
 * Changes to support Matlab 2018a
 * Added support for new interface in R
 
@@ -50,14 +50,14 @@ Version 0.3.0 (5 March 2018)
 * Added `time_limit` option
 * Added CUTEst interface
 * Fixed bug in upper triangular `P` extraction. Now the solver can accept both complete `P` matrix or just the upper triangular part.
-* Fixed [#33](https://github.com/oxfordcontrol/osqp/issues/33)
-* Fixed [#34](https://github.com/oxfordcontrol/osqp/issues/34)
-* Allow `eps_rel=0` [#40](https://github.com/oxfordcontrol/osqp/issues/40)
+* Fixed [#33](https://github.com/osqp/osqp/issues/33)
+* Fixed [#34](https://github.com/osqp/osqp/issues/34)
+* Allow `eps_rel=0` [#40](https://github.com/osqp/osqp/issues/40)
 * Fixed bug when calling `osqp_solve` or `osqp_cleanup` after failed linear system initialization
 * Add "install" CMake target and installation of CMake configuration files
-* Fixed potential name conflict with SCS [47](https://github.com/oxfordcontrol/osqp/issues/47)
+* Fixed potential name conflict with SCS [47](https://github.com/osqp/osqp/issues/47)
 * Changed `set_default_settings` to `osqp_set_default_settings` and brought function to main API header `osqp.h`
-* Fixed [#49](https://github.com/oxfordcontrol/osqp/issues/49)
+* Fixed [#49](https://github.com/osqp/osqp/issues/49)
 
 
 Version 0.2.1 (25 November 2017)
@@ -71,7 +71,7 @@ Version 0.2.0 (23 November 2017)
 *   Simplified several settings
     *  "early_terminate" and "early_terminate_interval" -> "check_termination"
     *  "scaling_iter" removed and put inside "scaling" parameter
-*   Julia interface [OSQP.jl](https://github.com/oxfordcontrol/OSQP.jl)
+*   Julia interface [OSQP.jl](https://github.com/osqp/OSQP.jl)
 *   Shared libraries available on bintray.com
 *   Added inaccurate return statuses
 *   Added new object-oriented structure for linear system solvers
@@ -92,9 +92,9 @@ Version 0.1.2 (20 July 2017)
 *   Now Matlab interface does support logical entries for the settings
 *   Fixed bug in index ordering of sparse matrices of Python interface
 *   Changed 2-norms to inf-norms
-*   Fixed code generation bug when scaling is disabled [#7](https://github.com/oxfordcontrol/osqp/issues/7)
+*   Fixed code generation bug when scaling is disabled [#7](https://github.com/osqp/osqp/issues/7)
 *   Removed warnings in code-generation for standard <= C99
-*   Fixed MATLAB 2015b compatibility [#6](https://github.com/oxfordcontrol/osqp/issues/6)
+*   Fixed MATLAB 2015b compatibility [#6](https://github.com/osqp/osqp/issues/6)
 
 
 Version 0.1.1 (11 April 2017)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # The Operator Splitting QP Solver
 
 [![CI](https://github.com/osqp/osqp/actions/workflows/main.yml/badge.svg)](https://github.com/osqp/osqp/actions/workflows/main.yml)
-[![Code coverage](https://coveralls.io/repos/github/oxfordcontrol/osqp/badge.svg?branch=master)](https://coveralls.io/github/oxfordcontrol/osqp?branch=master)
+[![Code coverage](https://coveralls.io/repos/github/osqp/osqp/badge.svg?branch=master)](https://coveralls.io/github/osqp/osqp?branch=master)
 ![License](https://img.shields.io/badge/License-Apache%202.0-brightgreen.svg)
 
 
@@ -36,9 +36,9 @@ If you are using OSQP for your work, we encourage you to
 
 ## Bug reports and support
 
-Please report any issues via the [Github issue tracker](https://github.com/oxfordcontrol/osqp/issues). All types of issues are welcome including bug reports, documentation typos, feature requests and so on.
+Please report any issues via the [Github issue tracker](https://github.com/osqp/osqp/issues). All types of issues are welcome including bug reports, documentation typos, feature requests and so on.
 
 
 ## Numerical benchmarks
-Numerical benchmarks against other solvers are available [here](https://github.com/oxfordcontrol/osqp_benchmarks).
+Numerical benchmarks against other solvers are available [here](https://github.com/osqp/osqp_benchmarks).
 

--- a/docs/citing/index.rst
+++ b/docs/citing/index.rst
@@ -3,7 +3,7 @@
 Citing OSQP
 ===========
 
-If you use OSQP for published work, we encourage you to put a star on `GitHub <https://github.com/oxfordcontrol/osqp>`_ and cite the accompanying papers:
+If you use OSQP for published work, we encourage you to put a star on `GitHub <https://github.com/osqp/osqp>`_ and cite the accompanying papers:
 
 
 .. glossary::

--- a/docs/contributing/index.rst
+++ b/docs/contributing/index.rst
@@ -21,7 +21,7 @@ Create a subdirectory with your solver name with four files:
 * Dynamic library loading: :code:`mysolver_loader.c` and :code:`mysolver_loader.h`.
 * Linear system solution: :code:`mysolver.c` and :code:`mysolver.h`.
 
-We suggest you to have a look at the `MKL Pardiso solver interface <https://github.com/oxfordcontrol/osqp/tree/master/lin_sys/direct/pardiso>`_ for more details.
+We suggest you to have a look at the `MKL Pardiso solver interface <https://github.com/osqp/osqp/tree/master/lin_sys/direct/pardiso>`_ for more details.
 
 Dynamic library loading
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/get_started/CC++.rst
+++ b/docs/get_started/CC++.rst
@@ -15,7 +15,7 @@ The required include files can be found in :code:`OSQP_FOLDER/include`.
 
 Simply compile with the linker option with :code:`-LOSQP_FOLDER/lib` and :code:`-losqp`.
 
-If you are interested in development builds, you can find them on `GitHUB <https://github.com/osqp/osqp/releases>`__.
+If you are interested in development builds, you can find them on `GitHub <https://github.com/osqp/osqp/releases>`__.
 
 Sources
 -------

--- a/docs/get_started/CC++.rst
+++ b/docs/get_started/CC++.rst
@@ -6,7 +6,7 @@ CC++
 Binaries
 --------
 
-Precompiled platform-dependent shared and static libraries are available on `Bintray <https://bintray.com/bstellato/generic/OSQP/0.6.2>`_.
+Precompiled platform-dependent shared and static libraries are available on `GitHub <https://github.com/osqp/osqp/releases>`_.
 We here assume that the user uncompressed each archive to :code:`OSQP_FOLDER`.
 
 Each archive contains static :code:`OSQP_FOLDER/lib/libosqp.a` and shared :code:`OSQP_FOLDER/lib/libosqp.ext` libraries to be used to interface OSQP to any C/C++ software.
@@ -15,7 +15,7 @@ The required include files can be found in :code:`OSQP_FOLDER/include`.
 
 Simply compile with the linker option with :code:`-LOSQP_FOLDER/lib` and :code:`-losqp`.
 
-If you are interested in development builds, you can find them on `Bintray <https://dl.bintray.com/bstellato/generic/OSQP-dev/>`__.
+If you are interested in development builds, you can find them on `GitHUB <https://github.com/osqp/osqp/releases>`__.
 
 Sources
 -------

--- a/docs/get_started/julia.rst
+++ b/docs/get_started/julia.rst
@@ -8,5 +8,5 @@ Julia interface can be directly installed from Julia package manager by running
    ] add OSQP
 
 
-The interface code is available on `GitHub <https://github.com/oxfordcontrol/OSQP.jl>`_.
+The interface code is available on `GitHub <https://github.com/osqp/OSQP.jl>`_.
 

--- a/docs/get_started/linear_system_solvers.rst
+++ b/docs/get_started/linear_system_solvers.rst
@@ -28,7 +28,7 @@ The only requirement is that the shared library related to the solver is in the 
 
 QDLDL
 ---------------
-OSQP comes with `QDLDL <https://github.com/oxfordcontrol/qdldl>`_ internally installed.
+OSQP comes with `QDLDL <https://github.com/osqp/qdldl>`_ internally installed.
 It does not require any external shared library.
 QDLDL is a sparse direct solver that works well for most small to medium sized problems.
 However, it becomes not really efficient for large scale problems since it is not multi-threaded.

--- a/docs/get_started/matlab.rst
+++ b/docs/get_started/matlab.rst
@@ -6,13 +6,13 @@ OSQP Matlab interface requires Matlab 2015b or newer.
 Binaries
 --------
 
-Precompiled platform-dependent Matlab binaries are available on `Bintray <https://bintray.com/bstellato/generic/OSQP>`_.
+Precompiled platform-dependent Matlab binaries are available on `GitHub <https://github.com/osqp/osqp-matlab/releases>`_.
 
 To install the interface, just run the following commands:
 
 .. code:: matlab
 
-    websave('install_osqp.m', 'https://dl.bintray.com/bstellato/generic/OSQP/0.6.2/install_osqp.m');
+    websave('install_osqp.m','https://raw.githubusercontent.com/osqp/osqp-matlab/master/package/install_osqp.m');
     install_osqp
 
 
@@ -47,7 +47,7 @@ You can now build the interface by running inside Matlab
 
 .. code:: matlab
 
-   !git clone --recurse-submodules https://github.com/oxfordcontrol/osqp-matlab
+   !git clone --recurse-submodules https://github.com/osqp/osqp-matlab
    cd osqp-matlab
    make_osqp
 

--- a/docs/get_started/python.rst
+++ b/docs/get_started/python.rst
@@ -39,6 +39,6 @@ Now you are ready to build OSQP python interface from sources. Run the following
 
 .. code:: bash
 
-   git clone --recurse-submodules https://github.com/oxfordcontrol/osqp-python
+   git clone --recurse-submodules https://github.com/osqp/osqp-python
    cd osqp-python
    python setup.py install

--- a/docs/get_started/r.rst
+++ b/docs/get_started/r.rst
@@ -22,7 +22,7 @@ If you would like to use the most recent version of OSQP-R and have access to gi
 
 .. code:: r
 
-  git clone --recursive https://github.com/oxfordcontrol/osqp-r.git
+  git clone --recursive https://github.com/osqp/osqp-r.git
   cd osqp-r
   R CMD install .
 

--- a/docs/get_started/sources.rst
+++ b/docs/get_started/sources.rst
@@ -58,13 +58,13 @@ Run the following commands from the terminal
 
 #. You first need to get the sources from one of these two options:
 
-    * Download the compressed file `from bintray.com <https://dl.bintray.com/bstellato/generic/OSQP/0.4.1/osqp-0.4.1.tar.gz>`_.
+    * Download the compressed source file from the latest OSQP release `at GitHub <https://github.com/osqp/osqp/releases>`_.
 
     * Clone the repository
 
         .. code:: bash
 
-            git clone --recursive https://github.com/oxfordcontrol/osqp
+            git clone --recursive https://github.com/osqp/osqp
 
 #. Create :code:`build` directory and change directory
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ optimization package for solving convex quadratic programs in the form
 where :math:`x` is the optimization variable and
 :math:`P \in \mathbf{S}^{n}_{+}` a positive semidefinite matrix.
 
-**Code available on** `GitHub <https://github.com/oxfordcontrol/osqp>`_.
+**Code available on** `GitHub <https://github.com/osqp/osqp>`_.
 
 .. rubric:: Citing OSQP
 
@@ -25,8 +25,8 @@ If you are using OSQP for your work, we encourage you to
 * Put a star on GitHub |github-star|
 
 
-.. |github-star| image:: https://img.shields.io/github/stars/oxfordcontrol/osqp.svg?style=social&label=Star
-  :target: https://github.com/oxfordcontrol/osqp
+.. |github-star| image:: https://img.shields.io/github/stars/osqp/osqp.svg?style=social&label=Star
+  :target: https://github.com/osqp/osqp
 
 
 **We are looking forward to hearing your success stories with OSQP!** Please `share them with us <bartolomeo.stellato@gmail.com>`_.
@@ -87,12 +87,12 @@ Interfaces development
 
 .. rubric:: Bug reports and support
 
-Please report any issues via the `Github issue tracker <https://github.com/oxfordcontrol/osqp/issues>`_. All types of issues are welcome including bug reports, documentation typos, feature requests and so on.
+Please report any issues via the `Github issue tracker <https://github.com/osqp/osqp/issues>`_. All types of issues are welcome including bug reports, documentation typos, feature requests and so on.
 
 
 .. rubric:: Numerical benchmarks
 
-Numerical benchmarks against other solvers are available `here <https://github.com/oxfordcontrol/osqp_benchmarks>`_.
+Numerical benchmarks against other solvers are available `here <https://github.com/osqp/osqp_benchmarks>`_.
 
 
 .. toctree::

--- a/docs/interfaces/fortran.rst
+++ b/docs/interfaces/fortran.rst
@@ -5,4 +5,4 @@ Fortran
 ========
 
 The interface is still experimental.
-You can find a demo of how it works in the `oxfordcontrol/osqp-fortran <https://github.com/oxfordcontrol/osqp-fortran/blob/master/demo/osqp_demo_fortran.F90>`_ repository.
+You can find a demo of how it works in the `osqp/osqp-fortran <https://github.com/osqp/osqp-fortran/blob/master/demo/osqp_demo_fortran.F90>`_ repository.

--- a/docs/interfaces/index.rst
+++ b/docs/interfaces/index.rst
@@ -25,22 +25,22 @@ Official
 +------------------------------------+----------------------------------------------------------+------------------------------------------------------------------------------------------+
 | Language                           | Maintainers                                              | Repository                                                                               |
 +====================================+==========================================================+==========================================================================================+
-| :ref:`C <c_interface>`             | | `Bartolomeo Stellato <bartolomeo.stellato@gmail.com>`_ | `github.com/oxfordcontrol/osqp <https://github.com/oxfordcontrol/osqp>`_                 |
+| :ref:`C <c_interface>`             | | `Bartolomeo Stellato <bartolomeo.stellato@gmail.com>`_ | `github.com/osqp/osqp <https://github.com/osqp/osqp>`_                                   |
 |                                    | | `Goran Banjac <gbanjac@control.ee.ethz.ch>`_           |                                                                                          |
 |                                    | | `Paul Goulart <paul.goulart@eng.ox.ac.uk>`_            |                                                                                          |
 +------------------------------------+----------------------------------------------------------+------------------------------------------------------------------------------------------+
-| :ref:`Python <python_interface>`   | | `Bartolomeo Stellato <bartolomeo.stellato@gmail.com>`_ | `github.com/oxfordcontrol/osqp-python <https://github.com/oxfordcontrol/osqp-python>`_   |
+| :ref:`Python <python_interface>`   | | `Bartolomeo Stellato <bartolomeo.stellato@gmail.com>`_ | `github.com/osqp/osqp-python <https://github.com/osqp/osqp-python>`_                     |
 |                                    | | `Goran Banjac <gbanjac@control.ee.ethz.ch>`_           |                                                                                          |
 +------------------------------------+----------------------------------------------------------+------------------------------------------------------------------------------------------+
-| :ref:`Matlab <matlab_interface>`   | | `Bartolomeo Stellato <bartolomeo.stellato@gmail.com>`_ | `github.com/oxfordcontrol/osqp-matlab <https://github.com/oxfordcontrol/osqp-matlab>`_   |
+| :ref:`Matlab <matlab_interface>`   | | `Bartolomeo Stellato <bartolomeo.stellato@gmail.com>`_ | `github.com/osqp/osqp-matlab <https://github.com/osqp/osqp-matlab>`_                     |
 |                                    | | `Goran Banjac <gbanjac@control.ee.ethz.ch>`_           |                                                                                          |
 |                                    | | `Paul Goulart <paul.goulart@eng.ox.ac.uk>`_            |                                                                                          |
 +------------------------------------+----------------------------------------------------------+------------------------------------------------------------------------------------------+
-| :ref:`Julia <julia_interface>`     | | `Twan Koolen <tkoolen@mit.edu>`_                       | `github.com/oxfordcontrol/OSQP.jl <https://github.com/oxfordcontrol/OSQP.jl>`_           |
+| :ref:`Julia <julia_interface>`     | | `Twan Koolen <tkoolen@mit.edu>`_                       | `github.com/osqp/OSQP.jl <https://github.com/osqp/OSQP.jl>`_                             |
 |                                    | | `Benoît Legat <benoit.legat@uclouvain.be>`_            |                                                                                          |
 |                                    | | `Bartolomeo Stellato <bartolomeo.stellato@gmail.com>`_ |                                                                                          |
 +------------------------------------+----------------------------------------------------------+------------------------------------------------------------------------------------------+
-| :ref:`R <rlang_interface>`         | | `Bartolomeo Stellato <bartolomeo.stellato@gmail.com>`_ | `github.com/oxfordcontrol/osqp-r <https://github.com/oxfordcontrol/osqp-r>`_             |
+| :ref:`R <rlang_interface>`         | | `Bartolomeo Stellato <bartolomeo.stellato@gmail.com>`_ | `github.com/osqp/osqp-r <https://github.com/osqp/osqp-r>`_                               |
 |                                    | | `Paul Goulart <paul.goulart@eng.ox.ac.uk>`_            |                                                                                          |
 +------------------------------------+----------------------------------------------------------+------------------------------------------------------------------------------------------+
 
@@ -76,11 +76,11 @@ Community Maintained
 +------------------------------------------------+----------------------------------------------------------+------------------------------------------------------------------------------------------+
 | :ref:`C++/Eigen Robotology <eigen_robotology>` | | `Giulio Romualdi <giulio.romualdi@gmail.com>`_         | `github.com/robotology/osqp-eigen <https://github.com/robotology/osqp-eigen>`_           |
 +------------------------------------------------+----------------------------------------------------------+------------------------------------------------------------------------------------------+
-| :ref:`Rust <rust_interface>`                   | | `Ed Barnard <eabarnard@gmail.com>`_                    | `github.com/oxfordcontrol/osqp.rs <https://github.com/oxfordcontrol/osqp.rs>`_           |
+| :ref:`Rust <rust_interface>`                   | | `Ed Barnard <eabarnard@gmail.com>`_                    | `github.com/osqp/osqp.rs <https://github.com/osqp/osqp.rs>`_                             |
 +------------------------------------------------+----------------------------------------------------------+------------------------------------------------------------------------------------------+
 | :ref:`Ruby <ruby_interface>`                   | | `Andrew Kane <andrew@chartkick.com>`_                  | `https://github.com/ankane/osqp <https://github.com/ankane/osqp>`_                       |
 +------------------------------------------------+----------------------------------------------------------+------------------------------------------------------------------------------------------+
-| :ref:`Fortran <fortran_interface>`             | | `Nick Gould <nick.gould@stfc.ac.uk>`_                  | `github.com/oxfordcontrol/osqp-fortran <https://github.com/oxfordcontrol/osqp-fortran>`_ |
+| :ref:`Fortran <fortran_interface>`             | | `Nick Gould <nick.gould@stfc.ac.uk>`_                  | `github.com/osqp/osqp-fortran <https://github.com/osqp/osqp-fortran>`_                   |
 |                                                | | `Bartolomeo Stellato <bartolomeo.stellato@gmail.com>`_ |                                                                                          |
 |                                                | | `Paul Goulart <paul.goulart@eng.ox.ac.uk>`_            |                                                                                          |
 +------------------------------------------------+----------------------------------------------------------+------------------------------------------------------------------------------------------+

--- a/docs/interfaces/status_values.rst
+++ b/docs/interfaces/status_values.rst
@@ -8,7 +8,7 @@ Status values and errors
 Status values
 -------------
 
-These are the exit statuses, their respective constants and values returned by the solver as defined in `constants.h <https://github.com/oxfordcontrol/osqp/blob/master/include/constants.h>`_.
+These are the exit statuses, their respective constants and values returned by the solver as defined in `constants.h <https://github.com/osqp/osqp/blob/master/include/constants.h>`_.
 The *inaccurate* statuses define when the optimality, primal infeasibility or dual infeasibility conditions are satisfied with tolerances 10 times larger than the ones set.
 
 +------------------------------+-----------------------------------+-------+

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -24,7 +24,7 @@ url: "https://osqp.org" # the base hostname & protocol for your site, e.g. http:
 # twitter_username: jekyllrb
 # github_username:  jekyll
 # facebook_link: https://www.facebook.com/groups/331532750262318/
-github_link: https://github.com/oxfordcontrol/osqp
+github_link: https://github.com/osqp/osqp
 google_analytics: UA-56714542-3
 discourse_link: https://osqp.discourse.group/
 

--- a/site/_layouts/home.html
+++ b/site/_layouts/home.html
@@ -43,7 +43,7 @@ layout: default
 				    <p class="lead">We benchmarked OSQP against problems from many different classes, applications and scalings. OSQP beats most available commercial and academic solvers.</p>
 			    </div>
 			    <div class="col-md-8">
-				    <a href="https://github.com/oxfordcontrol/osqp_benchmarks"> <img class="img-fluid mx-auto" src="{{ site.baseurl }}/assets/images/benchmarks/performance_profiles.jpg" alt="Performance Profiles"> </a>
+				    <a href="https://github.com/osqp/osqp_benchmarks"> <img class="img-fluid mx-auto" src="{{ site.baseurl }}/assets/images/benchmarks/performance_profiles.jpg" alt="Performance Profiles"> </a>
 			    </div>
 		    </div>
 

--- a/site/_pages/citing.md
+++ b/site/_pages/citing.md
@@ -10,7 +10,7 @@ order: 1
 If you use OSQP for published work, we encourage you to
 
 * Cite the accompanying papers
-* Put a star on <a class="github-button" href="https://github.com/oxfordcontrol/osqp" data-size="large" data-show-count="true" aria-label="Star oxfordcontrol/osqp on GitHub">GitHub</a>
+* Put a star on <a class="github-button" href="https://github.com/osqp/osqp" data-size="large" data-show-count="true" aria-label="Star osqp/osqp on GitHub">GitHub</a>
 
 We are looking forward to hearing your success stories with OSQP! Please [share them with us](mailto:bartolomeo.stellato@gmail.com).
 


### PR DESCRIPTION
Replaced all instances of `github.com/oxfordcontrol/` with `github.com/osqp/`. All links do work, so perhaps the organization was renamed at some point?

Also replaced references to Bintray with Github Releases.