### PR TITLE
Rename error.h to osqp_error.h to avoid OS collisions

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -4,7 +4,7 @@ set(
     "${CMAKE_CURRENT_SOURCE_DIR}/version.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/auxil.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/constants.h"
-    "${CMAKE_CURRENT_SOURCE_DIR}/error.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/osqp_error.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/glob_opts.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/lin_alg.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/osqp.h"

--- a/include/osqp_error.h
+++ b/include/osqp_error.h
@@ -1,5 +1,5 @@
-#ifndef ERROR_H
-# define ERROR_H
+#ifndef OSQP_ERROR_H
+# define OSQP_ERROR_H
 
 /* OSQP error handling */
 
@@ -35,4 +35,4 @@ extern "C" {
 }
 # endif // ifdef __cplusplus
 
-#endif // ifndef ERROR_H
+#endif // ifndef OSQP_ERROR_H

--- a/src/error.c
+++ b/src/error.c
@@ -1,4 +1,4 @@
-#include "error.h"
+#include "osqp_error.h"
 
 const char *OSQP_ERROR_MESSAGE[] = {
   "Problem data validation.",

--- a/src/osqp.c
+++ b/src/osqp.c
@@ -3,7 +3,7 @@
 #include "util.h"
 #include "scaling.h"
 #include "glob_opts.h"
-#include "error.h"
+#include "osqp_error.h"
 
 
 #ifndef EMBEDDED

--- a/src/polish.c
+++ b/src/polish.c
@@ -5,7 +5,7 @@
 #include "lin_sys.h"
 #include "kkt.h"
 #include "proj.h"
-#include "error.h"
+#include "osqp_error.h"
 
 /**
  * Form reduced matrix A that contains only rows that are active at the


### PR DESCRIPTION
On linux, error.h exists.  Depending on how your toolchain and compiler
is configured, the compiler can pick the system error.h instead.
This results in some pretty esoteric errors which are hard to debug.
Instead, prefix this file with osqp_ to avoid the collision.