### PR TITLE
Update QDLDL to most recent upstream version

### DIFF
--- a/algebra/default/CMakeLists.txt
+++ b/algebra/default/CMakeLists.txt
@@ -3,16 +3,26 @@ include(FetchContent)
 message(STATUS "Fetching/configuring QDLDL solver")
 list(APPEND CMAKE_MESSAGE_INDENT "  ")
 
+# Corresponds to 0.1.6 release of QDLDL
 FetchContent_Declare(
   qdldl
   GIT_REPOSITORY https://github.com/osqp/qdldl.git
-  GIT_TAG 07ff30a3eedee4857bbbeb0778f54a86b1ea78f9
+  GIT_TAG 29d140419a3bec20d860052d73ba2be927faf5a1
   SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/lin_sys/direct/qdldl_sources)
 FetchContent_GetProperties(qdldl)
 
 if(NOT qdldl_POPULATED)
   FetchContent_Populate(qdldl)
-  # We don't actually want to build anything from here
+
+  # Make QDLDL use the same types as OSQP
+  set(QDLDL_FLOAT ${DFLOAT} CACHE BOOL "QDLDL Float type")
+  set(QDLDL_LONG ${DLONG} CACHE BOOL "QDLDL Integer type")
+
+  # We only want the object library, so turn off the other library products
+  set(QDLDL_BUILD_STATIC_LIB OFF CACHE BOOL "Build QDLDL static library")
+  set(QDLDL_BUILD_SHARED_LIB OFF CACHE BOOL "Build QDLDL shared library")
+
+  # We don't actually want to build anything from here by default
   add_subdirectory(${qdldl_SOURCE_DIR} ${qdldl_BINARY_DIR} EXCLUDE_FROM_ALL)
 endif()
 

--- a/algebra/default/CMakeLists.txt
+++ b/algebra/default/CMakeLists.txt
@@ -79,7 +79,8 @@ if( OSQP_CODEGEN )
        ${CMAKE_CURRENT_SOURCE_DIR}/lin_sys/direct/qdldl_interface.h
        ${CMAKE_CURRENT_SOURCE_DIR}/lin_sys/direct/qdldl_interface.c
        ${qdldl_SOURCE_DIR}/src/qdldl.c
-       ${qdldl_SOURCE_DIR}/include/qdldl.h )
+       ${qdldl_SOURCE_DIR}/include/qdldl.h
+       ${qdldl_SOURCE_DIR}/include/qdldl_version.h )
 
   foreach( f ${EMBEDDED_LINALG} )
     get_filename_component( fname ${f} NAME )

--- a/algebra/default/lin_sys/direct/qdldl_codegen_types.h.in
+++ b/algebra/default/lin_sys/direct/qdldl_codegen_types.h.in
@@ -12,12 +12,21 @@
 extern "C" {
 # endif /* ifdef __cplusplus */
 
+#include <limits.h> //for the QDLDL_INT_TYPE_MAX
+
 /* Set the QDLDL integer and float types the same as OSQP */
 typedef c_int    QDLDL_int;   /* for indices */
 typedef c_float  QDLDL_float; /* for numerical values  */
 
 /* Always use int for bool because we must be C89 compliant */
 typedef int   QDLDL_bool;
+
+/* Maximum value of the signed type QDLDL_int. */
+#ifdef DLONG
+#define QDLDL_INT_MAX LLONG_MAX
+#else
+#define QDLDL_INT_MAX INT_MAX
+#endif
 
 # ifdef __cplusplus
 }

--- a/algebra/default/lin_sys/direct/qdldl_interface.c
+++ b/algebra/default/lin_sys/direct/qdldl_interface.c
@@ -12,6 +12,10 @@
 #include "kkt.h"
 #endif
 
+#define STRINGIZE_(x) #x
+#define STRINGIZE(x) STRINGIZE_(x)
+
+
 void update_settings_linsys_solver_qdldl(qdldl_solver       *s,
                                          const OSQPSettings *settings) {
   return;
@@ -364,7 +368,7 @@ c_int init_linsys_solver_qdldl(qdldl_solver      **sp,
 #endif  // EMBEDDED
 
 const char* name_qdldl() {
-  return "QDLDL";
+  return "QDLDL v" STRINGIZE(QDLDL_VERSION_MAJOR) "." STRINGIZE(QDLDL_VERSION_MINOR) "." STRINGIZE(QDLDL_VERSION_PATCH);
 }
 
 


### PR DESCRIPTION
Update the QDLDL version to the recently released version, and make it so that we only enable the object library target and not the shared/static libraries or the demo executable (since OSQP only needs the objects).