### PR TITLE
some interface fixes for update_matrices (for mkl algebra)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,6 +106,7 @@ jobs:
 
         - name: Valgrid check
           run: |
+            sudo apt-get update
             sudo apt-get install valgrind
             valgrind --suppressions=.valgrind-suppress.supp --leak-check=full --gen-suppressions=all \
               --track-origins=yes --error-exitcode=1 build/out/osqp_tester

--- a/algebra/mkl/lin_sys/direct/pardiso_interface.c
+++ b/algebra/mkl/lin_sys/direct/pardiso_interface.c
@@ -293,13 +293,17 @@ c_int solve_linsys_pardiso(pardiso_solver *s,
 // Update solver structure with new P and A
 c_int update_linsys_solver_matrices_pardiso(pardiso_solver   *s,
                                             const OSQPMatrix *P,
-                                            const OSQPMatrix *A) {
+                                            const c_int* Px_new_idx,
+                                            c_int P_new_n,
+                                            const OSQPMatrix *A,
+                                            const c_int* Ax_new_idx,
+                                            c_int A_new_n) {
 
   // Update KKT matrix with new P
-  update_KKT_P(s->KKT, P->csc, s->PtoKKT, s->sigma, 1);
+  update_KKT_P(s->KKT, P->csc, Px_new_idx, P_new_n, s->PtoKKT, s->sigma, 1);
 
   // Update KKT matrix with new A
-  update_KKT_A(s->KKT, A->csc, s->AtoKKT);
+  update_KKT_A(s->KKT, A->csc, Ax_new_idx, A_new_n, s->AtoKKT);
 
   // Perform numerical factorization
   s->phase = PARDISO_NUMERIC;

--- a/algebra/mkl/lin_sys/direct/pardiso_interface.h
+++ b/algebra/mkl/lin_sys/direct/pardiso_interface.h
@@ -35,7 +35,11 @@ struct pardiso {
 
     c_int (*update_matrices)(struct pardiso   *self,
                              const OSQPMatrix *P,
-                             const OSQPMatrix *A);
+                             const c_int* Px_new_idx,
+                             c_int P_new_n,
+                             const OSQPMatrix *A,
+                             const c_int* Ax_new_idx,
+                             c_int A_new_n);
 
     c_int (*update_rho_vec)(struct pardiso    *self,
                             const OSQPVectorf *rho_vec,
@@ -140,7 +144,11 @@ void warm_start_linsys_solver_pardiso(pardiso_solver    *s,
 c_int update_linsys_solver_matrices_pardiso(
                     pardiso_solver * s,
                     const OSQPMatrix *P,
-                    const OSQPMatrix *A);
+                    const c_int *Px_new_idx,
+                    c_int P_new_n,
+                    const OSQPMatrix *A,
+                    const c_int *Ax_new_idx,
+                    c_int A_new_n);
 
 
 /**

--- a/src/osqp_api.c
+++ b/src/osqp_api.c
@@ -969,7 +969,7 @@ c_int osqp_update_data_mat(OSQPSolver    *solver,
     return 1;
   }
   //indexing is required if the whole P is not updated
-  if(Px_new_idx == NULL && P_new_n != 0 && P_new_n != nnzP){
+  if(Px_new_idx == OSQP_NULL && P_new_n != 0 && P_new_n != nnzP){
     # ifdef PRINTING
         c_eprint("index vector is required for partial updates of P");
     # endif /* ifdef PRINTING */
@@ -986,7 +986,7 @@ c_int osqp_update_data_mat(OSQPSolver    *solver,
     return 2;
   }
   //indexing is required if the whole A is not updated
-  if(Ax_new_idx == NULL && A_new_n != 0 && A_new_n != nnzA){
+  if(Ax_new_idx == OSQP_NULL && A_new_n != 0 && A_new_n != nnzA){
     # ifdef PRINTING
         c_eprint("index vector is required for partial updates of A");
     # endif /* ifdef PRINTING */
@@ -1009,8 +1009,8 @@ c_int osqp_update_data_mat(OSQPSolver    *solver,
   if(solver->settings->scaling){
     exitflag = work->linsys_solver->update_matrices(
                   work->linsys_solver,
-                  work->data->P, NULL, nnzP,
-                  work->data->A, NULL, nnzA);
+                  work->data->P, OSQP_NULL, nnzP,
+                  work->data->A, OSQP_NULL, nnzA);
   }
   else{
     exitflag = work->linsys_solver->update_matrices(


### PR DESCRIPTION
Since the signature of `update_linsys_solver_matrices` has changed, compilation with `-DALGEBRA=mkl` was failing. I looked at the recent changes in the `qdldl` case and am mirroring the changes here for the mkl interface. @goulart-paul - perhaps you can take a look and see if I missed something?

Also, for `-DEMBEDDED=2`, compilation was failing due to `NULL` being undefined. I've replaced those instances with `OSQP_NULL`. @imciner2 - is `0` is a better replacement here?