### PR TITLE
Add the ability to override the printing functions at compile time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,10 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/configure/osqp_configure.h.in
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/configure/custom_headers/memory_defs.h.in
                ${CMAKE_CURRENT_BINARY_DIR}/include/private/memory_defs.h NEWLINE_STYLE LF)
 
+# Configure support for custom printing functions
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/configure/custom_headers/print_defs.h.in
+               ${CMAKE_CURRENT_BINARY_DIR}/include/private/print_defs.h NEWLINE_STYLE LF)
+
 # CUDA support
 # ----------------------------------------------
 if(ALGEBRA_CUDA)

--- a/configure/custom_headers/print_defs.h.in
+++ b/configure/custom_headers/print_defs.h.in
@@ -1,0 +1,50 @@
+#ifndef PRINT_DEFS_H_
+#define PRINT_DEFS_H_
+
+/* Header file defining printing functions */
+
+/* Printing */
+#cmakedefine OSQP_CUSTOM_PRINTING
+
+#include <stdio.h>
+#include <string.h>
+
+/* Error printing function */
+/* Always define this, and let implementations undefine if they want to change it */
+# if __STDC_VERSION__ >= 199901L
+/* The C99 standard gives the __func__ macro, which is preferred over __FUNCTION__ */
+# define c_eprint(...) c_print("ERROR in %s: ", __func__); \
+         c_print(__VA_ARGS__); c_print("\n");
+#else
+# define c_eprint(...) c_print("ERROR in %s: ", __FUNCTION__); \
+         c_print(__VA_ARGS__); c_print("\n");
+#endif
+
+
+#ifdef OSQP_CUSTOM_PRINTING
+/* Use user-provided printing functions */
+# include "@OSQP_CUSTOM_PRINTING@"
+#elif defined MATLAB
+/* informational print function */
+# define c_print mexPrintf
+#elif defined PYTHON
+# include <Python.h>
+# define c_print(...)                              \
+  {                                                  \
+    PyGILState_STATE gilstate = PyGILState_Ensure(); \
+    PySys_WriteStdout(__VA_ARGS__);                  \
+    PyGILState_Release(gilstate);                    \
+  }
+#elif defined R_LANG
+# include <R_ext/Print.h>
+# define c_print Rprintf
+    /* Some CRAN builds complain about __VA_ARGS__, so just print */
+    /* out the error messages on R without the __FUNCTION__ trace */
+# undefine c_eprint
+# define c_eprint Rprintf
+#else  /* ifdef MATLAB */
+# define c_print printf
+#endif /* Printing function configuration */
+
+
+#endif /* PRINT_DEFS_H_ */

--- a/include/private/glob_opts.h
+++ b/include/private/glob_opts.h
@@ -51,38 +51,9 @@
 
 # endif // end EMBEDDED
 
+/* Customized printing functions */
 # ifdef PRINTING
-#  include <stdio.h>
-#  include <string.h>
-
-/* informational print function */
-#  ifdef MATLAB
-#   define c_print mexPrintf
-#  elif defined PYTHON
-#   include <Python.h>
-# define c_print(...)                              \
-  {                                                  \
-    PyGILState_STATE gilstate = PyGILState_Ensure(); \
-    PySys_WriteStdout(__VA_ARGS__);                  \
-    PyGILState_Release(gilstate);                    \
-  }
-#  elif defined R_LANG
-#   include <R_ext/Print.h>
-#   define c_print Rprintf
-#  else  /* ifdef MATLAB */
-#   define c_print printf
-#  endif /* c_print configuration */
-
-/* error printing function */
-#  ifdef R_LANG
-    /* Some CRAN builds complain about __VA_ARGS__, so just print */
-    /* out the error messages on R without the __FUNCTION__ trace */
-#   define c_eprint Rprintf
-#  else
-#   define c_eprint(...) c_print("ERROR in %s: ", __FUNCTION__); \
-            c_print(__VA_ARGS__); c_print("\n");
-#  endif /* c_eprint configuration */
-
+# include "print_defs.h"
 # endif  /* PRINTING */
 
 

--- a/tests/custom_printing/CMakeLists.txt
+++ b/tests/custom_printing/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.16)
+project( OSQP_custom_printing )
+
+# Set the CMake options
+set( OSQP_BUILD_SHARED_LIB OFF )
+set( OSQP_BUILD_DEMO_EXE OFF )
+set( OSQP_CUSTOM_PRINTING "${CMAKE_CURRENT_SOURCE_DIR}/custom_printing.h" )
+
+add_subdirectory( ../../ ${CMAKE_CURRENT_BINARY_DIR}/osqp )
+
+add_executable( osqp_custom_printing ../../examples/osqp_demo.c custom_printing.c )
+target_link_libraries( osqp_custom_printing osqpstatic m )

