### PR TITLE
Refactor CI jobs and test more combinations

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -101,7 +101,7 @@ jobs:
             flag-name: run-${{ matrix.algebra }}-${{ matrix.float }}-${{ matrix.long }}
             parallel: true
 
-  finish:
+  finalize_coverage:
     needs: generate_coverage
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,0 +1,104 @@
+name: Coverage Generation
+
+on: [ "push", "pull_request" ]
+
+jobs:
+
+  generate_coverage:
+      runs-on: ubuntu-latest
+
+      strategy:
+        fail-fast: false
+
+        matrix:
+          python-version: [3.9]
+          algebra: ['default', 'mkl']
+          float: ['OFF', 'ON']
+          long: ['OFF', 'ON']
+
+      defaults:
+        run:
+          # Required when using an activated conda environment in steps
+          # See https://github.com/conda-incubator/setup-miniconda#IMPORTANT
+          shell: bash -l {0}
+
+      env:
+        OSQP_BUILD_DIR_PREFIX: ${{ github.workspace }}/build
+
+      steps:
+        - uses: actions/checkout@v2
+          with:
+            lfs: false
+            submodules: recursive
+
+        - name: Set up conda
+          uses: conda-incubator/setup-miniconda@v2
+          with:
+            auto-update-conda: true
+            python-version: ${{ matrix.python-version }}
+
+        # -----------------
+        # OS-specific setup
+        # -----------------
+        - name: Setup (Linux)
+          if: runner.os == 'Linux'
+          run: |
+            echo "LD_LIBRARY_PATH=$CONDA_PREFIX/lib" >> $GITHUB_ENV
+
+
+        - name: Install unit testing python dependencies
+          run: |
+            conda install numpy scipy
+            conda info
+            conda list
+
+        - name: Install MKL
+          run: |
+            conda install -c intel "mkl-devel<2022"
+            conda info
+            conda list
+
+        - name: Build
+          run: |
+            cmake -G "Unix Makefiles" \
+                  -S . -B $OSQP_BUILD_DIR_PREFIX \
+                  -DALGEBRA='mkl' \
+                  -DEMBEDDED=0 \
+                  -DPROFILING=ON \
+                  -DCTRLC=ON \
+                  -DPRINTING=ON \
+                  -DOSQP_BUILD_UNITTESTS=ON \
+                  -DOSQP_COVERAGE_CHECK=ON'
+                  -DLONG=${{ matrix.long }} \
+                  -DFLOAT=${{ matrix.float }} \
+            cmake --build $OSQP_BUILD_DIR_PREFIX
+
+
+        - name: Test
+          run: |
+            $OSQP_BUILD_DIR_PREFIX/out/osqp_tester
+
+        - name: Generate coverage
+          uses: imciner2/run-lcov@v1
+          with:
+            input_directory: '${{ env.OSQP_BUILD_DIR_PREFIX }}'
+            exclude: '"$GITHUB_WORKSPACE/tests/*" "$GITHUB_WORKSPACE/algebra/default/lin_sys/direct/amd/*" "$GITHUB_WORKSPACE/examples/*" "$GITHUB_WORKSPACE/build/*" "/usr/include/*"'
+            output_file: '${{ env.OSQP_BUILD_DIR_PREFIX }}/coverage.info'
+
+        - name: Coveralls upload
+          uses: coverallsapp/github-action@master
+          with:
+            path-to-lcov: '${{ env.OSQP_BUILD_DIR_PREFIX }}/coverage.info'
+            github-token: ${{ secrets.GITHUB_TOKEN }}
+            flag-name: run-${{ matrix.algebra }}-${{ matrix.float }}-${{ matrix.long }}
+            parallel: true
+
+  finish:
+    needs: generate_coverage
+    runs-on: ubuntu-latest
+    steps:
+    - name: Coveralls Finished
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.github_token }}
+        parallel-finished: true

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -71,14 +71,14 @@ jobs:
           run: |
             cmake -G "Unix Makefiles" \
                   -S . -B $OSQP_BUILD_DIR_PREFIX \
-                  -DALGEBRA='mkl' \
                   -DPROFILING=ON \
                   -DCTRLC=ON \
                   -DPRINTING=ON \
                   -DOSQP_BUILD_UNITTESTS=ON \
                   -DOSQP_COVERAGE_CHECK=ON \
                   -DLONG=${{ matrix.long }} \
