### PR TITLE
Check interia of KKT matrix in Pardiso factorization to verify convexity

### DIFF
--- a/algebra/mkl/lin_sys/direct/pardiso_interface.c
+++ b/algebra/mkl/lin_sys/direct/pardiso_interface.c
@@ -235,6 +235,14 @@ c_int init_linsys_solver_pardiso(pardiso_solver    **sp,
     *sp = OSQP_NULL;
     return OSQP_LINSYS_SOLVER_INIT_ERROR;
   }
+  if ( s->iparm[21] < n ) {
+    // Error: Number of positive eigenvalues of KKT should be the same as dimension of P
+#ifdef PRINTING
+    c_eprint("KKT matrix has fewer positive eigenvalues than it should. The problem seems to be non-convex");
+#endif
+    return OSQP_NONCVX_ERROR;
+  }
+
   return 0;
 }
 

--- a/tests/non_cvx/test_non_cvx.h
+++ b/tests/non_cvx/test_non_cvx.h
@@ -29,7 +29,7 @@ void test_non_cvx_solve()
   settings->adaptive_rho = 0;
   settings->sigma = 1e-6;
 
-#ifdef ALGEBRA_DEFAULT
+#ifndef ALGEBRA_CUDA
   if (settings->linsys_solver == DIRECT_SOLVER) {
       // Setup workspace
       exitflag = osqp_setup(&solver, data->P, data->q,


### PR DESCRIPTION
The Pardiso interface provides the inertia of the factorized matrix inside the `iparm` array as a returned value after the numerical factorization. We can use that inertia to then determine if the KKT matrix is non-convex by just checking the number of positive eigenvalues against the size of the P matrix.