### PR TITLE
CMake improvements

### DIFF
--- a/.github/workflows/cmake-install.yaml
+++ b/.github/workflows/cmake-install.yaml
@@ -31,7 +31,7 @@ jobs:
 
         - name: Build
           run: |
-            cmake -G "Unix Makefiles" -S . -B build -DCMAKE_INSTALL_PREFIX=$OSQP_INSTALL_PREFIX -DOSQP_VERSION=0.99 -DBUILD_TESTING=OFF
+            cmake -G "Unix Makefiles" -S . -B build -DCMAKE_INSTALL_PREFIX=$OSQP_INSTALL_PREFIX -DOSQP_VERSION=0.99 -DOSQP_BUILD_UNITTESTS=OFF
             cmake --build build
             cmake --install build
 
@@ -74,7 +74,7 @@ jobs:
 
         - name: Build
           run: |
-            cmake -G "Unix Makefiles" -S . -B build -DCMAKE_INSTALL_PREFIX=$OSQP_INSTALL_PREFIX -DOSQP_VERSION=0.99 -DBUILD_TESTING=OFF -DOSQP_BUILD_SHARED_LIB=OFF -DOSQP_BUILD_STATIC_LIB=ON
+            cmake -G "Unix Makefiles" -S . -B build -DCMAKE_INSTALL_PREFIX=$OSQP_INSTALL_PREFIX -DOSQP_VERSION=0.99 -DOSQP_BUILD_UNITTESTS=OFF -DOSQP_BUILD_SHARED_LIB=OFF -DOSQP_BUILD_STATIC_LIB=ON
             cmake --build build
             cmake --install build
 

--- a/.github/workflows/main-cuda.yml
+++ b/.github/workflows/main-cuda.yml
@@ -17,7 +17,7 @@ jobs:
         matrix:
           os: [ubuntu-latest]
           python-version: [3.9]
-          cmake_flags: ['-DBUILD_TESTING=ON -DALGEBRA=cuda -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DCMAKE_CUDA_HOST_COMPILER=g++-10']
+          cmake_flags: ['-DOSQP_BUILD_UNITTESTS=ON -DALGEBRA=cuda -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DCMAKE_CUDA_HOST_COMPILER=g++-10']
 
           include:
             - os: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,13 +21,13 @@ jobs:
           # updates (since Visual Studio is also updated at the same time).
           os: [ubuntu-latest, macos-latest, windows-2022]
           python-version: [3.9]
-          cmake_flags: ['-DBUILD_TESTING=OFF', '-DBUILD_TESTING=ON -DCOVERAGE=ON']
+          cmake_flags: ['-DOSQP_BUILD_UNITTESTS=OFF', '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=ON']
           cmake_flags_extra: ['', '-DDFLOAT=ON', '-DDLONG=OFF', '-DEMBEDDED=1', '-DEMBEDDED=2', '-DPROFILING=OFF',
                               '-DCTRLC=OFF', '-DPRINTING=OFF', '-DALGEBRA=default', '-DALGEBRA=mkl']
           exclude:
-            - cmake_flags: '-DBUILD_TESTING=ON -DCOVERAGE=ON'
+            - cmake_flags: '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=ON'
               cmake_flags_extra: '-DEMBEDDED=1'
-            - cmake_flags: '-DBUILD_TESTING=ON -DCOVERAGE=ON'
+            - cmake_flags: '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=ON'
               cmake_flags_extra: '-DEMBEDDED=2'
 
           include:
@@ -102,7 +102,7 @@ jobs:
         - name: Test
           run: |
             ./build/out/osqp_tester
-          if: ${{ matrix.cmake_flags == '-DBUILD_TESTING=ON -DCOVERAGE=ON' }}
+          if: ${{ matrix.cmake_flags == '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=ON' }}
 
         - name: Valgrid check
           run: |
@@ -110,7 +110,7 @@ jobs:
             sudo apt-get install valgrind
             valgrind --suppressions=.valgrind-suppress.supp --leak-check=full --gen-suppressions=all \
               --track-origins=yes --error-exitcode=1 build/out/osqp_tester