-                  -DFLOAT=${{ matrix.float }}
+                  -DFLOAT=${{ matrix.float }} \
+                  -DALGEBRA=${{ matrix.algebra }}
             cmake --build $OSQP_BUILD_DIR_PREFIX
 
 

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -66,7 +66,6 @@ jobs:
             cmake -G "Unix Makefiles" \
                   -S . -B $OSQP_BUILD_DIR_PREFIX \
                   -DALGEBRA='mkl' \
-                  -DEMBEDDED=0 \
                   -DPROFILING=ON \
                   -DCTRLC=ON \
                   -DPRINTING=ON \

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -70,7 +70,7 @@ jobs:
                   -DCTRLC=ON \
                   -DPRINTING=ON \
                   -DOSQP_BUILD_UNITTESTS=ON \
-                  -DOSQP_COVERAGE_CHECK=ON'
+                  -DOSQP_COVERAGE_CHECK=ON \
                   -DLONG=${{ matrix.long }} \
                   -DFLOAT=${{ matrix.float }}
             cmake --build $OSQP_BUILD_DIR_PREFIX

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -15,6 +15,9 @@ jobs:
           algebra: ['default', 'mkl']
           float: ['OFF', 'ON']
           long: ['OFF', 'ON']
+          exclude:
+            - algebra: 'mkl'
+              float: 'ON'
 
       defaults:
         run:
@@ -70,7 +73,7 @@ jobs:
                   -DOSQP_BUILD_UNITTESTS=ON \
                   -DOSQP_COVERAGE_CHECK=ON'
                   -DLONG=${{ matrix.long }} \
-                  -DFLOAT=${{ matrix.float }} \
+                  -DFLOAT=${{ matrix.float }}
             cmake --build $OSQP_BUILD_DIR_PREFIX
 
 

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,6 +1,12 @@
 name: Coverage Generation
 
-on: [ "push", "pull_request" ]
+on:
+  push:
+    branches: [ master, develop**, ci ]
+    tags:
+      - '*'
+  pull_request:
+    branches: [ master, develop** ]
 
 jobs:
 

--- a/.github/workflows/embedded.yaml
+++ b/.github/workflows/embedded.yaml
@@ -1,0 +1,73 @@
+name: Embedded Combinations
+
+on:
+  push:
+    branches: [ master, develop**, ci ]
+    tags:
+      - '*'
+  pull_request:
+    branches: [ master, develop** ]
+
+jobs:
+
+  build_and_test:
+      runs-on: ubuntu-latest
+
+      strategy:
+        fail-fast: false
+
+        matrix:
+          # Embedded is only a smoke test to ensure it compiles with all the options
+          long: ['ON', 'OFF']
+          float: ['ON', 'OFF']
+          embedded: ['1', '2']
+          printing: ['ON', 'OFF']
+          profiling: ['ON', 'OFF']
+          interrupt: ['ON', 'OFF']
+          exclude:
+            # These combinations are currently not supported
+            - embedded: '1'
+              profiling: 'ON'
+            - embedded: '1'
+              interrupt: 'ON'
+            - embedded: '1'
+              printing: 'ON'
+            - embedded: '2'
+              profiling: 'ON'
+            - embedded: '2'
+              interrupt: 'ON'
+            - embedded: '2'
+              printing: 'ON'
+
+          include:
+            - os: ubuntu-latest
+              cmake_generator: "Unix Makefiles"
+
+      defaults:
+        run:
+          # Required when using an activated conda environment in steps
+          # See https://github.com/conda-incubator/setup-miniconda#IMPORTANT
+          shell: bash -l {0}
+
+      env:
+        OSQP_BUILD_DIR_PREFIX: ${{ github.workspace }}/build
+
+      steps:
+        - uses: actions/checkout@v2
+          with:
+            lfs: false
+            submodules: recursive
+
+        - name: Build
+          run: |
+            cmake -G "${{ matrix.cmake_generator }}" \
+                  -S . -B $OSQP_BUILD_DIR_PREFIX \
+                  -DALGEBRA='default' \
+                  -DOSQP_BUILD_UNITTESTS=OFF \
+                  -DLONG=${{ matrix.long }} \
+                  -DFLOAT=${{ matrix.float }} \
+                  -DEMBEDDED=${{ matrix.embedded }} \
+                  -DPROFILING=${{ matrix.profiling }} \
+                  -DCTRLC=${{ matrix.interrupt }} \
+                  -DPRINTING=${{ matrix.printing }}
+            cmake --build $OSQP_BUILD_DIR_PREFIX

