### PR TITLE
Fixed test signature/return for a test function

### DIFF
--- a/tests/basic_qp2/test_basic_qp2.h
+++ b/tests/basic_qp2/test_basic_qp2.h
@@ -70,7 +70,7 @@ void test_basic_qp2_solve()
 }
 
 #ifdef ENABLE_MKL_PARDISO
-static char* test_basic_qp2_solve_pardiso()
+void test_basic_qp2_solve_pardiso()
 {
   c_int exitflag;
 
@@ -136,8 +136,6 @@ static char* test_basic_qp2_solve_pardiso()
   c_free(settings);
   clean_problem_basic_qp2(data);
   clean_problem_basic_qp2_sols_data(sols_data);
-
-  return 0;
 }
 #endif
 

--- a/tests/osqp_tester.cpp
+++ b/tests/osqp_tester.cpp
@@ -93,7 +93,7 @@ TEST_CASE( "test_basic_qp2", "[multi-file:5]" ) {
     }
 #ifdef ENABLE_MKL_PARDISO
     SECTION( "test_basic_qp2_solve_pardiso" ) {
-        test_basic_qp2_solve_pardiso() == 0;
+        test_basic_qp2_solve_pardiso();
     }
 #endif
     SECTION( "test_basic_qp2_update" ) {


### PR DESCRIPTION
I missed changing the signature/return value/check for a single function - noticed this while migrating these changes to develop-1.0