### PR TITLE
partial data matrix updates

### DIFF
--- a/algebra/_common/csc_math.c
+++ b/algebra/_common/csc_math.c
@@ -31,14 +31,13 @@ void csc_update_values(csc           *M,
 
   c_int i;
 
-  // Update P elements
+  // Update subset of elements
   if (Mx_new_idx) { // Change only Mx_new_idx
     for (i = 0; i < M_new_n; i++) {
       M->x[Mx_new_idx[i]] = Mx_new[i];
     }
   }
-  else // Change whole M
-  {
+  else{ // Change whole M.  Assumes M_new_n == nnz(M)
     for (i = 0; i < M_new_n; i++) {
       M->x[i] = Mx_new[i];
     }

--- a/algebra/_common/kkt.c
+++ b/algebra/_common/kkt.c
@@ -335,36 +335,75 @@ csc* form_KKT(csc*        P,
 
 #if EMBEDDED != 1
 
-void update_KKT_P(csc*        KKT,
-                  csc*        P,
-                  c_int*      PtoKKT,
-                  c_float     param1,
-                  c_int       format) {
+void update_KKT_P(csc*         KKT,
+                  csc*         P,
+                  const c_int* Px_new_idx,
+                  c_int        P_new_n,
+                  c_int*       PtoKKT,
+                  c_float      param1,
+                  c_int        format) {
 
-  c_int j, nnzP;
-
-  // Update elements of KKT using P
+  c_int j, nnzP, Pidx, Kidx, row, offset;
   nnzP = P->p[P->n];
-  for (j = 0; j < nnzP; j++) {
-    KKT->x[PtoKKT[j]] = P->x[j];
+
+  if(Px_new_idx == OSQP_NULL || P_new_n <= 0){return;}
+
+  //if nnzP is the same as the update length update,
+  //overwrite everything and apply sigma shifts
+  //as a final step
+  if(P_new_n == nnzP)
+  {
+    for (j = 0; j < P_new_n; j++) {
+      Pidx = Px_new_idx[j];
+      Kidx = PtoKKT[Pidx];
+      KKT->x[Kidx] = P->x[Pidx];
+    }
+
+    // Update diagonal elements of KKT by adding sigma
+    _kkt_shifts_param1(KKT, param1, P->n, format);
   }
 
-  // Update diagonal elements of KKT by adding sigma
-  _kkt_shifts_param1(KKT, param1, P->n, format);
+  //if nnzP indicates a partial update only, then
+  //check each entry in turn to see if it is on the
+  //diagonal and apply sigma shift as we go
+  else
+  {
+    offset = format == 0 ? 1 : 0;
 
+    for (j = 0; j < P_new_n; j++) {
+      Pidx = Px_new_idx[j];
+      Kidx = PtoKKT[Pidx];
+      KKT->x[Kidx] = P->x[Pidx];
+
+      //is the corresonding column nonempty with
+      //the current element on the diagonal (i.e. row==col)?
+      row  = P->i[Pidx];
+      if((P->p[row] < P->p[row+1]) && ((P->p[row+offset] - offset) == row)){
+        KKT->x[Kidx] += param1;
+      }
+    }
+  }
+  return;
 }
 
-void update_KKT_A(csc*        KKT,
-                  csc*        A,
-                  c_int*      AtoKKT) {
+void update_KKT_A(csc*         KKT,
+                  csc*         A,
+                  const c_int* Ax_new_idx,
+                  c_int        A_new_n,
+                  c_int*       AtoKKT) {
 
-  c_int j, nnzA;
+  c_int j, nnzA, Aidx, Kidx;
+
+  if(Ax_new_idx == OSQP_NULL || A_new_n <= 0){return;}
 
   // Update elements of KKT using A
   nnzA = A->p[A->n];
-  for (j = 0; j < nnzA; j++) {
-    KKT->x[AtoKKT[j]] = A->x[j];
+  for (j = 0; j < A_new_n; j++) {
+    Aidx = Ax_new_idx[j];
+    Kidx = AtoKKT[Aidx];
+    KKT->x[Kidx] = A->x[Aidx];
   }
+  return;
 }
 
 

--- a/algebra/_common/kkt.h
+++ b/algebra/_common/kkt.h
@@ -53,15 +53,19 @@ extern "C" {
  *
  * @param KKT       KKT matrix in CSC form (upper-triangular)
  * @param P         P matrix in csc format (triu form)
+ * @param P_new_idx indices of P to be updated
+ * @param P_new_n   number of elements of P to be updated
  * @param PtoKKT    Vector of pointers from P->x to KKT->x
  * @param param1    Parameter added to the diagonal elements of P
  * @param format    0 for CSC, 1 for CSR
  */
- void update_KKT_P(csc*        KKT,
-                   csc*        P,
-                   c_int*      PtoKKT,
-                   c_float     param1,
-                   c_int       format);
+ void update_KKT_P(csc*         KKT,
+                   csc*         P,
+                   const c_int* Px_new_idx,
+                   c_int        P_new_n,
+                   c_int*       PtoKKT,
+                   c_float      param1,
+                   c_int        format);
 
 
 /**
@@ -69,11 +73,15 @@ extern "C" {
  *
  * @param KKT       KKT matrix in CSC form (upper-triangular)
  * @param  A        A matrix in csc format
+ * @param A_new_idx indices of A to be updated
+ * @param A_new_n   number of elements of A to be updated
  * @param AtoKKT    Vector of pointers from A->x to KKT->x
  */
- void update_KKT_A(csc*        KKT,
-                   csc*        A,
-                   c_int*      AtoKKT);
+ void update_KKT_A(csc*         KKT,
+                   csc*         A,
+                   const c_int* Ax_new_idx,
+                   c_int        A_new_n,
+                   c_int*       AtoKKT);
 
 
 /**

--- a/algebra/default/lin_sys/direct/qdldl_interface.c
+++ b/algebra/default/lin_sys/direct/qdldl_interface.c
@@ -444,15 +444,21 @@ c_int update_linsys_solver_matrices_qdldl(qdldl_solver     *s,
                                           const c_int* Ax_new_idx,
                                           c_int A_new_n) {
 
+    int pos_D_count;
+
     // Update KKT matrix with new P
     update_KKT_P(s->KKT, P->csc, Px_new_idx, P_new_n, s->PtoKKT, s->sigma, 0);
 
     // Update KKT matrix with new A
     update_KKT_A(s->KKT, A->csc, Ax_new_idx, A_new_n, s->AtoKKT);
 
-    return (QDLDL_factor(s->KKT->n, s->KKT->p, s->KKT->i, s->KKT->x,
+    pos_D_count = QDLDL_factor(s->KKT->n, s->KKT->p, s->KKT->i, s->KKT->x,
         s->L->p, s->L->i, s->L->x, s->D, s->Dinv, s->Lnz,
-        s->etree, s->bwork, s->iwork, s->fwork) < 0);
+        s->etree, s->bwork, s->iwork, s->fwork);
+
+    //number of positive elements in D should match the
+    //dimension of P if P + \sigma I is PD.   Error otherwise.
+    return (pos_D_count == P->csc->n) ? 0 : 1;
 }
 
 

--- a/algebra/default/lin_sys/direct/qdldl_interface.c
+++ b/algebra/default/lin_sys/direct/qdldl_interface.c
@@ -438,13 +438,17 @@ c_int solve_linsys_qdldl(qdldl_solver *s,
 // Update private structure with new P and A
 c_int update_linsys_solver_matrices_qdldl(qdldl_solver     *s,
                                           const OSQPMatrix *P,
-                                          const OSQPMatrix *A) {
+                                          const c_int* Px_new_idx,
+                                          c_int P_new_n,
+                                          const OSQPMatrix *A,
+                                          const c_int* Ax_new_idx,
+                                          c_int A_new_n) {
 
     // Update KKT matrix with new P
-    update_KKT_P(s->KKT, P->csc, s->PtoKKT, s->sigma, 0);
+    update_KKT_P(s->KKT, P->csc, Px_new_idx, P_new_n, s->PtoKKT, s->sigma, 0);
 
     // Update KKT matrix with new A
-    update_KKT_A(s->KKT, A->csc, s->AtoKKT);
+    update_KKT_A(s->KKT, A->csc, Ax_new_idx, A_new_n, s->AtoKKT);
 
     return (QDLDL_factor(s->KKT->n, s->KKT->p, s->KKT->i, s->KKT->x,
         s->L->p, s->L->i, s->L->x, s->D, s->Dinv, s->Lnz,

--- a/algebra/default/lin_sys/direct/qdldl_interface.h
+++ b/algebra/default/lin_sys/direct/qdldl_interface.h
@@ -39,7 +39,11 @@ struct qdldl {
 #if EMBEDDED != 1
     c_int (*update_matrices)(struct qdldl     *self,
                              const OSQPMatrix *P,
-                             const OSQPMatrix *A);         ///< Update solver matrices
+                             const c_int* Px_new_idx,
+                             c_int P_new_n,
+                             const OSQPMatrix *A,
+                             const c_int* Ax_new_idx,
+                             c_int A_new_n);   ///< Update solver matrices
 
     c_int (*update_rho_vec)(struct qdldl      *self,
                             const OSQPVectorf *rho_vec,
@@ -128,15 +132,23 @@ void warm_start_linsys_solver_qdldl(qdldl_solver      *s,
 #if EMBEDDED != 1
 /**
  * Update linear system solver matrices
- * @param  s        Linear system solver structure
- * @param  P        Matrix P
- * @param  A        Matrix A
- * @return          Exitflag
+ * @param  s          Linear system solver structure
+ * @param  P          Matrix P
+ * @param  Px_new_idx elements of P to update,
+ * @param  P_new_n    number of elements to update
+ * @param  A          Matrix A
+ * @param  Ax_new_idx elements of A to update,
+ * @param  A_new_n    number of elements to update
+ * @return            Exitflag
  */
 c_int update_linsys_solver_matrices_qdldl(
                   qdldl_solver * s,
                   const OSQPMatrix *P,
-                  const OSQPMatrix *A);
+                  const c_int* Px_new_idx,
+                  c_int P_new_n,
+                  const OSQPMatrix *A,
+                  const c_int* Ax_new_idx,
+                  c_int A_new_n);
 
 
 

--- a/include/types.h
+++ b/include/types.h
@@ -194,7 +194,7 @@ struct OSQPWorkspace_ {
 # endif // ifdef PRINTING
 };
 
-// NB: "typedef struct OSQPWorkspace_ OSQPWorkspace" is declared already 
+// NB: "typedef struct OSQPWorkspace_ OSQPWorkspace" is declared already
 // in the osqp API where the main OSQPSolver is defined.
 
 
@@ -223,7 +223,11 @@ struct linsys_solver {
 # if EMBEDDED != 1
   c_int (*update_matrices)(LinSysSolver     *self,
                            const OSQPMatrix *P,            ///< update matrices P
-                           const OSQPMatrix *A);           //   and A in the solver
+                           const c_int* Px_new_idx,
+                           c_int P_new_n,
+                           const OSQPMatrix *A,            //   and A in the solver
+                           const c_int* Ax_new_idx,
+                           c_int A_new_n);
 
   c_int (*update_rho_vec)(LinSysSolver      *self,
                           const OSQPVectorf *rho_vec,

--- a/src/osqp_api.c
+++ b/src/osqp_api.c
@@ -960,46 +960,71 @@ c_int osqp_update_data_mat(OSQPSolver    *solver,
   nnzA = OSQPMatrix_get_nz(work->data->A);
 
 
-  if (Px_new_idx) {
-    // Check if the number of elements to update is valid
-    if (P_new_n > nnzP) {
+  // Check if the number of elements to update is valid
+  if (P_new_n > nnzP || P_new_n < 0) {
 # ifdef PRINTING
-      c_eprint("new number of elements (%i) greater than elements in P (%i)",
-               (int)P_new_n, (int)nnzP);
+    c_eprint("new number of elements (%i) out of bounds for P (%i max)",
+             (int)P_new_n, (int)nnzP);
 # endif /* ifdef PRINTING */
-      return 1;
-    }
+    return 1;
+  }
+  //indexing is required if the whole P is not updated
+  if(Px_new_idx == NULL && P_new_n != 0 && P_new_n != nnzP){
+    # ifdef PRINTING
+        c_eprint("index vector is required for partial updates of P");
+    # endif /* ifdef PRINTING */
+        return 1;
   }
 
-  if (Ax_new_idx) {
-    // Check if the number of elements to update is valid
-    if (A_new_n > nnzA) {
+  // Check if the number of elements to update is valid
+  if (A_new_n > nnzA || A_new_n < 0) {
 # ifdef PRINTING
-      c_eprint("new number of elements (%i) greater than elements in A (%i)",
-               (int)A_new_n,
-               (int)nnzA);
+    c_eprint("new number of elements (%i) out of bounds for A (%i max)",
+             (int)A_new_n,
+             (int)nnzA);
 # endif /* ifdef PRINTING */
-      return 2;
-    }
+    return 2;
+  }
+  //indexing is required if the whole A is not updated
+  if(Ax_new_idx == NULL && A_new_n != 0 && A_new_n != nnzA){
+    # ifdef PRINTING
+        c_eprint("index vector is required for partial updates of A");
+    # endif /* ifdef PRINTING */
+        return 2;
   }
 
   if (solver->settings->scaling) unscale_data(solver);
 
-  if (Px_new) OSQPMatrix_update_values(work->data->P, Px_new, Px_new_idx, P_new_n);
-  if (Ax_new) OSQPMatrix_update_values(work->data->A, Ax_new, Ax_new_idx, A_new_n);
+  if (Px_new){
+    OSQPMatrix_update_values(work->data->P, Px_new, Px_new_idx, P_new_n);
+  }
+  if (Ax_new){
+    OSQPMatrix_update_values(work->data->A, Ax_new, Ax_new_idx, A_new_n);
+  }
 
   if (solver->settings->scaling) scale_data(solver);
 
-  // Update linear system structure with new data
-  exitflag = work->linsys_solver->update_matrices(work->linsys_solver,
-                                                  work->data->P, Px_new_idx, P_new_n,
-                                                  work->data->A, Ax_new_idx, A_new_n);
+  // Update linear system structure with new data.
+  // If there is scaling, then a full update is needed.
+  if(solver->settings->scaling){
+    exitflag = work->linsys_solver->update_matrices(
+                  work->linsys_solver,
+                  work->data->P, NULL, nnzP,
+                  work->data->A, NULL, nnzA);
+  }
+  else{
+    exitflag = work->linsys_solver->update_matrices(
+                  work->linsys_solver,
+                  work->data->P, Px_new_idx, P_new_n,
+                  work->data->A, Ax_new_idx, A_new_n);
+  }
+
 
   // Reset solver information
   reset_info(solver->info);
 
 # ifdef PRINTING
-  if (exitflag < 0) c_eprint("new KKT matrix is not quasidefinite");
+  if (exitflag != 0){c_eprint("new KKT matrix is not quasidefinite");}
 # endif /* ifdef PRINTING */
 
 #ifdef PROFILING

--- a/src/osqp_api.c
+++ b/src/osqp_api.c
@@ -239,7 +239,7 @@ c_int osqp_setup(OSQPSolver         **solverp,
   }
 
   // Initialize linear system solver structure
-  exitflag = init_linsys_solver(&(work->linsys_solver), work->data->P, work->data->A, 
+  exitflag = init_linsys_solver(&(work->linsys_solver), work->data->P, work->data->A,
                                 work->rho_vec, solver->settings,
                                 &work->scaled_prim_res, &work->scaled_dual_res, 0);
 
@@ -992,8 +992,8 @@ c_int osqp_update_data_mat(OSQPSolver    *solver,
 
   // Update linear system structure with new data
   exitflag = work->linsys_solver->update_matrices(work->linsys_solver,
-                                                  work->data->P,
-                                                  work->data->A);
+                                                  work->data->P, Px_new_idx, P_new_n,
+                                                  work->data->A, Ax_new_idx, A_new_n);
 
   // Reset solver information
   reset_info(solver->info);

--- a/tests/update_matrices/generate_problem.py
+++ b/tests/update_matrices/generate_problem.py
@@ -30,6 +30,12 @@ test_form_KKT_A_new = test_form_KKT_A.copy()
 test_form_KKT_A_new.data += rg.standard_normal(test_form_KKT_A_new.nnz)
 test_form_KKT_Pu_new = test_form_KKT_Pu.copy()
 test_form_KKT_Pu_new.data += 0.1 * rg.standard_normal(test_form_KKT_Pu_new.nnz)
+
+test_form_KKT_A_new_idx = np.array(range(test_form_KKT_A_new.nnz))
+test_form_KKT_A_new_n = test_form_KKT_A_new.nnz
+test_form_KKT_Pu_new_idx = np.array(range(test_form_KKT_Pu_new.nnz))
+test_form_KKT_Pu_new_n = test_form_KKT_Pu_new.nnz
+
 test_form_KKT_P_new = test_form_KKT_Pu_new + test_form_KKT_Pu_new.T - sparse.diags(test_form_KKT_Pu_new.diagonal())
 
 test_form_KKT_KKT_new = sparse.bmat([
@@ -56,6 +62,7 @@ test_solve_Pu_new = test_form_KKT_Pu_new.copy()
 test_solve_A_new = test_form_KKT_A_new.copy()
 
 
+
 # Generate test data and solutions
 data = {'test_form_KKT_n': test_form_KKT_n,
         'test_form_KKT_m': test_form_KKT_m,
@@ -66,7 +73,11 @@ data = {'test_form_KKT_n': test_form_KKT_n,
         'test_form_KKT_KKT': test_form_KKT_KKT,
         'test_form_KKT_KKTu': test_form_KKT_KKTu,
         'test_form_KKT_A_new': test_form_KKT_A_new,
+        'test_form_KKT_A_new_idx': test_form_KKT_A_new_idx,
+        'test_form_KKT_A_new_n': test_form_KKT_A_new_n,
         'test_form_KKT_Pu_new': test_form_KKT_Pu_new,
+        'test_form_KKT_Pu_new_idx': test_form_KKT_Pu_new_idx,
+        'test_form_KKT_Pu_new_n': test_form_KKT_Pu_new_n,
         'test_form_KKT_KKT_new': test_form_KKT_KKT_new,
         'test_form_KKT_KKTu_new': test_form_KKT_KKTu_new,
         'test_solve_Pu': test_solve_Pu,

--- a/tests/update_matrices/test_update_matrices.h
+++ b/tests/update_matrices/test_update_matrices.h
@@ -55,13 +55,17 @@ void test_form_KKT() {
             csc_is_eq(KKT, data->test_form_KKT_KKTu, TESTS_TOL));
 
   // Update KKT matrix with new P and new A
-  update_KKT_P(KKT,
-               data->test_form_KKT_Pu_new,
-               PtoKKT, sigma, 0);
   update_KKT_A(KKT,
               data->test_form_KKT_A_new,
+              data->test_form_KKT_A_new_idx,
+              data->test_form_KKT_A_new_n,
               AtoKKT);
 
+  update_KKT_P(KKT,
+               data->test_form_KKT_Pu_new,
+               data->test_form_KKT_Pu_new_idx,
+               data->test_form_KKT_Pu_new_n,
+               PtoKKT, sigma, 0);
 
   // Assert if KKT matrix is the same as predicted one
   mu_assert("Update matrices: error in updating KKT matrix!",
@@ -146,7 +150,7 @@ void test_update() {
 
 
   // Update P
-  nnzP       = data->test_solve_Pu->p[data->test_solve_Pu->n];
+  nnzP       = data->test_solve_Pu_new->p[data->test_solve_Pu->n];
   Px_new_idx = (c_int*) c_malloc(nnzP * sizeof(c_int));
 
   // Generate indices going from beginning to end of P
@@ -155,7 +159,7 @@ void test_update() {
   }
 
   osqp_update_data_mat(solver,
-                       data->test_solve_Pu_new->x, Px_new_idx, nnzP,
+                       data->test_solve_Pu_new->x, NULL, nnzP,
                        NULL, NULL, 0);
 
   // Solve Problem

--- a/tests/utils/codegen_utils.py
+++ b/tests/utils/codegen_utils.py
@@ -35,6 +35,7 @@ def write_vec_int(f, x, name, *args):
         f.write("%s[%i] = " % (name, i))
         f.write("%i;\n" % x[i])
 
+    f.write("\n")
 
 def write_vec_float(f, x, name, *args):
     n = len(x)
@@ -56,6 +57,7 @@ def write_vec_float(f, x, name, *args):
         else:
             f.write("%.20f;\n" % x[i])
 
+    f.write("\n")
 
 def clean_vec(f, name, *args):
     f.write("c_free(")
@@ -420,9 +422,9 @@ def generate_data(problem_name, sols_data):
         elif sparse.issparse(value):  # Sparse matrix
             write_mat_sparse(f, value, key, "data")
         elif type(value) is np.ndarray:
-            if isinstance(value.flatten(order='F')[0], int):
+            if isinstance(value.flatten(order='F')[0], np.integer):
                 write_vec_int(f, value.flatten(order='F'), key, "data")
-            elif isinstance(value.flatten(order='F')[0], float):
+            elif isinstance(value.flatten(order='F')[0], np.float):
                 write_vec_float(f, value.flatten(order='F'), key, "data")
         else:
             if isinstance(value, int):

--- a/tests/utils/codegen_utils.py
+++ b/tests/utils/codegen_utils.py
@@ -380,9 +380,9 @@ def generate_data(problem_name, sols_data):
         elif sparse.issparse(value):  # Sparse matrix
             f.write("csc * %s;\n" % key)
         elif isinstance(value, np.ndarray):
-            if isinstance(value.flatten(order='F')[0], int):
+            if isinstance(value.flatten(order='F')[0], np.integer):
                 f.write("c_int * %s;\n" % key)
-            elif isinstance(value.flatten(order='F')[0], float):
+            elif isinstance(value.flatten(order='F')[0], np.float):
                 f.write("c_float * %s;\n" % key)
         else:
             if isinstance(value, int):


### PR DESCRIPTION
Implements support for partial updates to P and A matrices.

NB: untested because I think unit tests will require a modification to the python testing scripts to support export of c_int arrays that are required for indicating which elements to update.

Edit : I think it would also be a good idea to write one or more extra unit tests so that we can test 1) partial update of A and/or P and 2) full update of A and/or P.  This matters for P in particular because it is implemented two different ways.