--- a/.github/workflows/embedded.yaml
+++ b/.github/workflows/embedded.yaml
@@ -17,27 +17,9 @@ jobs:
         fail-fast: false
 
         matrix:
-          # Embedded is only a smoke test to ensure it compiles with all the options
-          long: ['ON', 'OFF']
+          # Embedded is only a smoke test to ensure it compiles with the options
           float: ['ON', 'OFF']
           embedded: ['1', '2']
-          printing: ['ON', 'OFF']
-          profiling: ['ON', 'OFF']
-          interrupt: ['ON', 'OFF']
-          exclude:
-            # These combinations are currently not supported
-            - embedded: '1'
-              profiling: 'ON'
-            - embedded: '1'
-              interrupt: 'ON'
-            - embedded: '1'
-              printing: 'ON'
-            - embedded: '2'
-              profiling: 'ON'
-            - embedded: '2'
-              interrupt: 'ON'
-            - embedded: '2'
-              printing: 'ON'
 
           include:
             - os: ubuntu-latest
@@ -62,12 +44,12 @@ jobs:
           run: |
             cmake -G "${{ matrix.cmake_generator }}" \
                   -S . -B $OSQP_BUILD_DIR_PREFIX \
-                  -DALGEBRA='default' \
-                  -DOSQP_BUILD_UNITTESTS=OFF \
-                  -DLONG=${{ matrix.long }} \
                   -DFLOAT=${{ matrix.float }} \
                   -DEMBEDDED=${{ matrix.embedded }} \
-                  -DPROFILING=${{ matrix.profiling }} \
-                  -DCTRLC=${{ matrix.interrupt }} \
-                  -DPRINTING=${{ matrix.printing }}
+                  -DALGEBRA='default' \
+                  -DLONG=OFF \
+                  -DPROFILING=OFF \
+                  -DCTRLC=OFF \
+                  -DPRINTING=OFF \
+                  -DOSQP_BUILD_UNITTESTS=OFF
             cmake --build $OSQP_BUILD_DIR_PREFIX

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,7 +89,8 @@ jobs:
             echo "$CONDA_PREFIX/Library/bin" >> $GITHUB_PATH
         # -----------------
 
-        - name: Install python dependencies
+        - name: Install unit testing python dependencies
+          if: ${{ matrix.cmake_flags == '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=ON' }}
           run: |
             conda install numpy scipy
             conda info

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,7 +92,6 @@ jobs:
           run: |
             cmake -G "${{ matrix.cmake_generator }}" \
                   -S . -B $OSQP_BUILD_DIR_PREFIX \
-                  -DEMBEDDED=0 \
                   -DALGEBRA=default \
                   -DOSQP_BUILD_UNITTESTS=ON \
                   -DOSQP_COVERAGE_CHECK=OFF \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Main
+name: Default Algebra
 
 on:
   push:
@@ -23,11 +23,9 @@ jobs:
           python-version: [3.9]
           long: ['ON', 'OFF']
           float: ['ON', 'OFF']
-          algebra: ['default', 'mkl']
           printing: ['ON', 'OFF']
           profiling: ['ON', 'OFF']
           interrupt: ['ON', 'OFF']
-          unit_tests: ['-DOSQP_BUILD_UNITTESTS=OFF', '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=OFF']
 
           include:
             - os: ubuntu-latest
@@ -90,25 +88,19 @@ jobs:
             conda info
             conda list
 
-        - name: Install MKL
-          if: ${{ matrix.algebra == 'mkl' }}
-          run: |
-            conda install -c intel "mkl-devel<2022"
-            conda info
-            conda list
-
         - name: Build
           run: |
             cmake -G "${{ matrix.cmake_generator }}" \
                   -S . -B $OSQP_BUILD_DIR_PREFIX \
                   -DEMBEDDED=0 \
+                  -DALGEBRA=default \
+                  -DOSQP_BUILD_UNITTESTS=ON \
+                  -DOSQP_COVERAGE_CHECK=OFF \
                   -DLONG=${{ matrix.long }} \
                   -DFLOAT=${{ matrix.float }} \
