### PR TITLE
Prefix linear solver constants with OSQP to prevent clashes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,9 @@ jobs:
         fail-fast: false
 
         matrix:
-          os: [ubuntu-latest, macos-latest, windows-latest]
+          # Specify the exact Windows image because the CMake generator in the CI breaks when the image
+          # updates (since Visual Studio is also updated at the same time).
+          os: [ubuntu-latest, macos-latest, windows-2022]
           python-version: [3.9]
           cmake_flags: ['-DBUILD_TESTING=OFF', '-DBUILD_TESTING=ON -DCOVERAGE=ON']
           cmake_flags_extra: ['', '-DDFLOAT=ON', '-DDLONG=OFF', '-DEMBEDDED=1', '-DEMBEDDED=2', '-DPROFILING=OFF',
@@ -33,8 +35,8 @@ jobs:
               cmake_generator: "Unix Makefiles"
             - os: macos-latest
               cmake_generator: "Unix Makefiles"
-            - os: windows-latest
-              cmake_generator: "Visual Studio 16 2019"
+            - os: windows-2022
+              cmake_generator: "Visual Studio 17 2022"
 
       defaults:
         run:

--- a/algebra/cuda/lin_sys/indirect/cuda_pcg_interface.cu
+++ b/algebra/cuda/lin_sys/indirect/cuda_pcg_interface.cu
@@ -112,7 +112,7 @@ c_int init_linsys_solver_cudapcg(cudapcg_solver    **sp,
   *sp = s;
 
   /* Assign type and the number of threads */
-  s->type     = INDIRECT_SOLVER;
+  s->type     = OSQP_INDIRECT_SOLVER;
   s->nthreads = 1;
 
   /* Problem dimensions */

--- a/algebra/cuda/lin_sys/indirect/cuda_pcg_interface.h
+++ b/algebra/cuda/lin_sys/indirect/cuda_pcg_interface.h
@@ -30,7 +30,7 @@
  */
 typedef struct cudapcg_solver_ {
 
-  enum linsys_solver_type type;
+  enum osqp_linsys_solver_type type;
 
   /**
    * @name Functions

--- a/algebra/default/lin_sys/direct/qdldl_interface.c
+++ b/algebra/default/lin_sys/direct/qdldl_interface.c
@@ -250,7 +250,7 @@ c_int init_linsys_solver_qdldl(qdldl_solver      **sp,
 #endif
 
     // Assign type
-    s->type = DIRECT_SOLVER;
+    s->type = OSQP_DIRECT_SOLVER;
 
     // Set number of threads to 1 (single threaded)
     s->nthreads = 1;

--- a/algebra/default/lin_sys/direct/qdldl_interface.h
+++ b/algebra/default/lin_sys/direct/qdldl_interface.h
@@ -12,7 +12,7 @@
 typedef struct qdldl qdldl_solver;
 
 struct qdldl {
-    enum linsys_solver_type type;
+    enum osqp_linsys_solver_type type;
 
     /**
      * @name Functions

--- a/algebra/mkl/lin_sys/direct/pardiso_interface.c
+++ b/algebra/mkl/lin_sys/direct/pardiso_interface.c
@@ -106,7 +106,7 @@ c_int init_linsys_solver_pardiso(pardiso_solver    **sp,
   s->update_settings = &update_settings_linsys_solver_pardiso;
 
   // Assign type
-  s->type = DIRECT_SOLVER;
+  s->type = OSQP_DIRECT_SOLVER;
 
   // Working vector
   s->bp = (c_float *)c_malloc(sizeof(c_float) * n_plus_m);

--- a/algebra/mkl/lin_sys/direct/pardiso_interface.h
+++ b/algebra/mkl/lin_sys/direct/pardiso_interface.h
@@ -13,7 +13,7 @@
 typedef struct pardiso pardiso_solver;
 
 struct pardiso {
-    enum linsys_solver_type type;
+    enum osqp_linsys_solver_type type;
 
     /**
      * @name Functions

--- a/algebra/mkl/lin_sys/indirect/mkl-cg_interface.c
+++ b/algebra/mkl/lin_sys/indirect/mkl-cg_interface.c
@@ -85,7 +85,7 @@ c_int init_linsys_mklcg(mklcg_solver      **sp,
   s->update_settings = &update_settings_linsys_solver_mklcg;
 
   // Assign type
-  s->type = INDIRECT_SOLVER;
+  s->type = OSQP_INDIRECT_SOLVER;
 
   //Don't know the thread count.  Just use
   //the same thing as the pardiso solver

--- a/algebra/mkl/lin_sys/indirect/mkl-cg_interface.h
+++ b/algebra/mkl/lin_sys/indirect/mkl-cg_interface.h
@@ -9,7 +9,7 @@
 
 typedef struct mklcg_solver_ {
 
-  enum linsys_solver_type type;
+  enum osqp_linsys_solver_type type;
 
   /**
    * @name Functions

--- a/docs/contributing/index.rst
+++ b/docs/contributing/index.rst
@@ -53,7 +53,7 @@ The linear system solver object is defined in :code:`mysolver.h` as follows
 
         struct mysolver {
             // Methods
-            enum linsys_solver_type type; // Linear system solver defined in constants.h
+            enum osqp_linsys_solver_type type; // Linear system solver defined in constants.h
 
             c_int (*solve)(struct mysolver * self, c_float * b);
             void (*free)(struct mysolver * self);

--- a/include/private/types.h
+++ b/include/private/types.h
@@ -202,7 +202,7 @@ struct OSQPWorkspace_ {
  *      on the choice
  */
 struct linsys_solver {
-  enum linsys_solver_type type;             ///< linear system solver type functions
+  enum osqp_linsys_solver_type type;             ///< linear system solver type functions
   c_int (*solve)(LinSysSolver *self,
                  OSQPVectorf  *b,
                  c_int         admm_iter);

--- a/include/public/osqp_api_constants.h
+++ b/include/public/osqp_api_constants.h
@@ -25,9 +25,9 @@ enum osqp_status_type {
 * Linear System Solvers *
 *************************/
 enum osqp_linsys_solver_type {
-    OSQP_DIRECT_SOLVER = 1,
+    OSQP_UNKNOWN_SOLVER = 0,    /* Start from 0 for unknown solver because we index an array*/
+    OSQP_DIRECT_SOLVER,
     OSQP_INDIRECT_SOLVER,
-    OSQP_UNKNOWN_SOLVER=99
 };
 extern const char * OSQP_LINSYS_SOLVER_NAME[];
 

--- a/include/public/osqp_api_constants.h
+++ b/include/public/osqp_api_constants.h
@@ -24,8 +24,12 @@ enum osqp_status_type {
 /*************************
 * Linear System Solvers *
 *************************/
-enum linsys_solver_type { DIRECT_SOLVER, INDIRECT_SOLVER, UNKNOWN_SOLVER=99 };
-extern const char * LINSYS_SOLVER_NAME[];
+enum osqp_linsys_solver_type {
+    OSQP_DIRECT_SOLVER = 1,
+    OSQP_INDIRECT_SOLVER,
+    OSQP_UNKNOWN_SOLVER=99
+};
+extern const char * OSQP_LINSYS_SOLVER_NAME[];
 
 
 /******************
@@ -48,9 +52,9 @@ extern const char * OSQP_ERROR_MESSAGE[];
 **********************************/
 
 #ifdef ALGEBRA_CUDA
-# define OSQP_LINSYS_SOLVER (INDIRECT_SOLVER)
+# define OSQP_LINSYS_SOLVER (OSQP_INDIRECT_SOLVER)
 #else
-# define OSQP_LINSYS_SOLVER (DIRECT_SOLVER)
+# define OSQP_LINSYS_SOLVER (OSQP_DIRECT_SOLVER)
 #endif
 
 # define OSQP_VERBOSE               (1)

--- a/include/public/osqp_api_types.h
+++ b/include/public/osqp_api_types.h
@@ -27,12 +27,12 @@ typedef float c_float;  /* for numerical values  */
  * User settings
  */
 typedef struct {
-  c_int device;                          ///< device identifier; currently used for CUDA devices
-  enum linsys_solver_type linsys_solver; ///< linear system solver to use
-  c_int verbose;                         ///< boolean; write out progress
-  c_int warm_starting;                   ///< boolean; warm start
-  c_int scaling;                         ///< data scaling iterations; if 0, then disabled
-  c_int polishing;                       ///< boolean; polish ADMM solution
+  c_int device;                               ///< device identifier; currently used for CUDA devices
+  enum osqp_linsys_solver_type linsys_solver; ///< linear system solver to use
+  c_int verbose;                              ///< boolean; write out progress
+  c_int warm_starting;                        ///< boolean; warm start
+  c_int scaling;                              ///< data scaling iterations; if 0, then disabled
+  c_int polishing;                            ///< boolean; polish ADMM solution
 
   // ADMM parameters
   c_float rho;                    ///< ADMM penalty parameter

--- a/src/auxil.c
+++ b/src/auxil.c
@@ -952,16 +952,16 @@ c_int validate_data(const csc     *P,
 c_int validate_linsys_solver(c_int linsys_solver) {
 
 #ifdef ALGEBRA_CUDA
-  if (linsys_solver == INDIRECT_SOLVER) {
+  if (linsys_solver == OSQP_INDIRECT_SOLVER) {
     return 0;
   }
 #elif defined ALGEBRA_MKL
-  if ((linsys_solver == DIRECT_SOLVER) ||
-      (linsys_solver == INDIRECT_SOLVER)) {
+  if ((linsys_solver == OSQP_DIRECT_SOLVER) ||
+      (linsys_solver == OSQP_INDIRECT_SOLVER)) {
     return 0;
   }
 #else
-  if (linsys_solver == DIRECT_SOLVER) {
+  if (linsys_solver == OSQP_DIRECT_SOLVER) {
     return 0;
   }
 #endif

--- a/src/lin_sys.c
+++ b/src/lin_sys.c
@@ -2,7 +2,7 @@
 
 
 const char *OSQP_LINSYS_SOLVER_NAME[] = {
-  "direct", "indirect"
+  "unknown", "direct", "indirect"
 };
 
 

--- a/src/lin_sys.c
+++ b/src/lin_sys.c
@@ -1,7 +1,7 @@
 #include "lin_sys.h"
 
 
-const char *LINSYS_SOLVER_NAME[] = {
+const char *OSQP_LINSYS_SOLVER_NAME[] = {
   "direct", "indirect"
 };
 
@@ -41,10 +41,10 @@ c_int init_linsys_solver(LinSysSolver      **s,
 #else /* ifdef ALGEBRA_CUDA */
 
 #ifdef ALGEBRA_MKL
-  case DIRECT_SOLVER:
+  case OSQP_DIRECT_SOLVER:
     return init_linsys_solver_pardiso((pardiso_solver **)s, P, A, rho_vec, settings, polishing);
 
-  case INDIRECT_SOLVER:
+  case OSQP_INDIRECT_SOLVER:
     return init_linsys_mklcg((mklcg_solver **)s, P, A, rho_vec, settings, polishing);
 #else
   default:

--- a/src/util.c
+++ b/src/util.c
@@ -84,7 +84,7 @@ void print_setup_header(const OSQPSolver *solver) {
   // Print Settings
   c_print("settings: ");
   c_print("linear system solver = %s %s", OSQP_ALGEBRA,
-          LINSYS_SOLVER_NAME[settings->linsys_solver]);
+          OSQP_LINSYS_SOLVER_NAME[settings->linsys_solver]);
 
   if (work->linsys_solver->nthreads != 1) {
     c_print(" (%d threads)", (int)work->linsys_solver->nthreads);

--- a/tests/basic_qp/test_basic_qp.h
+++ b/tests/basic_qp/test_basic_qp.h
@@ -301,8 +301,8 @@ void test_basic_qp_solve()
   settings->alpha = tmp_float;
 
   // Setup solver with wrong settings->linsys_solver
-  enum linsys_solver_type tmp_solver_type= settings->linsys_solver;
-  settings->linsys_solver = UNKNOWN_SOLVER;
+  enum osqp_linsys_solver_type tmp_solver_type = settings->linsys_solver;
+  settings->linsys_solver = OSQP_UNKNOWN_SOLVER;
   exitflag = osqp_setup(&solver, data->P, data->q,
                         data->A, data->l, data->u,
                         data->m, data->n, settings);
@@ -501,7 +501,7 @@ void test_basic_qp_solve_pardiso()
   settings->scaling       = 0;
   settings->verbose       = 1;
   settings->warm_starting = 0;
-  settings->linsys_solver = DIRECT_SOLVER;
+  settings->linsys_solver = OSQP_DIRECT_SOLVER;
 
   // Setup solver
   exitflag = osqp_setup(&solver, data->P, data->q,

--- a/tests/basic_qp2/test_basic_qp2.h
+++ b/tests/basic_qp2/test_basic_qp2.h
@@ -96,7 +96,7 @@ void test_basic_qp2_solve_pardiso()
   settings->rho           = 0.1;
   settings->polishing     = 1;
   settings->verbose       = 1;
-  settings->linsys_solver = DIRECT_SOLVER;
+  settings->linsys_solver = OSQP_DIRECT_SOLVER;
 
   // Setup workspace
   exitflag = osqp_setup(&solver, data->P, data->q,

--- a/tests/non_cvx/test_non_cvx.h
+++ b/tests/non_cvx/test_non_cvx.h
@@ -30,7 +30,7 @@ void test_non_cvx_solve()
   settings->sigma = 1e-6;
 
 #ifndef ALGEBRA_CUDA
-  if (settings->linsys_solver == DIRECT_SOLVER) {
+  if (settings->linsys_solver == OSQP_DIRECT_SOLVER) {
       // Setup workspace
       exitflag = osqp_setup(&solver, data->P, data->q,
                             data->A, data->l, data->u,

--- a/tests/solve_linsys/test_solve_linsys.h
+++ b/tests/solve_linsys/test_solve_linsys.h
@@ -82,7 +82,7 @@ void test_solveKKT_pardiso() {
   // Settings
   settings->rho           = data->test_solve_KKT_rho;
   settings->sigma         = data->test_solve_KKT_sigma;
-  settings->linsys_solver = DIRECT_SOLVER;
+  settings->linsys_solver = OSQP_DIRECT_SOLVER;
 
   // Set rho_vec
   m       = data->test_solve_KKT_A->m;

--- a/tests/update_matrices/test_update_matrices.h
+++ b/tests/update_matrices/test_update_matrices.h
@@ -398,7 +398,7 @@ void test_update_pardiso() {
   settings->max_iter      = 1000;
   settings->alpha         = 1.6;
   settings->verbose       = 1;
-  settings->linsys_solver = DIRECT_SOLVER;
+  settings->linsys_solver = OSQP_DIRECT_SOLVER;
 
   // Setup solver
   exitflag = osqp_setup(&solver,problem->P,problem->q,


### PR DESCRIPTION
This adds an `OSQP_` prefix to the constants/types/variables for identifying the linear solver to namespace them into OSQP and prevent possible conflicts with other software that might have similar defines.

I also shuffled around the order of the enum to make the unknown solver position 0, since previously it was at 99, and the status printing would try to index into an array with that value (so it would index into position 99 of a 2 element array). Putting it at position 0 allows for future expansion still, and puts it into a nice indexable position.