--- a/tests/custom_printing/custom_printing.c
+++ b/tests/custom_printing/custom_printing.c
@@ -1,0 +1,37 @@
+#include "custom_printing.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdarg.h>
+
+/* Make a global counter with the number of lines/errors printed */
+long int line_counter = 0;
+long int error_counter = 0;
+
+void my_print(const char* format, ...) {
+  line_counter = line_counter + 1;
+
+  /* Add a number to the begining of each line counting how many occurred*/
+  va_list print_args;
+  va_start( print_args, format);
+
+  printf( "Line %ld: ", line_counter );
+  printf( format, print_args );
+
+  va_end(print_args);
+}
+
+
+void my_eprint(const char* funcName, const char* format, ...) {
+  error_counter = error_counter + 1;
+
+  /* Add a number to the begining of each line counting how many errors occurred*/
+  va_list print_args;
+  va_start( print_args, format);
+
+  printf( "Error %ld: ", error_counter );
+  printf( "ERROR in %s: ", funcName );
+  printf( format, print_args );
+  printf( "\n" );
+
+  va_end(print_args);
+}

--- a/tests/custom_printing/custom_printing.h
+++ b/tests/custom_printing/custom_printing.h
@@ -1,0 +1,23 @@
+#ifndef OSQP_CUSTOM_PRINTING_H
+#define OSQP_CUSTOM_PRINTING_H
+
+# ifdef __cplusplus
+extern "C" {
+# endif
+
+/* We will provide our own error function, so remove the default one */
+#undef c_eprint
+
+/* Must have the same signature as printf for both macros */
+#define c_print       my_print
+#define c_eprint(...) my_eprint( __FUNCTION__, __VA_ARGS__ )
+
+/* Implemented inside custom_printing.c */
+void my_print(const char* format, ...);
+void my_eprint(const char* funcName, const char* format, ...);
+
+# ifdef __cplusplus
+}
+# endif
+
+#endif /* ifndef  OSQP_CUSTOM_PRINTING_H */


### PR DESCRIPTION
This allows for users/interfaces to provide their own implementation of the c_print/c_eprint functions, and can allow for us to move the interface-specific printing functions for R/Matlab/Python into the interface repos instead of having them here in the main library.

This also includes a small example program that overrides the printing logic and prepends a line number to the front to demonstrate the use of this functionality (note that because we don't always call `c_print` with a full line, it sometimes puts that in the middle of other lines). The output is:
```
Line 1: 
Line 2:            OSQP   -  Operator Splitting QP Solver
              (c) Bartolomeo Stellato,  Goran Banjac
        University of Oxford  -  Stanford University 2021
Line 3: 
Line 4: problem:  Line 5: variables n = -1990180728, constraints m = -1990180728
          Line 6: nnz(P) + nnz(A) = -1990180728
Line 7: settings: Line 8: linear system solver =Line 9: ,
          Line 10: eps_abs = 0.0e+00, eps_rel = 0.0e+00,
          Line 11: eps_prim_inf = 0.0e+00, eps_dual_inf = 0.0e+00,
          Line 12: rho = 0.00e+00 Line 13: (adaptive)Line 14: ,
          Line 15: sigma = 0.00e+00, alpha = 0.00, Line 16: max_iter = -1990180728
Line 17:           check_termination: on (interval -1990180728),
Line 18:           time_limit: 0.00e+00 sec,
Line 19:           scaling: on, Line 20: scaled_termination: off
Line 21:           warm starting: on, Line 22: polishing: on, Line 23: 
Line 24: iter   Line 25: objective    prim res   dual res   rhoLine 26:         timeLine 27: 
Line 28: -1990180632Line 29:    4.4759e-91Line 30:    4.48e-91Line 31:    4.48e-91Line 32:    4.48e-91Line 33:    4.48e-91sLine 34: 
Line 35: -1990180632Line 36:    0.0000e+00Line 37:    0.00e+00Line 38:    0.00e+00Line 39:    0.00e+00Line 40:    0.00e+00sLine 41: 
Line 42:   Line 43:   2.5252e-312Line 44:   2.53e-312Line 45:   2.53e-312Line 46:    --------Line 47:   2.53e-312sLine 48: 
Line 49: 
Line 50: status:               
Line 51: solution polishing:   successful
Line 52: number of iterations: -1990180616
Line 53: optimal objective:    0.0000
Line 54: run time:             6.95e-310s
Line 55: optimal rho estimate: 6.95e-310
Line 56: 
```