### PR TITLE
Dynamic doxygen project version

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,6 +25,14 @@ import subprocess
 
 __version__ = os.environ.get('OSQP_VERSION', '0.0.0')
 
+# An incoming version number of '0.0.0' is a placeholder for missing version information.
+# In such cases, use a <blank> version to effectively avoid mentioning the version number
+# in the built documentation at all.
+__version__ = '' if __version__ == '0.0.0' else __version__
+
+# Set OSQP_VERSION envvar in case subprocesses (like doxygen) need it too
+os.environ['OSQP_VERSION'] = __version__
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.

--- a/docs/doxygen.conf
+++ b/docs/doxygen.conf
@@ -38,7 +38,7 @@ PROJECT_NAME           = "OSQP"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 0.6.2
+PROJECT_NUMBER         = $(OSQP_VERSION) 
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a
@@ -1103,7 +1103,7 @@ IGNORE_PREFIX          =
 # If the GENERATE_HTML tag is set to YES, doxygen will generate HTML output
 # The default value is: YES.
 
-GENERATE_HTML          = YES
+GENERATE_HTML          = NO 
 
 # The HTML_OUTPUT tag is used to specify where the HTML docs will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of

--- a/site/_pages/citing.md
+++ b/site/_pages/citing.md
@@ -90,7 +90,7 @@ Code generation functionality and example in this [paper](https://stanford.edu/~
 {% endraw %}
 
 #### Mixed-integer optimization
-A branch-and-bound solver for mixed-integer quadratic optimization in this [paper](https://stellato.io/assets/downloads/publications/2018/miosqp_ecc.pdf).
+A branch-and-bound solver for mixed-integer quadratic optimization in this [paper](https://stellato.io/downloads/publications/2018/miosqp_ecc.pdf).
 
 {% raw %}
 ```latex


### PR DESCRIPTION
Removed hardcoded `0.6.2` from doxygen configuration. The version number is now obtained from an environment variable passed down from Sphinx. A blank version number is used for sphix+doxygen purposes in case it is 0.0.0.

Doxygen html generation is not needed for integration with Sphinx - just xml, so its now disabled by default.