### PR TITLE
Capture console output in a log file

### DIFF
--- a/examples/osqp_demo.c
+++ b/examples/osqp_demo.c
@@ -1,5 +1,5 @@
 #include "osqp.h"
-
+#include "osqp_log.h"
 
 int main(int argc, char **argv) {
   // Load problem data
@@ -36,6 +36,9 @@ int main(int argc, char **argv) {
     data->u = u;
   }
 
+  // Capture console output in a log file
+  osqp_open_log("osqp_demo.log");
+
   // Define solver settings as default
   if (settings) osqp_set_default_settings(settings);
 
@@ -53,6 +56,9 @@ int main(int argc, char **argv) {
     c_free(data);
   }
   if (settings)  c_free(settings);
+
+  // Close the log file
+  osqp_close_log();
 
   return exitflag;
 }

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -9,6 +9,7 @@ set(
     "${CMAKE_CURRENT_SOURCE_DIR}/lin_alg.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/osqp.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/osqp_configure.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/osqp_log.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/proj.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/scaling.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/types.h"

--- a/include/glob_opts.h
+++ b/include/glob_opts.h
@@ -128,6 +128,7 @@ typedef float c_float;  /* for numerical values  */
 # ifdef PRINTING
 #  include <stdio.h>
 #  include <string.h>
+#  include "osqp_log.h"
 
 /* informational print function */
 #  ifdef MATLAB
@@ -144,7 +145,7 @@ typedef float c_float;  /* for numerical values  */
 #   include <R_ext/Print.h>
 #   define c_print Rprintf
 #  else  /* ifdef MATLAB */
-#   define c_print printf
+#   define c_print osqp_log
 #  endif /* c_print configuration */
 
 /* error printing function */

--- a/include/osqp_log.h
+++ b/include/osqp_log.h
@@ -1,0 +1,41 @@
+#ifndef OSQP_LOG_H
+#define OSQP_LOG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* ifdef __cplusplus */
+
+/* Maximum length of the log file name */
+#define OSQP_LOG_NAME_SIZE 255
+
+/**
+ * Assigns the name of the log file and opens the file for writing.
+ *
+ * @param log_name the path name of the log file to open.
+ *
+ * @return 0 if successful, non-zero otherwise.
+ */
+int osqp_open_log(const char* log_name);
+
+/**
+ * Closes the log file if it is open; otherwise, a no-op.
+ */
+void osqp_close_log();
+
+/**
+ * Writes a message to the console and to the log file (if a log
+ * file has been opened).
+ *
+ * @param format the printf format.
+ * @param ...    additional arguments to printf.
+ *
+ * @return the number of characters written, if successful, or -1
+ * otherwise.
+ */
+int osqp_log(const char* format, ...);
+
+#ifdef __cplusplus
+}
+#endif /* ifdef __cplusplus */
+
+#endif /* ifndef OSQP_LOG_H */

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+########################################################################
+# Usage: install.sh <target_dir>
+########################################################################
+
+if [ $# -ne 1 ]
+then
+    echo "Usage: install.sh <target_dir>"
+    exit 1
+fi
+
+TARGET_DIR=$1
+
+if [ ! -d $TARGET_DIR ]
+then
+    mkdir -p $TARGET_DIR
+fi
+
+cd `dirname $0`
+
+if [ ! -d build ]
+then
+    mkdir build
+fi
+
+cd build
+cmake -DCMAKE_INSTALL_PREFIX:PATH=${TARGET_DIR} -G "Unix Makefiles" ..
+cmake --build .
+cmake --build . --target install
+exit 0

--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,12 @@ TARGET_DIR=$1
 if [ ! -d $TARGET_DIR ]
 then
     mkdir -p $TARGET_DIR
+
+    if [ ! -d $TARGET_DIR ]
+    then
+        echo "Failed to create directory $TARGET_DIR; exiting."
+        exit 1
+    fi
 fi
 
 cd `dirname $0`

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@ set(
     "${CMAKE_CURRENT_SOURCE_DIR}/error.c"
     "${CMAKE_CURRENT_SOURCE_DIR}/lin_alg.c"
     "${CMAKE_CURRENT_SOURCE_DIR}/osqp.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/osqp_log.c"
     "${CMAKE_CURRENT_SOURCE_DIR}/proj.c"
     "${CMAKE_CURRENT_SOURCE_DIR}/scaling.c"
     "${CMAKE_CURRENT_SOURCE_DIR}/util.c"

--- a/src/osqp_log.c
+++ b/src/osqp_log.c
@@ -1,0 +1,47 @@
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/errno.h>
+#include "osqp_log.h"
+
+static FILE* osqp_log_fp = NULL;
+static char  osqp_log_name[OSQP_LOG_NAME_SIZE + 1];
+
+int osqp_open_log(const char* log_name) {
+  if (strlen(log_name) > OSQP_LOG_NAME_SIZE) {
+    fprintf(stderr, "WARNING: Log file name exceeds the allowed size.\n");
+    return -1;
+  }
+
+  osqp_close_log();
+  strcpy(osqp_log_name, log_name);
+  osqp_log_fp = fopen(osqp_log_name, "w");
+
+  if (osqp_log_fp)
+    return 0;
+  else
+    return errno;
+}
+
+void osqp_close_log() {
+  if (osqp_log_fp) {
+    fclose(osqp_log_fp);
+    osqp_log_fp = NULL;
+  }
+}
+
+int osqp_log(const char* format, ...) {
+  va_list args;
+
+  va_start(args, format);
+  int result = vprintf(format, args);
+  va_end(args);
+
+  if (osqp_log_fp) {
+    va_start(args, format);
+    result = vfprintf(osqp_log_fp, format, args);
+    va_end(args);
+  }
+
+  return result;
+}


### PR DESCRIPTION
In our production setting, we like to capture the optimizer log output in a text file and archive that file along with the optimal solution. We would rather not simply redirect standard output because we also want to view the optimization process in the console window. This enhancement allows for both console output and log file capture.

Happy to discuss further,
Scott Shaffer
scott@d3xsystems.com