### PR TITLE
Raise minimum CMake version to 3.18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.18)
 project(osqp)
 
 include(GNUInstallDirs)


### PR DESCRIPTION
The `CMAKE_CUDA_ARCHITECTURES` variable requires at least CMake 3.18, so that needs to be our new minimum version to support setting the GPU architecture correctly (otherwise the CUDA build using double precision will fail because it is using a compute capability less than 6).

@vineetbansal I am not sure what CMake version is present in the Python build system you use, but this is a bump by only 2 minor versions (from 3.16 to 3.18). For the Julia build system, I had to update CMake for this since it was 3.17 (which is how I detected these variables weren't working to start with).