-                  -DALGEBRA=${{ matrix.algebra }} \
                   -DPROFILING=${{ matrix.profiling }} \
                   -DCTRLC=${{ matrix.interrupt }} \
-                  -DPRINTING=${{ matrix.printing }} \
-                  ${{ matrix.unit_tests }}
+                  -DPRINTING=${{ matrix.printing }}
             cmake --build $OSQP_BUILD_DIR_PREFIX
 
         # useful for inspecting the OSQP version information
@@ -119,7 +111,6 @@ jobs:
         - name: Test
           run: |
             $OSQP_BUILD_DIR_PREFIX/out/osqp_tester
-          if: ${{ matrix.unit_tests == '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=OFF' }}
 
         - name: Codegen compilation test
           run: |
@@ -131,7 +122,7 @@ jobs:
             cmake --build tests/codegen/settings/build
             ./tests/codegen/settings/build/osqp_codegen_embedded_mode1_settings
             ./tests/codegen/settings/build/osqp_codegen_embedded_mode2_settings
-          if: ${{ runner.os == 'Linux' && matrix.unit_tests == '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=OFF' }}
+          if: ${{ runner.os == 'Linux' }}
 
         - name: Valgrid check
           run: |
@@ -139,4 +130,4 @@ jobs:
             sudo apt-get install valgrind
             valgrind --suppressions=.valgrind-suppress.supp --leak-check=full --gen-suppressions=all \
               --track-origins=yes --error-exitcode=1 $OSQP_BUILD_DIR_PREFIX/out/osqp_tester
