### PR TITLE
Support appending the algebra type to the library name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,11 @@ option(PRINTING "Enable solver printing" ON)
 option(PROFILING "Enable solver profiling (timing)" ON)
 option(CTRLC "Enable user interrupt (Ctrl-C)" ON)
 
+# Allow appending the algebra shortname to the end of the library and the soname so people can have
+# multiple libraries side-by-side on an install.
+option(OSQP_LIB_SUFFIX_ALGEBRA "Add the algebra name to the library name" OFF)
+mark_as_advanced(OSQP_LIB_SUFFIX_ALGEBRA)
+
 # Set the relevant boolean values for the algebra
 if(${ALGEBRA} STREQUAL "default")
   set(ALGEBRA_DEFAULT ON)
@@ -377,7 +382,15 @@ if( OSQP_BUILD_STATIC_LIB )
   add_library(osqpstatic STATIC
               $<TARGET_OBJECTS:OSQPLIB>
               "${CMAKE_CURRENT_SOURCE_DIR}/src/osqp_api.c")
-  set_target_properties(osqpstatic PROPERTIES OUTPUT_NAME osqpstatic)
+
+  # Append the algebra name to the library file if desired
+  if(OSQP_LIB_SUFFIX_ALGEBRA)
+    set_target_properties(osqpstatic PROPERTIES OUTPUT_NAME "osqpstatic-${ALGEBRA}")
+  else()
+    set_target_properties(osqpstatic PROPERTIES OUTPUT_NAME "osqpstatic")
+  endif()
+
+
   if(ALGEBRA_DEFAULT)
     # Transitive dependency on OBJECT library does not work. See https://gitlab.kitware.com/cmake/cmake/-/issues/18682
     target_sources(osqpstatic PRIVATE $<TARGET_OBJECTS:qdldlobject>)
@@ -424,6 +437,11 @@ if(OSQP_BUILD_SHARED_LIB)
   # a PUBLIC compile definition.
   target_compile_definitions(osqp PRIVATE BUILDING_OSQP)
   target_compile_definitions(osqp PUBLIC  OSQP_SHARED_LIB)
+
+  # Modify the soname of the library to include the algebra if desired
+  if(OSQP_LIB_SUFFIX_ALGEBRA)
+    set_target_properties(osqp PROPERTIES LIBRARY_OUTPUT_NAME "osqp-${ALGEBRA}")
+  endif()
 endif()
 
 # ----------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,7 +190,7 @@ message(STATUS "CODEGEN = ${OSQP_CODEGEN}")
 # Rename compile-time constants & configure
 # ----------------------------------------------
 # If we are creating any OSQP_* compile-time constants from CMake variables, do so here.
-set(OSQP_ALGEBRA ${ALGEBRA})
+set(OSQP_ALGEBRA ${ALGEBRA_USER_STRING})
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/configure/osqp_configure.h.in
                ${CMAKE_CURRENT_BINARY_DIR}/include/public/osqp_configure.h NEWLINE_STYLE LF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,10 +90,13 @@ mark_as_advanced(OSQP_LIB_SUFFIX_ALGEBRA)
 
 # Set the relevant boolean values for the algebra
 if(${ALGEBRA} STREQUAL "default")
+  set(ALGEBRA_USER_STRING "builtin")
   set(ALGEBRA_DEFAULT ON)
 elseif(${ALGEBRA} STREQUAL "mkl")
+  set(ALGEBRA_USER_STRING "mkl")
   set(ALGEBRA_MKL ON)
 elseif(${ALGEBRA} STREQUAL "cuda")
+  set(ALGEBRA_USER_STRING "cuda")
   set(ALGEBRA_CUDA ON)
 endif()
 
@@ -385,7 +388,7 @@ if( OSQP_BUILD_STATIC_LIB )
 
   # Append the algebra name to the library file if desired
   if(OSQP_LIB_SUFFIX_ALGEBRA)
-    set_target_properties(osqpstatic PROPERTIES OUTPUT_NAME "osqpstatic-${ALGEBRA}")
+    set_target_properties(osqpstatic PROPERTIES OUTPUT_NAME "osqpstatic-${ALGEBRA_USER_STRING}")
   else()
     set_target_properties(osqpstatic PROPERTIES OUTPUT_NAME "osqpstatic")
   endif()
@@ -440,7 +443,7 @@ if(OSQP_BUILD_SHARED_LIB)
 
   # Modify the soname of the library to include the algebra if desired
   if(OSQP_LIB_SUFFIX_ALGEBRA)
-    set_target_properties(osqp PROPERTIES LIBRARY_OUTPUT_NAME "osqp-${ALGEBRA}")
+    set_target_properties(osqp PROPERTIES LIBRARY_OUTPUT_NAME "osqp-${ALGEBRA_USER_STRING}")
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -388,7 +388,7 @@ if( OSQP_BUILD_STATIC_LIB )
 
   # Append the algebra name to the library file if desired
   if(OSQP_LIB_SUFFIX_ALGEBRA)
-    set_target_properties(osqpstatic PROPERTIES OUTPUT_NAME "osqpstatic-${ALGEBRA_USER_STRING}")
+    set_target_properties(osqpstatic PROPERTIES OUTPUT_NAME "osqpstatic_${ALGEBRA_USER_STRING}")
   else()
     set_target_properties(osqpstatic PROPERTIES OUTPUT_NAME "osqpstatic")
   endif()
@@ -443,7 +443,7 @@ if(OSQP_BUILD_SHARED_LIB)
 
   # Modify the soname of the library to include the algebra if desired
   if(OSQP_LIB_SUFFIX_ALGEBRA)
-    set_target_properties(osqp PROPERTIES LIBRARY_OUTPUT_NAME "osqp-${ALGEBRA_USER_STRING}")
+    set_target_properties(osqp PROPERTIES LIBRARY_OUTPUT_NAME "osqp_${ALGEBRA_USER_STRING}")
   endif()
 endif()
 


### PR DESCRIPTION
By appending the algebra type to the soname, the users can then ship multiple shared libraries next to eachother, each with a different algebra backend.

If the user specified the CMake flag `-DOSQP_LIB_SUFFIX_ALGEBRA=ON`, it will create libraries that look like the following:

For the default algebra:
```
$ objdump -x libosqp-builtin.so | grep SONAME
  SONAME               libosqp-builtin.so
$ ls build/out
/home/b63738im/dev/optimization/osqp/c_code/build/out
Permissions Size User     Date Modified Git Name
.rwxrwxr-x@ 139k b63738im  5 Jul 14:59   -I libosqp-builtin.so
.rw-rw-r--@ 231k b63738im  5 Jul 14:59   -I libosqpstatic-builtin.a
.rwxrwxr-x@ 127k b63738im  5 Jul 14:59   -I osqp_codegen_demo
.rwxrwxr-x@ 127k b63738im  5 Jul 14:59   -I osqp_demo
```

For MKL:
```
$ objdump -x libosqp-mkl.so | grep SONAME
  SONAME               libosqp-mkl.so
$ ls build/out
/home/b63738im/dev/optimization/osqp/c_code/build-mkl/out
Permissions Size User     Date Modified Git Name
.rwxrwxr-x@  96k b63738im  5 Jul 14:51   -I libosqp-mkl.so
.rw-rw-r--@ 142k b63738im  5 Jul 14:51   -I libosqpstatic-mkl.a
.rwxrwxr-x@  92k b63738im  5 Jul 14:51   -I osqp_demo

```