-          if: ${{ runner.os == 'Linux' && matrix.cmake_flags == '-DBUILD_TESTING=ON -DCOVERAGE=ON' && matrix.cmake_flags_extra == '-DALGEBRA=default' }}
+          if: ${{ runner.os == 'Linux' && matrix.cmake_flags == '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=ON' && matrix.cmake_flags_extra == '-DALGEBRA=default' }}
 
         - name: Generate coverage
           uses: imciner2/run-lcov@v1
@@ -118,11 +118,11 @@ jobs:
             input_directory: '${{ runner.workspace }}/osqp/build'
             exclude: '"$GITHUB_WORKSPACE/tests/*" "$GITHUB_WORKSPACE/algebra/default/lin_sys/direct/amd/*" "$GITHUB_WORKSPACE/build/*" "/usr/include/*"'
             output_file: '${{ runner.workspace }}/osqp/build/coverage.info'
-          if: ${{ runner.os == 'Linux' && matrix.cmake_flags == '-DBUILD_TESTING=ON -DCOVERAGE=ON' && matrix.cmake_flags_extra == '' }}
+          if: ${{ runner.os == 'Linux' && matrix.cmake_flags == '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=ON' && matrix.cmake_flags_extra == '' }}
 
         - name: Coveralls
           uses: coverallsapp/github-action@master
           with:
             path-to-lcov: '${{ runner.workspace }}/osqp/build/coverage.info'
             github-token: ${{ secrets.GITHUB_TOKEN }}
-          if: ${{ runner.os == 'Linux' && matrix.cmake_flags == '-DBUILD_TESTING=ON -DCOVERAGE=ON' && matrix.cmake_flags_extra == '' }}
+          if: ${{ runner.os == 'Linux' && matrix.cmake_flags == '-DOSQP_BUILD_UNITTESTS=ON -DOSQP_COVERAGE_CHECK=ON' && matrix.cmake_flags_extra == '' }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -471,16 +471,13 @@ endif()
 # ----------------------------------------------
 # Testing
 # ----------------------------------------------
-if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND OSQP_BUILD_UNITTESTS)
   include(CTest)
-endif()
 
-if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME
-   AND OSQP_BUILD_UNITTESTS)
   message( STATUS "Building unit tests" )
 
   if( OSQP_COVERAGE_CHECK )
