### PR TITLE
Clean up algebra linking and always link against MKL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,6 +314,11 @@ get_property(
   TARGET OSQPLIB
   PROPERTY SOURCES)
 
+get_property(
+  osqplib_link_libs
+  TARGET OSQPLIB
+  PROPERTY LINK_LIBRARIES)
+
 # ----------------------------------------------
 # Language-specific compilation checks
 # ----------------------------------------------
@@ -425,14 +430,8 @@ if(OSQP_BUILD_SHARED_LIB)
   target_include_directories(osqp PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
                                          "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}/osqp>")
 
-  if(MSVC OR IS_MAC)
-    # Visual Studio on Windows, and Mac OS need cuda or mkl libaries to be linked as well
-    if(ALGEBRA_CUDA)
-      target_link_libraries(osqp cublas cusparse)
-    elseif(ALGEBRA_MKL)
-      target_link_libraries(osqp $<LINK_ONLY:MKL::MKL>)
-    endif()
-  endif()
+  # Link against the libraries for the algebras
+  target_link_libraries(osqp ${osqplib_link_libs})
 
   # Declare that we are building the shared library to get proper symbol exports.
   # Shared library consumers should also define OSQP_SHARED_LIB to get the library
@@ -455,12 +454,7 @@ message( STATUS "Build demo executable: " ${OSQP_BUILD_DEMO_EXE} )
 if(OSQP_BUILD_DEMO_EXE)
   add_executable(osqp_demo ${PROJECT_SOURCE_DIR}/examples/osqp_demo.c)
   #target_include_directories(osqp_demo PRIVATE ${osqplib_includes})
-  target_link_libraries(osqp_demo osqpstatic)
-  if(ALGEBRA_MKL)
-    target_link_libraries(osqp_demo $<LINK_ONLY:MKL::MKL>)
-  elseif(ALGEBRA_CUDA)
-    target_link_libraries(osqp_demo cublas cusparse)
-  endif()
+  target_link_libraries(osqp_demo osqpstatic ${osqplib_link_libs})
 
   if(OSQP_CODEGEN)
     add_executable(osqp_codegen_demo ${PROJECT_SOURCE_DIR}/examples/osqp_codegen_demo.c)

--- a/algebra/cuda/CMakeLists.txt
+++ b/algebra/cuda/CMakeLists.txt
@@ -11,3 +11,5 @@ file(
 target_sources(OSQPLIB PRIVATE ${SRC_FILES})
 
 target_include_directories(OSQPLIB PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} include lin_sys/indirect)
+
+target_link_libraries(OSQPLIB cublas cusparse)

--- a/algebra/mkl/CMakeLists.txt
+++ b/algebra/mkl/CMakeLists.txt
@@ -4,6 +4,9 @@ else()
   set(MKL_INTERFACE "lp64")
 endif()
 
+# Link against the single dynamic library version of the MKL library
+set(MKL_LINK "sdl")
+
 find_package(MKL CONFIG REQUIRED)
 
 target_sources(

--- a/algebra/mkl/CMakeLists.txt
+++ b/algebra/mkl/CMakeLists.txt
@@ -27,3 +27,5 @@ target_include_directories(OSQPLIB PRIVATE ../_common ${CMAKE_CURRENT_SOURCE_DIR
 
 target_include_directories(OSQPLIB PUBLIC $<TARGET_PROPERTY:MKL::MKL,INTERFACE_INCLUDE_DIRECTORIES>)
 target_compile_options(OSQPLIB PUBLIC $<TARGET_PROPERTY:MKL::MKL,INTERFACE_COMPILE_OPTIONS>)
+
+target_link_libraries(OSQPLIB MKL::MKL)

--- a/algebra/mkl/algebra_libs.c
+++ b/algebra/mkl/algebra_libs.c
@@ -1,5 +1,20 @@
 #include "osqp_api_types.h"
+#include <mkl.h>
 
-c_int osqp_algebra_init_libs(void) {return 0;}
+c_int osqp_algebra_init_libs(void) {
+    c_int retval = 0;
+
+#ifdef DLONG
+    retval = mkl_set_interface_layer(MKL_INTERFACE_ILP64);
+#else
+    retval = mkl_set_interface_layer(MKL_INTERFACE_LP64);
+#endif
+
+    // Positive value is the interface chosen, so -1 is the error condition
+    if(retval == -1)
+        return 1;
+
+    return 0;
+}
 
 void osqp_algebra_free_libs(void) {return;}

--- a/algebra/mkl/algebra_libs.c
+++ b/algebra/mkl/algebra_libs.c
@@ -1,7 +1,8 @@
+#include "osqp_configure.h"
 #include "osqp_api_types.h"
 #include <mkl.h>
 
-c_int osqp_algebra_init_libs(void) {
+c_int osqp_algebra_init_libs(c_int device) {
     c_int retval = 0;
 
 #ifdef DLONG

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,13 +69,7 @@ add_custom_command(
 # ----------------------------------------------
 add_executable(osqp_tester osqp_tester.cpp osqp_tester.h ${headers} ${codegen_headers})
 target_include_directories(osqp_tester PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${osqplib_includes})
-if(ALGEBRA_MKL)
-  target_link_libraries(osqp_tester osqpstatic Catch2::Catch2 $<LINK_ONLY:MKL::MKL>)
-elseif(ALGEBRA_CUDA)
-  target_link_libraries(osqp_tester osqpstatic Catch2::Catch2 cublas cusparse)
-else()
-  target_link_libraries(osqp_tester osqpstatic Catch2::Catch2)
-endif()
+target_link_libraries(osqp_tester osqpstatic Catch2::Catch2 ${osqplib_link_libs})
 
 add_test(NAME osqp_tester COMMAND osqp_tester)
 
@@ -87,13 +81,7 @@ add_executable(
   osqp_tester.cpp osqp_tester.h ${headers} ${codegen_headers} ${CMAKE_CURRENT_SOURCE_DIR}/custom_memory/custom_memory.h
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_memory/custom_memory.c)
 target_include_directories(osqp_tester_custom_memory PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${osqplib_includes})
-if(ALGEBRA_MKL)
-  target_link_libraries(osqp_tester_custom_memory osqpstatic Catch2::Catch2 $<LINK_ONLY:MKL::MKL>)
-elseif(ALGEBRA_CUDA)
-  target_link_libraries(osqp_tester_custom_memory osqpstatic Catch2::Catch2 cublas cusparse)
-else()
-  target_link_libraries(osqp_tester_custom_memory osqpstatic Catch2::Catch2)
-endif()
+target_link_libraries(osqp_tester_custom_memory osqpstatic Catch2::Catch2 ${osqplib_link_libs})
 
 add_test(NAME osqp_tester_custom_memory COMMAND osqp_tester_custom_memory)
 


### PR DESCRIPTION
Even on Linux we need to tell the shared library it has a dependency on MKL, otherwise the dynamic loader can have issues with undefined symbols because it doesn't know to load the MKL library. I have also cleaned up the linking so now the algebras define the libraries in a similar way to the include directories, removing the need for all the conditionals in the CMake code (and making the algebras more self contained).