### PR TITLE
Rework name printing for linear system solvers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,7 +100,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
-build/
+build*/
 develop-eggs/
 dist/
 downloads/

--- a/algebra/cuda/lin_sys/indirect/cuda_pcg_interface.cu
+++ b/algebra/cuda/lin_sys/indirect/cuda_pcg_interface.cu
@@ -193,6 +193,7 @@ c_int init_linsys_solver_cudapcg(cudapcg_solver    **sp,
   if (!s->d_rho_vec) cuda_malloc((void **) &s->d_AtA_diag_val, n * sizeof(c_float));
 
   /* Link functions */
+  s->name            = &name_cudapcg;
   s->solve           = &solve_linsys_cudapcg;
   s->warm_start      = &warm_start_linsys_solver_cudapcg;
   s->free            = &free_linsys_solver_cudapcg;
@@ -205,6 +206,11 @@ c_int init_linsys_solver_cudapcg(cudapcg_solver    **sp,
 
   /* No error */
   return 0;
+}
+
+
+const char* name_cudapcg() {
+  return "CUDA Preconditioned Conjugate Gradient";
 }
 
 

--- a/algebra/cuda/lin_sys/indirect/cuda_pcg_interface.h
+++ b/algebra/cuda/lin_sys/indirect/cuda_pcg_interface.h
@@ -36,6 +36,8 @@ typedef struct cudapcg_solver_ {
    * @name Functions
    * @{
    */
+  const char* (*name)(void);
+
   c_int (*solve)(struct cudapcg_solver_ *self,
                  OSQPVectorf            *b,
                  c_int                   admm_iter);
@@ -148,6 +150,12 @@ c_int init_linsys_solver_cudapcg(cudapcg_solver    **sp,
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * Get the user-friendly name of the PCG solver.
+ * @return The user-friendly name
+ */
+const char* name_cudapcg();
 
 
 c_int solve_linsys_cudapcg(cudapcg_solver *s,

--- a/algebra/default/lin_sys/direct/qdldl_interface.c
+++ b/algebra/default/lin_sys/direct/qdldl_interface.c
@@ -235,6 +235,7 @@ c_int init_linsys_solver_qdldl(qdldl_solver      **sp,
     s->polishing = polishing;
 
     // Link Functions
+    s->name            = &name_qdldl;
     s->solve           = &solve_linsys_qdldl;
     s->update_settings = &update_settings_linsys_solver_qdldl;
     s->warm_start      = &warm_start_linsys_solver_qdldl;
@@ -371,6 +372,10 @@ c_int init_linsys_solver_qdldl(qdldl_solver      **sp,
 }
 
 #endif  // EMBEDDED
+
+const char* name_qdldl() {
+  return "QDLDL";
+}
 
 
 // // Permute x = P*b using P

--- a/algebra/default/lin_sys/direct/qdldl_interface.h
+++ b/algebra/default/lin_sys/direct/qdldl_interface.h
@@ -18,6 +18,8 @@ struct qdldl {
      * @name Functions
      * @{
      */
+    const char* (*name)(void);
+
     c_int (*solve)(struct qdldl *self,
                    OSQPVectorf  *b,
                    c_int         admm_iter);
@@ -104,6 +106,12 @@ c_int init_linsys_solver_qdldl(qdldl_solver      **sp,
                                const OSQPVectorf  *rho_vec,
                                const OSQPSettings *settings,
                                c_int               polishing);
+
+/**
+ * Get the user-friendly name of the QDLDL solver.
+ * @return The user-friendly name
+ */
+const char* name_qdldl();
 
 /**
  * Solve linear system and store result in b

--- a/algebra/mkl/lin_sys/direct/pardiso_interface.c
+++ b/algebra/mkl/lin_sys/direct/pardiso_interface.c
@@ -98,6 +98,7 @@ c_int init_linsys_solver_pardiso(pardiso_solver    **sp,
   s->polishing = polishing;
 
   // Link Functions
+  s->name            = &name_pardiso;
   s->solve           = &solve_linsys_pardiso;
   s->free            = &free_linsys_solver_pardiso;
   s->warm_start      = &warm_start_linsys_solver_pardiso;
@@ -244,6 +245,10 @@ c_int init_linsys_solver_pardiso(pardiso_solver    **sp,
   }
 
   return 0;
+}
+
+const char* name_pardiso() {
+  return "Pardiso";
 }
 
 // Returns solution to linear system  Ax = b with solution stored in b

--- a/algebra/mkl/lin_sys/direct/pardiso_interface.h
+++ b/algebra/mkl/lin_sys/direct/pardiso_interface.h
@@ -19,6 +19,8 @@ struct pardiso {
      * @name Functions
      * @{
      */
+    const char* (*name)(void);
+
     c_int (*solve)(struct pardiso *self,
                    OSQPVectorf    *b,
                    c_int           admm_iter);
@@ -100,6 +102,13 @@ c_int init_linsys_solver_pardiso(pardiso_solver    **sp,
                                  const OSQPVectorf  *rho_vec,
                                  const OSQPSettings *settings,
                                  c_int               polishing);
+
+
+/**
+ * Get the user-friendly name of the MKL Pardiso solver.
+ * @return The user-friendly name
+ */
+const char* name_pardiso();
 
 
 /**

--- a/algebra/mkl/lin_sys/indirect/mkl-cg_interface.c
+++ b/algebra/mkl/lin_sys/indirect/mkl-cg_interface.c
@@ -77,6 +77,7 @@ c_int init_linsys_mklcg(mklcg_solver      **sp,
   }
 
   //Link functions
+  s->name            = &name_mklcg;
   s->solve           = &solve_linsys_mklcg;
   s->warm_start      = &warm_start_linys_mklcg;
   s->free            = &free_linsys_mklcg;
@@ -117,6 +118,11 @@ c_int init_linsys_mklcg(mklcg_solver      **sp,
 
   status = cg_solver_init(s);
   return status;
+}
+
+
+const char* name_mklcg() {
+  return "MKL RCI Conjugate Gradient";
 }
 
 

--- a/algebra/mkl/lin_sys/indirect/mkl-cg_interface.h
+++ b/algebra/mkl/lin_sys/indirect/mkl-cg_interface.h
@@ -15,6 +15,7 @@ typedef struct mklcg_solver_ {
    * @name Functions
    * @{
    */
+  const char* (*name)(void);
   c_int (*solve)(struct mklcg_solver_ *self, OSQPVectorf * b, c_int admm_iter);
   void (*update_settings)(struct mklcg_solver_ *self, const OSQPSettings *settings);
   void (*warm_start)(struct mklcg_solver_ *self, const OSQPVectorf *x);
@@ -84,6 +85,13 @@ c_int init_linsys_mklcg(mklcg_solver       **sp,
                         const OSQPVectorf   *rho_vec,
                         const OSQPSettings  *settings,
                         c_int                polish);
+
+
+/**
+ * Get the user-friendly name of the MKL CG solver.
+ * @return The user-friendly name
+ */
+const char* name_mklcg();
 
 
 /**

--- a/examples/osqp_demo.c
+++ b/examples/osqp_demo.c
@@ -22,8 +22,8 @@ int main(void) {
   c_int exitflag;
 
   /* Solver, settings, matrices */
-  OSQPSolver   *solver;
-  OSQPSettings *settings;
+  OSQPSolver   *solver   = NULL;
+  OSQPSettings *settings = NULL;
   csc *P = malloc(sizeof(csc));
   csc *A = malloc(sizeof(csc));
 
@@ -36,6 +36,9 @@ int main(void) {
   if (settings) {
     osqp_set_default_settings(settings);
     settings->polishing = 1;
+
+    //settings->linsys_solver = OSQP_DIRECT_SOLVER;
+    //settings->linsys_solver = OSQP_INDIRECT_SOLVER;
   }
 
   /* Setup solver */

--- a/include/private/types.h
+++ b/include/private/types.h
@@ -203,6 +203,9 @@ struct OSQPWorkspace_ {
  */
 struct linsys_solver {
   enum osqp_linsys_solver_type type;             ///< linear system solver type functions
+
+  const char* (*name)(void);
+
   c_int (*solve)(LinSysSolver *self,
                  OSQPVectorf  *b,
                  c_int         admm_iter);
@@ -212,6 +215,7 @@ struct linsys_solver {
 
   void (*warm_start)(LinSysSolver      *self,
                      const OSQPVectorf *x);
+
 
 # ifndef EMBEDDED
   void (*free)(LinSysSolver *self);         ///< free linear system solver (only in desktop version)

--- a/include/public/osqp_api_constants.h
+++ b/include/public/osqp_api_constants.h
@@ -29,7 +29,6 @@ enum osqp_linsys_solver_type {
     OSQP_DIRECT_SOLVER,
     OSQP_INDIRECT_SOLVER,
 };
-extern const char * OSQP_LINSYS_SOLVER_NAME[];
 
 
 /******************

--- a/src/lin_sys.c
+++ b/src/lin_sys.c
@@ -1,11 +1,6 @@
 #include "lin_sys.h"
 
 
-const char *OSQP_LINSYS_SOLVER_NAME[] = {
-  "unknown", "direct", "indirect"
-};
-
-
 #ifdef ALGEBRA_DEFAULT
 # include "qdldl_interface.h"
 #endif

--- a/src/util.c
+++ b/src/util.c
@@ -84,7 +84,7 @@ void print_setup_header(const OSQPSolver *solver) {
   // Print Settings
   c_print("settings: ");
   c_print("linear system solver = %s %s", OSQP_ALGEBRA,
-          OSQP_LINSYS_SOLVER_NAME[settings->linsys_solver]);
+          work->linsys_solver->name());
 
   if (work->linsys_solver->nthreads != 1) {
     c_print(" (%d threads)", (int)work->linsys_solver->nthreads);

--- a/src/util.c
+++ b/src/util.c
@@ -83,8 +83,10 @@ void print_setup_header(const OSQPSolver *solver) {
 
   // Print Settings
   c_print("settings: ");
-  c_print("linear system solver = %s %s", OSQP_ALGEBRA,
-          work->linsys_solver->name());
+  c_print("algebra = %s", OSQP_ALGEBRA);
+  c_print(",\n          ");
+
+  c_print("linear system solver = %s", work->linsys_solver->name());
 
   if (work->linsys_solver->nthreads != 1) {
     c_print(" (%d threads)", (int)work->linsys_solver->nthreads);


### PR DESCRIPTION
This allows more fine-grained printing of the solver's name instead of just direct/indirect, and removes the need for a global list of names. Being more precise is useful because it allows us to say specifically which indirect method is being used by MKL (since it has by CG and GMRES), and call out Pardiso by name since that is what people would be familiar with.

This was implemented by adding another callback to the linear system struct, where the function just returns a string containing the name.

The solver output now looks like this:
```
-----------------------------------------------------------------
           OSQP v0.0.0  -  Operator Splitting QP Solver
              (c) Bartolomeo Stellato,  Goran Banjac
        University of Oxford  -  Stanford University 2021
-----------------------------------------------------------------
problem:  variables n = 2, constraints m = 3
          nnz(P) + nnz(A) = 7
settings: algebra = cuda,
          linear system solver = CUDA Preconditioned Conjugate Gradient,
          eps_abs = 1.0e-03, eps_rel = 1.0e-03,
          eps_prim_inf = 1.0e-04, eps_dual_inf = 1.0e-04,
          rho = 1.00e-01 (adaptive),
          sigma = 1.00e-06, alpha = 1.60, max_iter = 4000
          check_termination: on (interval 5),
          time_limit: 1.00e+10 sec,
          scaling: on, scaled_termination: off
          warm starting: on, polishing: on, 
iter   objective    prim res   dual res   rho        time
   1  -2.4617e-01   1.76e+00   9.87e-01   1.00e-01   5.67e-01s
  30   1.8769e+00   1.02e-03   4.72e-04   4.15e-01   5.77e-01s
plsh   1.8800e+00   0.00e+00   0.00e+00   --------   5.79e-01s

status:               solved
solution polishing:   successful
number of iterations: 30
optimal objective:    1.8800
run time:             5.79e-01s
optimal rho estimate: 1.19e+00

```