-    message( STATUS "Generating code coverage files")
+    message( STATUS "Enabling code coverage file generation" )
   endif()
 
   add_subdirectory(tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,16 @@ cmake_dependent_option( OSQP_BUILD_DEMO_EXE
                         ON    # Default to on
                         OSQP_BUILD_STATIC_LIB OFF ) # Force off if the static library isn't built
 
+cmake_dependent_option( OSQP_BUILD_UNITTESTS
+                        "Build the unit testing suite"
+                        OFF    # Default to off
+                        OSQP_BUILD_STATIC_LIB OFF ) # Force off if the static library isn't built
+
+cmake_dependent_option( OSQP_COVERAGE_CHECK
+                        "Check the code coverage of the unit tests"
+                        OFF    # Default to off
+                        OSQP_BUILD_UNITTESTS OFF ) # Force off if the unit tests aren't built
+
 set(ALGEBRA
     "default"
     CACHE STRING "The Algebra to use (default/mkl/cuda)")
@@ -157,12 +167,6 @@ if(DEBUG)
   set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 endif()
 
-option(COVERAGE "Perform code coverage" OFF)
-message(STATUS "COVERAGE = ${COVERAGE}")
-
-if(OSQP_CUSTOM_MEMORY)
-  message(STATUS "User custom memory management header: ${OSQP_CUSTOM_MEMORY}")
-endif()
 
 # Rename compile-time constants & configure
 # ----------------------------------------------
@@ -215,7 +219,7 @@ endif()
 set(CMAKE_POSITION_INDEPENDENT_CODE ON) # -fPIC
 
 if(NOT MSVC)
-  if(COVERAGE)
+  if(OSQP_COVERAGE_CHECK)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
     if(FORTRAN)
@@ -265,10 +269,10 @@ if(PYTHON)
   include_directories(${PYTHON_INCLUDE_DIRS})
   add_definitions(-DPYTHON)
 
-  if(BUILD_TESTING)
-    message(STATUS "Disabling BUILD_TESTING because we are building Python interface")
-    set(BUILD_TESTING OFF)
-  endif(BUILD_TESTING)
+  if(OSQP_BUILD_UNITTESTS)
+    message(STATUS "Disabling OSQP_BUILD_UNITTESTS because we are building Python interface")
+    set(OSQP_BUILD_UNITTESTS OFF)
+  endif(OSQP_BUILD_UNITTESTS)
 endif(PYTHON)
 
 if(MATLAB)
@@ -285,10 +289,10 @@ if(MATLAB)
   add_definitions(-DMATLAB_MEXSRC_RELEASE=R2017b)
   message(STATUS "Using Matlab pre-2018a API for mxGetPr compatibility")
 
-  if(BUILD_TESTING)
-    message(STATUS "Disabling BUILD_TESTING because we are building Matlab interface")
-    set(BUILD_TESTING OFF)
-  endif(BUILD_TESTING)
+  if(OSQP_BUILD_UNITTESTS)
+    message(STATUS "Disabling OSQP_BUILD_UNITTESTS because we are building Matlab interface")
+    set(OSQP_BUILD_UNITTESTS OFF)
+  endif(OSQP_BUILD_UNITTESTS)
 endif(MATLAB)
 
 if(R_LANG)
@@ -304,10 +308,10 @@ if(R_LANG)
   include_directories(${R_INCLUDE_DIRS})
   add_definitions(-DR_LANG)
 
-  if(BUILD_TESTING)
-    message(STATUS "Disabling UNITTESTS because we are building the R interface")
-    set(BUILD_TESTING OFF)
-  endif(BUILD_TESTING)
+  if(OSQP_BUILD_UNITTESTS)
+    message(STATUS "Disabling OSQP_BUILD_UNITTESTS because we are building the R interface")
+    set(OSQP_BUILD_UNITTESTS OFF)
+  endif(OSQP_BUILD_UNITTESTS)
 endif(R_LANG)
 
 if(PYTHON OR MATLAB OR R_LANG)
@@ -466,7 +470,12 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
 endif()
 
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME
-   AND BUILD_TESTING
-   AND OSQP_BUILD_STATIC_LIB)
+   AND OSQP_BUILD_UNITTESTS)
+  message( STATUS "Building unit tests" )
+
+  if( OSQP_COVERAGE_CHECK )
+    message( STATUS "Generating code coverage files")
+  endif()
+
   add_subdirectory(tests)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,6 +323,8 @@ endif()
 # ----------------------------------------------
 # Static Library - osqpstatic
 # ----------------------------------------------