-          if: ${{ runner.os == 'Linux' && matrix.unit_tests == '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=ON' }}
+          if: ${{ runner.os == 'Linux' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,7 +82,6 @@ jobs:
         # -----------------
 
         - name: Install unit testing python dependencies
-          if: ${{ matrix.cmake_flags == '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=OFF' }}
           run: |
             conda install numpy scipy
             conda info

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,35 +24,10 @@ jobs:
           long: ['ON', 'OFF']
           float: ['ON', 'OFF']
           algebra: ['default', 'mkl']
-          embedded: ['0', '1', '2']
           printing: ['ON', 'OFF']
           profiling: ['ON', 'OFF']
           interrupt: ['ON', 'OFF']
           unit_tests: ['-DOSQP_BUILD_UNITTESTS=OFF', '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=ON']
-          exclude:
-            # Don't run the unit tests in the embedded modes
-            - unit_tests: '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=ON'
-              embedded: '1'
-            - unit_tests: '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=ON'
-              embedded: '2'
-            # MKL doesn't support embedded mode
-            - algebra: 'mkl'
-              embedded: '1'
-            - algebra: 'mkl'
-              embedded: '2'
-            # These combinations are currently not supported
-            - embedded: '1'
-              profiling: 'ON'
-            - embedded: '1'
-              interrupt: 'ON'
-            - embedded: '1'
-              printing: 'ON'
-            - embedded: '2'
-              profiling: 'ON'
-            - embedded: '2'
-              interrupt: 'ON'
-            - embedded: '2'
-              printing: 'ON'
 
           include:
             - os: ubuntu-latest
@@ -126,10 +101,10 @@ jobs:
           run: |
             cmake -G "${{ matrix.cmake_generator }}" \
                   -S . -B $OSQP_BUILD_DIR_PREFIX \
+                  -DEMBEDDED=0 \
                   -DLONG=${{ matrix.long }} \
                   -DFLOAT=${{ matrix.float }} \
                   -DALGEBRA=${{ matrix.algebra }} \
-                  -DEMBEDDED=${{ matrix.embedded }} \
                   -DPROFILING=${{ matrix.profiling }} \
                   -DCTRLC=${{ matrix.interrupt }} \
                   -DPRINTING=${{ matrix.printing }} \
@@ -140,7 +115,6 @@ jobs:
         - name: OSQP Demo
           run: |
             $OSQP_BUILD_DIR_PREFIX/out/osqp_demo
-          if: ${{ matrix.embedded == 0 }}
 
         - name: Test
           run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,8 @@ jobs:
           python-version: [3.9]
           cmake_flags: ['-DBUILD_TESTING=OFF', '-DBUILD_TESTING=ON -DCOVERAGE=ON']
           cmake_flags_extra: ['', '-DDFLOAT=ON', '-DDLONG=OFF', '-DEMBEDDED=1', '-DEMBEDDED=2', '-DPROFILING=OFF',
-                              '-DCTRLC=OFF', '-DPRINTING=OFF', '-DALGEBRA=default', '-DALGEBRA=mkl']
+                              '-DCTRLC=OFF', '-DPRINTING=OFF']
+          algebra: ['default', 'mkl']
           exclude:
             - cmake_flags: '-DBUILD_TESTING=ON -DCOVERAGE=ON'
               cmake_flags_extra: '-DEMBEDDED=1'
@@ -83,14 +84,20 @@ jobs:
 
         - name: Install python dependencies
           run: |
-            conda install -c intel "mkl-devel<2022"
             conda install numpy scipy
+            conda info
+            conda list
+
+        - name: Install MKL
+          if: ${{ matrix.algebra == 'mkl' }}
+          run: |
+            conda install -c intel "mkl-devel<2022"
             conda info
             conda list
 
         - name: Build
           run: |
-            cmake -G "${{ matrix.cmake_generator }}" -S . -B build ${{ matrix.cmake_flags }} ${{ matrix.cmake_flags_extra }}
+            cmake -G "${{ matrix.cmake_generator }}" -S . -B build ${{ matrix.cmake_flags }} ${{ matrix.cmake_flags_extra }} -DALGEBRA=${{ matrix.algebra }}
             cmake --build build
 
         # useful for inspecting the OSQP version information
@@ -110,7 +117,7 @@ jobs:
             sudo apt-get install valgrind
             valgrind --suppressions=.valgrind-suppress.supp --leak-check=full --gen-suppressions=all \
               --track-origins=yes --error-exitcode=1 build/out/osqp_tester
-          if: ${{ runner.os == 'Linux' && matrix.cmake_flags == '-DBUILD_TESTING=ON -DCOVERAGE=ON' && matrix.cmake_flags_extra == '-DALGEBRA=default' }}
+          if: ${{ runner.os == 'Linux' && matrix.cmake_flags == '-DBUILD_TESTING=ON -DCOVERAGE=ON' && matrix.algebra == 'default' }}
 
         - name: Generate coverage
           uses: imciner2/run-lcov@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,19 +21,38 @@ jobs:
           # updates (since Visual Studio is also updated at the same time).
           os: [ubuntu-latest, macos-latest, windows-2022]
           python-version: [3.9]
-          cmake_flags: ['-DOSQP_BUILD_UNITTESTS=OFF', '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=ON']
-          cmake_flags_extra: ['', '-DDFLOAT=ON', '-DDLONG=OFF', '-DEMBEDDED=1', '-DEMBEDDED=2', '-DPROFILING=OFF',
-                              '-DCTRLC=OFF', '-DPRINTING=OFF']
+          long: ['ON', 'OFF']
+          float: ['ON', 'OFF']
           algebra: ['default', 'mkl']
+          embedded: ['0', '1', '2']
+          printing: ['ON', 'OFF']
+          profiling: ['ON', 'OFF']
+          interrupt: ['ON', 'OFF']
+          unit_tests: ['-DOSQP_BUILD_UNITTESTS=OFF', '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=ON']
           exclude:
-            - cmake_flags: '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=ON'
-              cmake_flags_extra: '-DEMBEDDED=1'
-            - cmake_flags: '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=ON'
-              cmake_flags_extra: '-DEMBEDDED=2'
+            # Don't run the unit tests in the embedded modes
+            - unit_tests: '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=ON'
+              embedded: '1'
+            - unit_tests: '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=ON'
+              embedded: '2'
+            # MKL doesn't support embedded mode
             - algebra: 'mkl'
-              cmake_flags_extra: '-DEMBEDDED=1'
+              embedded: '1'
             - algebra: 'mkl'
-              cmake_flags_extra: '-DEMBEDDED=2'
+              embedded: '2'
+            # These combinations are currently not supported
+            - embedded: '1'
+              profiling: 'ON'
+            - embedded: '1'
+              interrupt: 'ON'
+            - embedded: '1'
+              printing: 'ON'
+            - embedded: '2'
+              profiling: 'ON'
+            - embedded: '2'
+              interrupt: 'ON'
+            - embedded: '2'
+              printing: 'ON'
 
           include:
             - os: ubuntu-latest
@@ -105,27 +124,40 @@ jobs:
 
         - name: Build
           run: |
-            cmake -G "${{ matrix.cmake_generator }}" -S . -B $OSQP_BUILD_DIR_PREFIX ${{ matrix.cmake_flags }} ${{ matrix.cmake_flags_extra }} -DALGEBRA=${{ matrix.algebra }}
+            cmake -G "${{ matrix.cmake_generator }}" \
+                  -S . -B $OSQP_BUILD_DIR_PREFIX \
+                  -DLONG=${{ matrix.long }} \
+                  -DFLOAT=${{ matrix.float }} \
+                  -DALGEBRA=${{ matrix.algebra }} \
+                  -DEMBEDDED=${{ matrix.embedded }} \
+                  -DPROFILING=${{ matrix.profiling }} \
+                  -DCTRLC=${{ matrix.interrupt }} \
+                  -DPRINTING=${{ matrix.printing }} \
+                  ${{ matrix.unit_tests }}
             cmake --build $OSQP_BUILD_DIR_PREFIX
 
         # useful for inspecting the OSQP version information
         - name: OSQP Demo
           run: |
             $OSQP_BUILD_DIR_PREFIX/out/osqp_demo
-          if: ${{ !contains(matrix.cmake_flags_extra, 'EMBEDDED') }}
+          if: ${{ matrix.embedded == 0 }}
 
         - name: Test
           run: |
             $OSQP_BUILD_DIR_PREFIX/out/osqp_tester
-          if: ${{ matrix.cmake_flags == '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=ON' }}
+          if: ${{ matrix.unit_tests == '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=ON' }}
 
         - name: Codegen compilation test
           run: |
-            cmake -G "${{ matrix.cmake_generator }}" -S tests/codegen/settings -B tests/codegen/settings/build -DOSQP_BUILD_DIR=$OSQP_BUILD_DIR_PREFIX -DOSQP_TEST_CODEGEN_DIR=$OSQP_BUILD_DIR_PREFIX/tests/testcodes
+            cmake -G "${{ matrix.cmake_generator }}" \
+                  -S tests/codegen/settings \
+                  -B tests/codegen/settings/build \
+                  -DOSQP_BUILD_DIR=$OSQP_BUILD_DIR_PREFIX \
+                  -DOSQP_TEST_CODEGEN_DIR=$OSQP_BUILD_DIR_PREFIX/tests/testcodes
             cmake --build tests/codegen/settings/build
             ./tests/codegen/settings/build/osqp_codegen_embedded_mode1_settings
             ./tests/codegen/settings/build/osqp_codegen_embedded_mode2_settings
-          if: ${{ runner.os == 'Linux' && matrix.cmake_flags == '-DBUILD_TESTING=ON -DCOVERAGE=ON' && matrix.cmake_flags_extra == '-DALGEBRA=default' }}
+          if: ${{ runner.os == 'Linux' && matrix.unit_tests == '-DBUILD_TESTING=ON -DCOVERAGE=ON' && matrix.algebra == 'default' }}
 
         - name: Valgrid check
           run: |
@@ -133,7 +165,7 @@ jobs:
             sudo apt-get install valgrind
             valgrind --suppressions=.valgrind-suppress.supp --leak-check=full --gen-suppressions=all \
               --track-origins=yes --error-exitcode=1 $OSQP_BUILD_DIR_PREFIX/out/osqp_tester
-          if: ${{ runner.os == 'Linux' && matrix.cmake_flags == '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=ON' && matrix.algebra == 'default' }}
+          if: ${{ runner.os == 'Linux' && matrix.unit_tests == '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=ON' && matrix.algebra == 'default' }}
 
         - name: Generate coverage
           uses: imciner2/run-lcov@v1
@@ -141,11 +173,11 @@ jobs:
             input_directory: '${{ env.OSQP_BUILD_DIR_PREFIX }}'
             exclude: '"$GITHUB_WORKSPACE/tests/*" "$GITHUB_WORKSPACE/algebra/default/lin_sys/direct/amd/*" "$GITHUB_WORKSPACE/examples/*" "$GITHUB_WORKSPACE/build/*" "/usr/include/*"'
             output_file: '${{ env.OSQP_BUILD_DIR_PREFIX }}/coverage.info'
-          if: ${{ runner.os == 'Linux' && matrix.cmake_flags == '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=ON' && matrix.cmake_flags_extra == '' }}
+          if: ${{ runner.os == 'Linux' && matrix.unit_tests == '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=ON' && matrix.printing == 'ON' && matrix.interrupt == 'ON' && matrix.profiling == 'ON' }}
 
         - name: Coveralls
           uses: coverallsapp/github-action@master
           with:
             path-to-lcov: '${{ env.OSQP_BUILD_DIR_PREFIX }}/coverage.info'
             github-token: ${{ secrets.GITHUB_TOKEN }}
-          if: ${{ runner.os == 'Linux' && matrix.cmake_flags == '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=ON' && matrix.cmake_flags_extra == '' }}
+          if: ${{ runner.os == 'Linux' && matrix.unit_tests == '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=ON' && matrix.printing == 'ON' && matrix.interrupt == 'ON' && matrix.profiling == 'ON' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,10 @@ jobs:
               cmake_flags_extra: '-DEMBEDDED=1'
             - cmake_flags: '-DBUILD_TESTING=ON -DCOVERAGE=ON'
               cmake_flags_extra: '-DEMBEDDED=2'
+            - algebra: 'mkl'
+              cmake_flags_extra: '-DEMBEDDED=1'
+            - algebra: 'mkl'
+              cmake_flags_extra: '-DEMBEDDED=2'
 
           include:
             - os: ubuntu-latest

--- a/.github/workflows/mkl.yaml
+++ b/.github/workflows/mkl.yaml
@@ -98,7 +98,6 @@ jobs:
                   -S . -B $OSQP_BUILD_DIR_PREFIX \
                   -DALGEBRA='mkl' \
                   -DFLOAT=OFF \
-                  -DEMBEDDED=0 \
                   -DPROFILING=ON \
                   -DCTRLC=ON \
                   -DPRINTING=ON \

--- a/.github/workflows/mkl.yaml
+++ b/.github/workflows/mkl.yaml
@@ -1,4 +1,4 @@
-name: Main
+name: MKL Algebra
 
 on:
   push:
@@ -23,11 +23,10 @@ jobs:
           python-version: [3.9]
           long: ['ON', 'OFF']
           float: ['ON', 'OFF']
-          algebra: ['default', 'mkl']
           printing: ['ON', 'OFF']
           profiling: ['ON', 'OFF']
           interrupt: ['ON', 'OFF']
-          unit_tests: ['-DOSQP_BUILD_UNITTESTS=OFF', '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=OFF']
+          unit_tests: ['-DOSQP_BUILD_UNITTESTS=OFF', '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=ON']
 
           include:
             - os: ubuntu-latest
@@ -84,14 +83,13 @@ jobs:
         # -----------------
 
         - name: Install unit testing python dependencies
-          if: ${{ matrix.cmake_flags == '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=OFF' }}
+          if: ${{ matrix.cmake_flags == '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=ON' }}
           run: |
             conda install numpy scipy
             conda info
             conda list
 
         - name: Install MKL
-          if: ${{ matrix.algebra == 'mkl' }}
           run: |
             conda install -c intel "mkl-devel<2022"
             conda info
@@ -101,10 +99,10 @@ jobs:
           run: |
             cmake -G "${{ matrix.cmake_generator }}" \
                   -S . -B $OSQP_BUILD_DIR_PREFIX \
+                  -DALGEBRA='mkl' \
                   -DEMBEDDED=0 \
                   -DLONG=${{ matrix.long }} \
                   -DFLOAT=${{ matrix.float }} \
-                  -DALGEBRA=${{ matrix.algebra }} \
                   -DPROFILING=${{ matrix.profiling }} \
                   -DCTRLC=${{ matrix.interrupt }} \
                   -DPRINTING=${{ matrix.printing }} \
@@ -119,24 +117,4 @@ jobs:
         - name: Test
           run: |
             $OSQP_BUILD_DIR_PREFIX/out/osqp_tester
-          if: ${{ matrix.unit_tests == '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=OFF' }}
-
-        - name: Codegen compilation test
-          run: |
-            cmake -G "${{ matrix.cmake_generator }}" \
-                  -S tests/codegen/settings \
-                  -B tests/codegen/settings/build \
-                  -DOSQP_BUILD_DIR=$OSQP_BUILD_DIR_PREFIX \
-                  -DOSQP_TEST_CODEGEN_DIR=$OSQP_BUILD_DIR_PREFIX/tests/testcodes
-            cmake --build tests/codegen/settings/build
-            ./tests/codegen/settings/build/osqp_codegen_embedded_mode1_settings
-            ./tests/codegen/settings/build/osqp_codegen_embedded_mode2_settings
-          if: ${{ runner.os == 'Linux' && matrix.unit_tests == '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=OFF' }}
-
-        - name: Valgrid check
-          run: |
-            sudo apt-get update
-            sudo apt-get install valgrind
-            valgrind --suppressions=.valgrind-suppress.supp --leak-check=full --gen-suppressions=all \
-              --track-origins=yes --error-exitcode=1 $OSQP_BUILD_DIR_PREFIX/out/osqp_tester
-          if: ${{ runner.os == 'Linux' && matrix.unit_tests == '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=ON' }}
+          if: ${{ matrix.unit_tests == '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=ON' }}

--- a/.github/workflows/mkl.yaml
+++ b/.github/workflows/mkl.yaml
@@ -22,11 +22,8 @@ jobs:
           os: [ubuntu-latest, macos-latest, windows-2022]
           python-version: [3.9]
           long: ['ON', 'OFF']
-          float: ['ON', 'OFF']
-          printing: ['ON', 'OFF']
-          profiling: ['ON', 'OFF']
-          interrupt: ['ON', 'OFF']
-          unit_tests: ['-DOSQP_BUILD_UNITTESTS=OFF', '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=ON']
+
+          # MKL only supports double precision in the iterative solver, so that is the only combination we support as well.
 
           include:
             - os: ubuntu-latest
@@ -100,13 +97,14 @@ jobs:
             cmake -G "${{ matrix.cmake_generator }}" \
                   -S . -B $OSQP_BUILD_DIR_PREFIX \
                   -DALGEBRA='mkl' \
+                  -DFLOAT=OFF \
                   -DEMBEDDED=0 \
-                  -DLONG=${{ matrix.long }} \
-                  -DFLOAT=${{ matrix.float }} \
-                  -DPROFILING=${{ matrix.profiling }} \
-                  -DCTRLC=${{ matrix.interrupt }} \
-                  -DPRINTING=${{ matrix.printing }} \
-                  ${{ matrix.unit_tests }}
+                  -DPROFILING=ON \
+                  -DCTRLC=ON \
+                  -DPRINTING=ON \
+                  -DOSQP_BUILD_UNITTESTS=ON \
+                  -DOSQP_COVERAGE_CHECK=OFF \
+                  -DLONG=${{ matrix.long }}
             cmake --build $OSQP_BUILD_DIR_PREFIX
 
         # useful for inspecting the OSQP version information

--- a/.github/workflows/mkl.yaml
+++ b/.github/workflows/mkl.yaml
@@ -80,7 +80,6 @@ jobs:
         # -----------------
 
         - name: Install unit testing python dependencies
-          if: ${{ matrix.cmake_flags == '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=ON' }}
           run: |
             conda install numpy scipy
             conda info

--- a/.github/workflows/mkl.yaml
+++ b/.github/workflows/mkl.yaml
@@ -24,6 +24,7 @@ jobs:
           long: ['ON', 'OFF']
 
           # MKL only supports double precision in the iterative solver, so that is the only combination we support as well.
+          float: ['OFF']
 
           include:
             - os: ubuntu-latest
@@ -96,7 +97,7 @@ jobs:
             cmake -G "${{ matrix.cmake_generator }}" \
                   -S . -B $OSQP_BUILD_DIR_PREFIX \
                   -DALGEBRA='mkl' \
-                  -DFLOAT=OFF \
+                  -DFLOAT=${{ matrix.float }} \
                   -DPROFILING=ON \
                   -DCTRLC=ON \
                   -DPRINTING=ON \


### PR DESCRIPTION
Instead of always installing MKL on the CI job, only install it in the ones that use the MKL algebra. This allows for the non-MKL jobs to continue even if there are issues installing it from conda.