### PR TITLE
Replace deprecated cusparse functions by cusparseSpMV()

### DIFF
--- a/algebra/_common/csc_math.c
+++ b/algebra/_common/csc_math.c
@@ -234,38 +234,38 @@ void csc_Atxpy(const csc *A, const c_float *x, c_float *y,
 
 // 1/2 x'*P*x
 
-c_float csc_quad_form(const csc *P, const c_float *x) {
+// c_float csc_quad_form(const csc *P, const c_float *x) {
 
-  //NB:implementation assumes upper triangular part only
+//   //NB:implementation assumes upper triangular part only
 
-  c_float quad_form = 0.;
-  c_int   i, j, ptr;
-  c_int*   Pp = P->p;
-  c_int*   Pi = P->i;
-  c_float* Px = P->x;
-  c_int    Pn = P->n;
+//   c_float quad_form = 0.;
+//   c_int   i, j, ptr;
+//   c_int*   Pp = P->p;
+//   c_int*   Pi = P->i;
+//   c_float* Px = P->x;
+//   c_int    Pn = P->n;
 
 
-  for (j = 0; j < Pn; j++) {                    // Iterate over columns
-    for (ptr = Pp[j]; ptr < Pp[j + 1]; ptr++) { // Iterate over rows
-      i = Pi[ptr];                            // Row index
+//   for (j = 0; j < Pn; j++) {                    // Iterate over columns
+//     for (ptr = Pp[j]; ptr < Pp[j + 1]; ptr++) { // Iterate over rows
+//       i = Pi[ptr];                            // Row index
 
-      if (i == j) {                                 // Diagonal element
-        quad_form += (c_float).5 * Px[ptr] * x[i] * x[i];
-      }
-      else if (i < j) {                             // Off-diagonal element
-        quad_form += Px[ptr] * x[i] * x[j];
-      }
-      else {                                        // Element in lower triangle
-#ifdef PRINTING
-        c_eprint("quad_form matrix is not upper triangular");
-#endif /* ifdef PRINTING */
-        return -1.;
-      }
-    }
-  }
-  return quad_form;
-}
+//       if (i == j) {                                 // Diagonal element
+//         quad_form += (c_float).5 * Px[ptr] * x[i] * x[i];
+//       }
+//       else if (i < j) {                             // Off-diagonal element
+//         quad_form += Px[ptr] * x[i] * x[j];
+//       }
+//       else {                                        // Element in lower triangle
+// #ifdef PRINTING
+//         c_eprint("quad_form matrix is not upper triangular");
+// #endif /* ifdef PRINTING */
+//         return -1.;
+//       }
+//     }
+//   }
+//   return quad_form;
+// }
 
 /* columnwise infinity norm */
 

--- a/algebra/_common/csc_math.h
+++ b/algebra/_common/csc_math.h
@@ -67,8 +67,8 @@ void csc_Atxpy(const csc *A,
                      c_float alpha,
                      c_float beta);
 
-// returns 1/2 x'*P*x
-c_float csc_quad_form(const csc *P, const c_float *x);
+// // returns 1/2 x'*P*x
+// c_float csc_quad_form(const csc *P, const c_float *x);
 
 // E[i] = inf_norm(M(:,i))
 void csc_col_norm_inf(const csc *M, c_float *E);

--- a/algebra/cuda/algebra_types.h
+++ b/algebra/cuda/algebra_types.h
@@ -52,13 +52,12 @@ typedef struct csr_t csr;
 
 struct OSQPMatrix_ {
   csr     *S;   /* P or A */
-  csr     *At;
+  csr     *At;  /* NULL if symmetric */
   c_int   *d_A_to_At_ind;
   c_float *d_P_triu_val;
   c_int   *d_P_triu_to_full_ind;
   c_int   *d_P_diag_ind;
   c_int    P_triu_nnz;
-  c_int    symmetric;
 };
 
 

--- a/algebra/cuda/algebra_types.h
+++ b/algebra/cuda/algebra_types.h
@@ -18,11 +18,8 @@
 #ifndef ALGEBRA_TYPES_H
 # define ALGEBRA_TYPES_H
 
-# ifdef __cplusplus
-extern "C" {
-# endif
 
-
+#include <cusparse.h>
 #include "osqp_api_types.h"
 
 
@@ -37,8 +34,9 @@ struct OSQPVectori_ {
 };
 
 struct OSQPVectorf_ {
-  c_float *d_val;
-  c_int    length;
+  c_float              *d_val;
+  c_int                 length;
+  cusparseDnVecDescr_t  vec;
 };
 
 
@@ -60,9 +58,5 @@ struct OSQPMatrix_ {
   c_int    P_triu_nnz;
 };
 
-
-# ifdef __cplusplus
-}
-# endif
 
 #endif /* ifndef ALGEBRA_TYPES_H */

--- a/algebra/cuda/include/csr_type.h
+++ b/algebra/cuda/include/csr_type.h
@@ -19,26 +19,25 @@
 # define CSR_TYPE_H
 
 
-#include <cusparse_v2.h>
+#include <cusparse.h>
 #include "osqp_api_types.h"   /* --> c_int, c_float */
 
 
 /* CSR matrix structure */
 struct csr_t {
-  c_int               m;          ///< number of rows
-  c_int               n;          ///< number of columns
-  c_int              *row_ptr;    ///< row pointers (size m+1)
-  c_int              *row_ind;    ///< uncompressed row indices (size nnz), NULL if not needed 
-  c_int              *col_ind;    ///< column indices (size nnz)
-  c_float            *val;        ///< numerical values (size nnz)
-  c_int               nnz;        ///< number of non-zero entries in matrix
+  c_int m;            ///< number of rows
+  c_int n;            ///< number of columns
+  c_int nnz;          ///< number of non-zero entries
 
-  void               *buffer;
-  size_t              bufferSizeInBytes;
-  cusparseAlgMode_t   alg;
-  cusparseMatDescr_t  MatDescription;
+  c_int   *row_ptr;   ///< row pointers (size m+1)
+  c_int   *row_ind;   ///< uncompressed row indices (size nnz), NULL if not needed 
+  c_int   *col_ind;   ///< column indices (size nnz)
+  c_float *val;       ///< numerical values (size nnz)
+
+  size_t                SpMatBufferSize;
+  void                 *SpMatBuffer;
+  cusparseSpMatDescr_t  SpMatDescr;
 };
 
 
 #endif /* ifndef CSR_TYPE_H */
-

--- a/algebra/cuda/include/cuda_handler.h
+++ b/algebra/cuda/include/cuda_handler.h
@@ -18,7 +18,7 @@
 #ifndef CUDA_HANDLER_H
 # define CUDA_HANDLER_H
 
-#include <cusparse_v2.h>
+#include <cusparse.h>
 #include <cublas_v2.h>
 
 # ifdef __cplusplus

--- a/algebra/cuda/include/cuda_lin_alg.h
+++ b/algebra/cuda/include/cuda_lin_alg.h
@@ -18,6 +18,7 @@
 #ifndef CUDA_LIN_ALG_H
 # define CUDA_LIN_ALG_H
 
+#include <cusparse.h>
 #include "algebra_types.h"
 
 # ifdef __cplusplus
@@ -28,6 +29,12 @@ extern "C" {
 /*******************************************************************************
  *                           Vector Functions                                  *
  *******************************************************************************/
+
+void cuda_vec_create(cusparseDnVecDescr_t *vec,
+                     const c_float        *d_x,
+                     c_int                 n);
+
+void cuda_vec_destroy(cusparseDnVecDescr_t vec);
 
 /*
  * d_y[i] = d_x[i] for i in [0,n-1]
@@ -315,11 +322,11 @@ void cuda_mat_rmult_diag_new(const csr     *S,
 /**
  * d_y = alpha * A*d_x + beta*d_y
  */
-void cuda_mat_Axpy(const csr     *A,
-                   const c_float *d_x,
-                   c_float       *d_y,
-                   c_float        alpha,
-                   c_float        beta);
+void cuda_mat_Axpy(const csr                  *A,
+                   const cusparseDnVecDescr_t  vecx,
+                   cusparseDnVecDescr_t        vecy,
+                   c_float                     alpha,
+                   c_float                     beta);
 
 /**
  * d_res[i] = |S_i|_inf where S_i is i-th row of S

--- a/algebra/cuda/include/cuda_lin_alg.h
+++ b/algebra/cuda/include/cuda_lin_alg.h
@@ -119,13 +119,6 @@ void cuda_vec_norm_inf(const c_float *d_x,
                        c_int          n,
                        c_float       *h_res);
 
-// /**
-//  * h_res = |d_x|_1
-//  */
-// void cuda_vec_norm_1(const c_float *d_x,
-//                      c_int          n,
-//                      c_float       *h_res);
-
 /**
  * res = |d_x|_2
  */
@@ -327,13 +320,6 @@ void cuda_mat_Axpy(const csr     *A,
                    c_float       *d_y,
                    c_float        alpha,
                    c_float        beta);
-
-/**
- * h_res = (1/2) d_x' * P * d_x
- */
-void cuda_mat_quad_form(const csr     *P,
-                        const c_float *d_x,
-                        c_float       *h_res);
 
 /**
  * d_res[i] = |S_i|_inf where S_i is i-th row of S

--- a/algebra/cuda/include/cuda_lin_alg.h
+++ b/algebra/cuda/include/cuda_lin_alg.h
@@ -295,7 +295,6 @@ void cuda_vec_gather(c_int          nnz,
  */
 void cuda_mat_mult_sc(csr     *S,
                       csr     *At,
-                      c_int    symmetric,
                       c_float  sc);
 
 /**
@@ -303,7 +302,6 @@ void cuda_mat_mult_sc(csr     *S,
  */
 void cuda_mat_lmult_diag(csr           *S,
                          csr           *At,
-                         c_int          symmetric,
                          const c_float *d_diag);
 
 /**
@@ -311,7 +309,6 @@ void cuda_mat_lmult_diag(csr           *S,
  */
 void cuda_mat_rmult_diag(csr           *S,
                          csr           *At,
-                         c_int          symmetric,
                          const c_float *d_diag);
 
 /**

--- a/algebra/cuda/lin_sys/indirect/cuda_pcg_interface.c
+++ b/algebra/cuda/lin_sys/indirect/cuda_pcg_interface.c
@@ -69,7 +69,7 @@ static void compute_rhs(cudapcg_solver *s,
   c_int n = s->n;
   c_int m = s->m;
 
-  /* d_rhs = d_b1 */
+  /* rhs = b1 */
   cuda_vec_copy_d2d(s->d_rhs, d_b, n);
 
   if (m == 0) return;
@@ -87,7 +87,7 @@ static void compute_rhs(cudapcg_solver *s,
   }
 
   /* d_rhs += A' * d_z */
-  cuda_mat_Axpy(s->At, s->d_z, s->d_rhs, 1.0, 1.0);
+  cuda_mat_Axpy(s->At, s->vecz, s->vecrhs, 1.0, 1.0);
 }
 
 
@@ -151,7 +151,7 @@ c_int init_linsys_solver_cudapcg(cudapcg_solver    **sp,
     s->h_rho   = 1. / settings->delta;
   }
 
-  /* Allocate PCG iterates */
+  /* Allocate raw PCG iterates */
   cuda_calloc((void **) &s->d_x,   n * sizeof(c_float));    /* Set d_x to zero */
   cuda_malloc((void **) &s->d_p,   n * sizeof(c_float));
   cuda_malloc((void **) &s->d_Kp,  n * sizeof(c_float));
@@ -160,6 +160,15 @@ c_int init_linsys_solver_cudapcg(cudapcg_solver    **sp,
   cuda_malloc((void **) &s->d_rhs, n * sizeof(c_float));
   if (m) cuda_malloc((void **) &s->d_z, m * sizeof(c_float));
   else   s->d_z = NULL;
+
+  /* Create dense vector descriptors for PCG iterates */
+  cuda_vec_create(&s->vecx,   s->d_x,   n);
+  cuda_vec_create(&s->vecp,   s->d_p,   n);
+  cuda_vec_create(&s->vecKp,  s->d_Kp,  n);
+  cuda_vec_create(&s->vecr,   s->d_r,   n);
+  cuda_vec_create(&s->vecrhs, s->d_rhs, n);
+  if (m) cuda_vec_create(&s->vecz, s->d_z, m);
+  else   s->vecz = NULL;
 
   /* Allocate scalar in host memory that is page-locked and accessible to device */
   cuda_malloc_host((void **) &s->h_r_norm, sizeof(c_float));
@@ -215,18 +224,24 @@ c_int solve_linsys_cudapcg(cudapcg_solver *s,
   /* Solve the linear system with PCG */
   pcg_iters = cuda_pcg_alg(s, eps, s->max_iter);
 
-  /* Copy the first part of the solution to b->d_val */
+  /* Copy the first part of the solution to b */
   cuda_vec_copy_d2d(b->d_val, s->d_x, s->n);
 
   if (!s->polishing) {
-    /* Compute d_z = A * d_x */
-    if (s->m) cuda_mat_Axpy(s->A, s->d_x, b->d_val + s->n, 1.0, 0.0);
+    /* Compute z = A * x */
+    if (s->m) cuda_mat_Axpy(s->A, s->vecx, s->vecz, 1.0, 0.0);
   }
   else {
-    // yred = (A * d_x - b) / delta
-    cuda_mat_Axpy(s->A, s->d_x, b->d_val + s->n, 1.0, -1.0);
-    cuda_vec_mult_sc(b->d_val + s->n, s->h_rho, s->m);
+    /* Copy the second part of b to z */
+    cuda_vec_copy_d2d(s->d_z, b->d_val + s->n, s->m);
+
+    /* yred = (A * x - b2) / delta */
+    cuda_mat_Axpy(s->A, s->vecx, s->vecz, 1.0, -1.0);
+    cuda_vec_mult_sc(s->d_z, s->h_rho, s->m);
   }
+
+  /* Copy the second part of the solution to b */
+  if (s->m) cuda_vec_copy_d2d(b->d_val + s->n, s->d_z, s->m);
 
   // Number of consecutive ADMM iterations with zero PCG iterations
   if (pcg_iters == 0) s->zero_pcg_iters++;
@@ -255,7 +270,15 @@ void warm_start_linsys_solver_cudapcg(cudapcg_solver    *s,
 void free_linsys_solver_cudapcg(cudapcg_solver *s) {
 
   if (s) {
-    /* PCG iterates */
+    /* Dense vector descriptors for PCG iterates */
+    cuda_vec_destroy(s->vecx);
+    cuda_vec_destroy(s->vecp);
+    cuda_vec_destroy(s->vecKp);
+    cuda_vec_destroy(s->vecr);
+    cuda_vec_destroy(s->vecrhs);
+    if (s->m) cuda_vec_destroy(s->vecz);
+
+    /* Raw PCG iterates */
     cuda_free((void **) &s->d_x);
     cuda_free((void **) &s->d_p);
     cuda_free((void **) &s->d_Kp);

--- a/algebra/cuda/lin_sys/indirect/cuda_pcg_interface.h
+++ b/algebra/cuda/lin_sys/indirect/cuda_pcg_interface.h
@@ -18,10 +18,8 @@
 #ifndef CUDA_PCG_INTERFACE_H
 #define CUDA_PCG_INTERFACE_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
+#include <cusparse.h>
 #include "osqp.h"
 #include "types.h"                /* OSQPMatrix and OSQPVector[fi] types */
 #include "algebra_types.h"        /* csr type */
@@ -89,7 +87,7 @@ typedef struct cudapcg_solver_ {
   c_int   *d_P_diag_ind;
   c_float *d_rho_vec;
 
-  /* PCG iterates */
+  /* PCG iterates: raw vectors */
   c_float *d_x;             ///<  current iterate solution
   c_float *d_p;             ///<  current search direction
   c_float *d_Kp;            ///<  holds K*p
@@ -97,6 +95,14 @@ typedef struct cudapcg_solver_ {
   c_float *d_r;             ///<  residual r = K*x - b
   c_float *d_rhs;           ///<  right-hand side of Kx = b
   c_float *d_z;             ///<  holds z = A*x for computing A'*z = A'*(A*x);
+
+  /* PCG iterates: dense vector desciptors */
+  cusparseDnVecDescr_t vecx;
+  cusparseDnVecDescr_t vecp;
+  cusparseDnVecDescr_t vecKp;
+  cusparseDnVecDescr_t vecr;
+  cusparseDnVecDescr_t vecrhs;
+  cusparseDnVecDescr_t vecz;
 
   /* Pointer to page-locked host memory */
   c_float *h_r_norm;
@@ -126,6 +132,9 @@ typedef struct cudapcg_solver_ {
 } cudapcg_solver;
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 c_int init_linsys_solver_cudapcg(cudapcg_solver    **sp,
                                  const OSQPMatrix   *P,
@@ -135,6 +144,10 @@ c_int init_linsys_solver_cudapcg(cudapcg_solver    **sp,
                                  c_float            *scaled_prim_res,
                                  c_float            *scaled_dual_res,
                                  c_int               polishing);
+
+#ifdef __cplusplus
+}
+#endif
 
 
 c_int solve_linsys_cudapcg(cudapcg_solver *s,
@@ -157,9 +170,5 @@ c_int update_linsys_solver_rho_vec_cudapcg(cudapcg_solver    *s,
                                            const OSQPVectorf *rho_vec,
                                            c_float            rho_sc);
 
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* ifndef OSQP_API_TYPES_H */

--- a/algebra/cuda/lin_sys/indirect/cuda_pcg_interface.h
+++ b/algebra/cuda/lin_sys/indirect/cuda_pcg_interface.h
@@ -80,14 +80,14 @@ typedef struct cudapcg_solver_ {
   c_float *scaled_prim_res;
   c_float *scaled_dual_res;
 
-  /* Pointers to problem data and ADMM settings */
+  /* ADMM settings and pointers to problem data */
+  c_float  h_rho;
+  c_float  h_sigma;
   csr     *A;
   csr     *At;
   csr     *P;
   c_int   *d_P_diag_ind;
   c_float *d_rho_vec;
-  c_float *h_sigma;
-  c_float *h_rho;
 
   /* PCG iterates */
   c_float *d_x;             ///<  current iterate solution

--- a/algebra/cuda/matrix.cu
+++ b/algebra/cuda/matrix.cu
@@ -104,24 +104,6 @@ void OSQPMatrix_Atxpy(const OSQPMatrix  *mat,
   cuda_mat_Axpy(mat->At, x->d_val, y->d_val, alpha, beta);
 }
 
-c_float OSQPMatrix_quad_form(const OSQPMatrix  *mat,
-                             const OSQPVectorf *x) {
-
-  c_float res;
-
-  if (!mat->At) {
-    cuda_mat_quad_form(mat->S, x->d_val, &res);
-    return res;
-  }
-  else {
-#ifdef PRINTING
-    c_eprint("quad_form matrix is not upper triangular");
-#endif /* ifdef PRINTING */
-    return -1.0;
-  }
-}
-
-
 void OSQPMatrix_col_norm_inf(const OSQPMatrix *mat,
                              OSQPVectorf      *res) {
 

--- a/algebra/cuda/matrix.cu
+++ b/algebra/cuda/matrix.cu
@@ -36,13 +36,12 @@ OSQPMatrix* OSQPMatrix_new_from_csc(const csc *M,
 
   if (is_triu) {
     /* Initialize P */
-    out->symmetric = 1;
+    out->At = NULL;   /* indicates a symmetric matrix */
     out->P_triu_nnz = M->p[M->n];
     cuda_mat_init_P(M, &out->S, &out->d_P_triu_val, &out->d_P_triu_to_full_ind, &out->d_P_diag_ind);
   }
   else {
     /* Initialize A */
-    out->symmetric = 0;
     cuda_mat_init_A(M, &out->S, &out->At, &out->d_A_to_At_ind);
   }
 
@@ -54,12 +53,12 @@ void OSQPMatrix_update_values(OSQPMatrix    *mat,
                               const c_int   *Mx_new_idx,
                               c_int          Mx_new_n) {
 
-  if (mat->symmetric) {
-    cuda_mat_update_P(Mx_new, Mx_new_idx, Mx_new_n, &mat->S, mat->d_P_triu_val,
-                      mat->d_P_triu_to_full_ind, mat->d_P_diag_ind, mat->P_triu_nnz);
+  if (mat->At) { /* not symmetric */
+    cuda_mat_update_A(Mx_new, Mx_new_idx, Mx_new_n, &mat->S, &mat->At, mat->d_A_to_At_ind);
   }
   else {
-    cuda_mat_update_A(Mx_new, Mx_new_idx, Mx_new_n, &mat->S, &mat->At, mat->d_A_to_At_ind);
+    cuda_mat_update_P(Mx_new, Mx_new_idx, Mx_new_n, &mat->S, mat->d_P_triu_val,
+                      mat->d_P_triu_to_full_ind, mat->d_P_diag_ind, mat->P_triu_nnz);
   }
 }
 
@@ -67,24 +66,24 @@ c_int OSQPMatrix_get_m( const OSQPMatrix *mat) { return mat->S->m; }
 
 c_int OSQPMatrix_get_n( const OSQPMatrix *mat) { return mat->S->n; }
 
-c_int OSQPMatrix_get_nz(const OSQPMatrix *mat) { return mat->symmetric ? mat->P_triu_nnz : mat->S->nnz; }
+c_int OSQPMatrix_get_nz(const OSQPMatrix *mat) { return mat->At ? mat->S->nnz : mat->P_triu_nnz; }
 
 void OSQPMatrix_mult_scalar(OSQPMatrix *mat,
                             c_float     sc) {
 
-  cuda_mat_mult_sc(mat->S, mat->At, mat->symmetric, sc);
+  cuda_mat_mult_sc(mat->S, mat->At, sc);
 }
 
 void OSQPMatrix_lmult_diag(OSQPMatrix        *mat,
                            const OSQPVectorf *D) {
 
-  cuda_mat_lmult_diag(mat->S, mat->At, mat->symmetric, D->d_val);
+  cuda_mat_lmult_diag(mat->S, mat->At, D->d_val);
 }
 
 void OSQPMatrix_rmult_diag(OSQPMatrix        *mat,
                            const OSQPVectorf *D) {
 
-  cuda_mat_rmult_diag(mat->S, mat->At, mat->symmetric, D->d_val);
+  cuda_mat_rmult_diag(mat->S, mat->At, D->d_val);
 }
 
 void OSQPMatrix_Axpy(const OSQPMatrix  *mat,
@@ -110,7 +109,7 @@ c_float OSQPMatrix_quad_form(const OSQPMatrix  *mat,
 
   c_float res;
 
-  if (mat->symmetric) {
+  if (!mat->At) {
     cuda_mat_quad_form(mat->S, x->d_val, &res);
     return res;
   }
@@ -126,8 +125,8 @@ c_float OSQPMatrix_quad_form(const OSQPMatrix  *mat,
 void OSQPMatrix_col_norm_inf(const OSQPMatrix *mat,
                              OSQPVectorf      *res) {
 
-  if (mat->symmetric) cuda_mat_row_norm_inf(mat->S,  res->d_val);
-  else                cuda_mat_row_norm_inf(mat->At, res->d_val);
+  if (mat->At) cuda_mat_row_norm_inf(mat->At, res->d_val);
+  else         cuda_mat_row_norm_inf(mat->S,  res->d_val);
 }
 
 void OSQPMatrix_row_norm_inf(const OSQPMatrix *mat,
@@ -155,7 +154,7 @@ OSQPMatrix* OSQPMatrix_submatrix_byrows(const OSQPMatrix  *mat,
 
   OSQPMatrix *out;
 
-  if (mat->symmetric) {
+  if (!mat->At) {
 #ifdef PRINTING
     c_eprint("row selection not implemented for partially filled matrices");
 #endif
@@ -163,10 +162,8 @@ OSQPMatrix* OSQPMatrix_submatrix_byrows(const OSQPMatrix  *mat,
   }
 
   out = (OSQPMatrix *) c_calloc(1, sizeof(OSQPMatrix));
-
   if (!out) return OSQP_NULL;
 
-  out->symmetric = 0;
   cuda_submat_byrows(mat->S, rows->d_val, &out->S, &out->At);
 
   return out;

--- a/algebra/cuda/matrix.cu
+++ b/algebra/cuda/matrix.cu
@@ -92,7 +92,12 @@ void OSQPMatrix_Axpy(const OSQPMatrix  *mat,
                      c_float            alpha,
                      c_float            beta) {
 
-  cuda_mat_Axpy(mat->S, x->d_val, y->d_val, alpha, beta);
+  if (mat->S->nnz == 0 || alpha == 0.0) {
+    /*  y = beta * y  */
+    cuda_vec_mult_sc(y->d_val, beta, y->length);
+    return;
+  }
+  cuda_mat_Axpy(mat->S, x->vec, y->vec, alpha, beta);
 }
 
 void OSQPMatrix_Atxpy(const OSQPMatrix  *mat,
@@ -101,7 +106,12 @@ void OSQPMatrix_Atxpy(const OSQPMatrix  *mat,
                       c_float            alpha,
                       c_float            beta) {
 
-  cuda_mat_Axpy(mat->At, x->d_val, y->d_val, alpha, beta);
+  if (mat->At->nnz == 0 || alpha == 0.0) {
+    /*  y = beta * y  */
+    cuda_vec_mult_sc(y->d_val, beta, y->length);
+    return;
+  }
+  cuda_mat_Axpy(mat->At, x->vec, y->vec, alpha, beta);
 }
 
 void OSQPMatrix_col_norm_inf(const OSQPMatrix *mat,
@@ -116,8 +126,6 @@ void OSQPMatrix_row_norm_inf(const OSQPMatrix *mat,
 
   cuda_mat_row_norm_inf(mat->S, res->d_val);
 }
-
-
 
 void OSQPMatrix_free(OSQPMatrix *mat){
   if (mat) {

--- a/algebra/cuda/src/cuda_lin_alg.cu
+++ b/algebra/cuda/src/cuda_lin_alg.cu
@@ -884,12 +884,11 @@ void cuda_vec_gather(c_int          nnz,
 
 void cuda_mat_mult_sc(csr     *S,
                       csr     *At,
-                      c_int    symmetric,
                       c_float  sc) {
 
   checkCudaErrors(cublasTscal(CUDA_handle->cublasHandle, S->nnz, &sc, S->val, 1));
 
-  if (!symmetric) {
+  if (At) {
     /* Update At as well */
     checkCudaErrors(cublasTscal(CUDA_handle->cublasHandle, At->nnz, &sc, At->val, 1));
   }
@@ -897,7 +896,6 @@ void cuda_mat_mult_sc(csr     *S,
 
 void cuda_mat_lmult_diag(csr           *S,
                          csr           *At,
-                         c_int          symmetric,
                          const c_float *d_diag) {
 
   c_int nnz = S->nnz;
@@ -905,7 +903,7 @@ void cuda_mat_lmult_diag(csr           *S,
 
   mat_lmult_diag_kernel<<<number_of_blocks,THREADS_PER_BLOCK>>>(S->row_ind, d_diag, S->val, nnz);
 
-  if (!symmetric) {
+  if (At) {
     /* Multiply At from right */
     mat_rmult_diag_kernel<<<number_of_blocks,THREADS_PER_BLOCK>>>(At->col_ind, d_diag, At->val, nnz);
   }
@@ -913,7 +911,6 @@ void cuda_mat_lmult_diag(csr           *S,
 
 void cuda_mat_rmult_diag(csr           *S,
                          csr           *At,
-                         c_int          symmetric,
                          const c_float *d_diag) {
 
   c_int nnz = S->nnz;
@@ -921,7 +918,7 @@ void cuda_mat_rmult_diag(csr           *S,
 
   mat_rmult_diag_kernel<<<number_of_blocks,THREADS_PER_BLOCK>>>(S->col_ind, d_diag, S->val, nnz);
 
-  if (!symmetric) {
+  if (At) {
     /* Multiply At from left */
     mat_lmult_diag_kernel<<<number_of_blocks,THREADS_PER_BLOCK>>>(At->row_ind, d_diag, At->val, nnz);
   }

--- a/algebra/cuda/src/cuda_lin_alg.cu
+++ b/algebra/cuda/src/cuda_lin_alg.cu
@@ -614,13 +614,6 @@ void cuda_vec_norm_inf(const c_float *d_x,
   }
 }
 
-// void cuda_vec_norm_1(const c_float *d_x,
-//                      c_int          n,
-//                      c_float       *h_res) {
-
-//   cublasTasum(CUDA_handle->cublasHandle, n, d_x, 1, h_res);
-// }
-
 void cuda_vec_norm_2(const c_float *d_x,
                      c_int          n,
                      c_float       *h_res) {
@@ -953,27 +946,6 @@ void cuda_mat_Axpy(const csr     *A,
                                   CUDA_FLOAT, A->row_ptr, A->col_ind, d_x,
                                   CUDA_FLOAT, &beta, CUDA_FLOAT, d_y,
                                   CUDA_FLOAT, CUDA_FLOAT, A->buffer));
-}
-
-void cuda_mat_quad_form(const csr     *P,
-                        const c_float *d_x,
-                        c_float       *h_res) {
-
-  c_int n = P->n;
-  c_float *d_Px;
-
-  cuda_malloc((void **) &d_Px, n * sizeof(c_float));
-
-  /* d_Px = P * x */
-  cuda_mat_Axpy(P, d_x, d_Px, 1.0, 0.0);
-
-  /* h_res = d_Px' * d_x */
-  cuda_vec_prod(d_Px, d_x, n, h_res);
-
-  /* h_res *= 0.5 */
-  (*h_res) *= 0.5;
-
-  cuda_free((void **) &d_Px);
 }
 
 void cuda_mat_row_norm_inf(const csr *S,

--- a/algebra/default/algebra_impl.h
+++ b/algebra/default/algebra_impl.h
@@ -31,7 +31,7 @@ struct OSQPVectorf_ {
 /**
  *  An enum used to indicate whether a matrix is symmetric.   Options
  *  NONE : matrix is fully populated
- *  TRUI : matrix is symmetric and only upper triangle is stored
+ *  TRIU : matrix is symmetric and only upper triangle is stored
  */
 typedef enum OSQPMatrix_symmetry_type {NONE,TRIU} OSQPMatrix_symmetry_type;
 

--- a/algebra/default/matrix.c
+++ b/algebra/default/matrix.c
@@ -106,18 +106,17 @@ void OSQPMatrix_Atxpy(const OSQPMatrix  *A,
    else            csc_Axpy_sym_triu(A->csc, x->values, y->values, alpha, beta);
 }
 
+// c_float OSQPMatrix_quad_form(const OSQPMatrix  *P,
+//                              const OSQPVectorf *x) {
 
-c_float OSQPMatrix_quad_form(const OSQPMatrix  *P,
-                             const OSQPVectorf *x) {
-
-   if (P->symmetry == TRIU) return csc_quad_form(P->csc, OSQPVectorf_data(x));
-   else {
-#ifdef PRINTING
-     c_eprint("quad_form matrix is not upper triangular");
-#endif /* ifdef PRINTING */
-     return -1.0;
-   }
-}
+//    if (P->symmetry == TRIU) return csc_quad_form(P->csc, OSQPVectorf_data(x));
+//    else {
+// #ifdef PRINTING
+//      c_eprint("quad_form matrix is not upper triangular");
+// #endif /* ifdef PRINTING */
+//      return -1.0;
+//    }
+// }
 
 #if EMBEDDED != 1
 

--- a/algebra/mkl/algebra_impl.h
+++ b/algebra/mkl/algebra_impl.h
@@ -31,7 +31,7 @@ struct OSQPVectorf_ {
 /**
  *  An enum used to indicate whether a matrix is symmetric.   Options
  *  NONE : matrix is fully populated
- *  TRUI : matrix is symmetric and only upper triangle is stored
+ *  TRIU : matrix is symmetric and only upper triangle is stored
  */
 typedef enum OSQPMatrix_symmetry_type {NONE,TRIU} OSQPMatrix_symmetry_type;
 

--- a/algebra/mkl/matrix.c
+++ b/algebra/mkl/matrix.c
@@ -103,18 +103,17 @@ void OSQPMatrix_Atxpy(const OSQPMatrix  *A,
     csc_Axpy_sym_triu(A->csc, OSQPVectorf_data(x), OSQPVectorf_data(y), alpha, beta);
 }
 
-
-c_float OSQPMatrix_quad_form(const OSQPMatrix  *P,
-                             const OSQPVectorf *x) {
-  if(P->symmetry == TRIU)
-    return csc_quad_form(P->csc, OSQPVectorf_data(x));
-  else {
-#ifdef PRINTING
-     c_eprint("quad_form matrix is not upper triangular");
-#endif /* ifdef PRINTING */
-     return -1.0;
-  }
-}
+// c_float OSQPMatrix_quad_form(const OSQPMatrix  *P,
+//                              const OSQPVectorf *x) {
+//   if(P->symmetry == TRIU)
+//     return csc_quad_form(P->csc, OSQPVectorf_data(x));
+//   else {
+// #ifdef PRINTING
+//      c_eprint("quad_form matrix is not upper triangular");
+// #endif /* ifdef PRINTING */
+//      return -1.0;
+//   }
+// }
 
 void OSQPMatrix_col_norm_inf(const OSQPMatrix *M,
                              OSQPVectorf      *E) {

--- a/include/algebra_matrix.h
+++ b/include/algebra_matrix.h
@@ -96,8 +96,8 @@ void OSQPMatrix_Atxpy(const OSQPMatrix  *A,
                       c_float            alpha,
                       c_float            beta);
 
-c_float OSQPMatrix_quad_form(const OSQPMatrix  *P,
-                             const OSQPVectorf *x);
+// c_float OSQPMatrix_quad_form(const OSQPMatrix  *P,
+//                              const OSQPVectorf *x);
 
 #if EMBEDDED != 1
 

--- a/include/algebra_vector.h
+++ b/include/algebra_vector.h
@@ -51,6 +51,7 @@ OSQPVectorf* OSQPVectorf_view(const OSQPVectorf *a,
                               c_int              length);
 
 /* Points existing subview somewhere else.  (Does not use MALLOC)
+ * TODO: Get rid of this function
  */
 void OSQPVectorf_view_update(OSQPVectorf *a, const OSQPVectorf *b, c_int head, c_int length);
 

--- a/tests/lin_alg/test_lin_alg.h
+++ b/tests/lin_alg/test_lin_alg.h
@@ -274,22 +274,22 @@ void test_mat_vec_multiplication() {
   clean_problem_lin_alg_sols_data(data);
 }
 
-void test_quad_form_upper_triang() {
+// void test_quad_form_upper_triang() {
 
-  c_float val;
-  lin_alg_sols_data *data = generate_problem_lin_alg_sols_data();
-  OSQPMatrix* P  = OSQPMatrix_new_from_csc(data->test_qpform_Pu, 1); //triu;
-  OSQPVectorf* x = OSQPVectorf_new(data->test_qpform_x, data->test_mat_vec_n);
+//   c_float val;
+//   lin_alg_sols_data *data = generate_problem_lin_alg_sols_data();
+//   OSQPMatrix* P  = OSQPMatrix_new_from_csc(data->test_qpform_Pu, 1); //triu;
+//   OSQPVectorf* x = OSQPVectorf_new(data->test_qpform_x, data->test_mat_vec_n);
 
-  // Compute quadratic form
-  val = OSQPMatrix_quad_form(P, x);
+//   // Compute quadratic form
+//   val = OSQPMatrix_quad_form(P, x);
 
-  mu_assert(
-    "Linear algebra tests: error in computing quadratic form using upper triangular matrix!",
-    (c_absval(val - data->test_qpform_value) < TESTS_TOL));
+//   mu_assert(
+//     "Linear algebra tests: error in computing quadratic form using upper triangular matrix!",
+//     (c_absval(val - data->test_qpform_value) < TESTS_TOL));
 
-  // cleanup
-  OSQPMatrix_free(P);
-  OSQPVectorf_free(x);
-  clean_problem_lin_alg_sols_data(data);
-}
+//   // cleanup
+//   OSQPMatrix_free(P);
+//   OSQPVectorf_free(x);
+//   clean_problem_lin_alg_sols_data(data);
+// }

--- a/tests/osqp_tester.cpp
+++ b/tests/osqp_tester.cpp
@@ -34,9 +34,9 @@ TEST_CASE( "test_lin_alg", "[multi-file:1]" ) {
     SECTION( "test_mat_vec_multiplication" ) {
         test_mat_vec_multiplication();
     }
-    SECTION( "test_quad_form_upper_triang" ) {
-        test_quad_form_upper_triang();
-    }
+    // SECTION( "test_quad_form_upper_triang" ) {
+    //     test_quad_form_upper_triang();
+    // }
 	osqp_algebra_free_libs();
 }
 


### PR DESCRIPTION
I have also removed `OSQPMatrix_quad_form()` as there is no need for it. We always evaluate the objective function after computing the dual residual `Px + q + A'y`, which means that `Px` is already computed; hence, we can evaluate the inner product between `Px` and `x` instead of computing `x'Px` from scratch.