+message( STATUS "Build static library: " ${OSQP_BUILD_STATIC_LIB} )
+
 if( OSQP_BUILD_STATIC_LIB )
   add_library(osqpstatic STATIC
               $<TARGET_OBJECTS:OSQPLIB>
@@ -345,6 +347,8 @@ endif()
 # ----------------------------------------------
 # Shared Library - osqp
 # ----------------------------------------------
+message( STATUS "Build shared library: " ${OSQP_BUILD_SHARED_LIB} )
+
 if(OSQP_BUILD_SHARED_LIB)
   add_library(osqp SHARED
               $<TARGET_OBJECTS:OSQPLIB>
@@ -377,6 +381,8 @@ endif()
 # ----------------------------------------------
 # Application - osqp_demo
 # ----------------------------------------------
+message( STATUS "Build demo executable: " ${OSQP_BUILD_DEMO_EXE} )
+
 if(OSQP_BUILD_DEMO_EXE)
   add_executable(osqp_demo ${PROJECT_SOURCE_DIR}/examples/osqp_demo.c)
   #target_include_directories(osqp_demo PRIVATE ${osqplib_includes})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,29 +73,7 @@ option(PRINTING "Enable solver printing" ON)
 option(PROFILING "Enable solver profiling (timing)" ON)
 option(CTRLC "Enable user interrupt (Ctrl-C)" ON)
 
-# Is the code generated for embedded platforms? 1 :   Yes. Matrix update not allowed. 2 :   No. Matrix update allowed.
-if(DEFINED EMBEDDED)
-  message(STATUS "Forcing ALGEBRA=default for EMBEDDED mode")
-  set(ALGEBRA "default")
-  message(STATUS "Disabling printing/profiling/Ctrl-C for EMBEDDED mode")
-  set(PRINTING OFF)
-  set(PROFILING OFF)
-  set(CTRLC OFF)
-
-  # Disable shared library and demo exe on embedded applications
-  set(OSQP_BUILD_SHARED_LIB OFF)
-  set(OSQP_BUILD_DEMO_EXE OFF)
-
-  message(STATUS "EMBEDDED = ${EMBEDDED}")
-else()
-  message(STATUS "EMBEDDED = OFF")
-endif()
-
-# Display final CTRLC behaviour
-message(STATUS "CTRLC = ${CTRLC}")
-
-# Display final ALGEBRA chosen and set internal boolean variables
-message(STATUS "ALGEBRA = ${ALGEBRA}")
+# Set the relevant boolean values for the algebra
 if(${ALGEBRA} STREQUAL "default")
   set(ALGEBRA_DEFAULT ON)
 elseif(${ALGEBRA} STREQUAL "mkl")
@@ -104,24 +82,66 @@ elseif(${ALGEBRA} STREQUAL "cuda")
   set(ALGEBRA_CUDA ON)
 endif()
 
+# Is the code generated for embedded platforms? 1 :   Yes. Matrix update not allowed. 2 :   No. Matrix update allowed.
+if(DEFINED EMBEDDED)
+  if(NOT ALGEBRA_DEFAULT)
+    message(WARNING "Forcing ALGEBRA=default for EMBEDDED mode.")
+  endif()
+
+  set(ALGEBRA "default")
+  set(ALGEBRA_DEFAULT ON)
+  unset(ALGEBRA_CUDA)
+  unset(ALGEBRA_MKL)
+
+  if(${PRINTING} OR ${PROFILING} OR ${CTRLC})
+    message(WARNING "Disabling printing/profiling/Ctrl-C for EMBEDDED mode.")
+  endif()
+
+  set(PRINTING OFF)
+  set(PROFILING OFF)
+  set(CTRLC OFF)
+
+  # Disable shared library and demo exe on embedded applications
+  if(${OSQP_BUILD_SHARED_LIB} OR ${OSQP_BUILD_DEMO_EXE})
+    message(WARNING "Disabling shared library and demo executable for EMBEDDED mode.")
+  endif()
+
+  set(OSQP_BUILD_SHARED_LIB OFF)
+  set(OSQP_BUILD_DEMO_EXE OFF)
+
+  message(STATUS "EMBEDDED = ${EMBEDDED}")
+else()
+  message(STATUS "EMBEDDED = OFF")
+endif()
+
+# Display final ALGEBRA chosen
+message(STATUS "ALGEBRA = ${ALGEBRA}")
+
+# Display final CTRLC behaviour
+message(STATUS "CTRLC = ${CTRLC}")
+
 if(ALGEBRA_CUDA)
+  # Some options have different defaults for the CUDA algebra
   option(DFLOAT "Use floats instead of doubles" ON)
+  option(DLONG "Use long integers (64bit) for indexing" OFF)
 else()
   option(DFLOAT "Use floats instead of doubles" OFF)
+  option(DLONG "Use long integers (64bit) for indexing" ON)
 endif()
 
 if(DFLOAT AND ALGEBRA_MKL)
-  message(STATUS "Disabling DFLOAT for MKL (Intel RCI ISS does not support single-precision values yet.)")
+  message(WARNING "Disabling DFLOAT for MKL (Intel RCI ISS does not support single-precision values yet.)")
   set(DFLOAT OFF)
 endif()
 message(STATUS "DFLOAT = ${DFLOAT}")
 
-option(DLONG "Use long integers (64bit) for indexing" ON)
 if(NOT (CMAKE_SIZEOF_VOID_P EQUAL 8))
-  message(STATUS "Disabling long integers (64bit) on 32bit machine")
+  message(WARNING "Disabling long integers (64bit) on 32bit machine.")
   set(DLONG OFF)
-elseif(ALGEBRA_CUDA)
-  message(STATUS "Disabling long integers (64bit) for CUDA")
+endif()
+
+if(ALGEBRA_CUDA AND DLONG)
+  message(WARNING "Disabling long integers (64bit) for CUDA.")
   set(DLONG OFF)
 endif()
 message(STATUS "DLONG = ${DLONG}")


### PR DESCRIPTION
This PR does more CMake cleanup and contains the following things:

* Make notifications of automatic changes to build options due to other options into warnings so that it is more obvious to the user that something has changed from what is the default/specified by them.
* Migrate the testing/code coverage build options to be dependent options and rename them to prefix them.