### PR TITLE
report CNTRLC status

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,9 @@ else()
   message(STATUS "EMBEDDED = OFF")
 endif()
 
+# Display final CTRLC behaviour
+message(STATUS "CTRLC = ${CTRLC}")
+
 # Display final ALGEBRA chosen and set internal boolean variables
 message(STATUS "ALGEBRA = ${ALGEBRA}")
 if(${ALGEBRA} STREQUAL "default")


### PR DESCRIPTION
Adds an information line reporting the final status of the CTRLC option in cmake.   This would have been helpful with #366, for example.