### PR TITLE
Fix linkage of generated solver object

### DIFF
--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -45,13 +45,23 @@ jobs:
         # Test that embedded mode 1 works
         - name: Embedded mode 1 (vector)
           run: |
-            cmake -G "Unix Makefiles" -S tests/codegen/vector -B tests/codegen/vector/build -DOSQP_BUILD_DIR=$OSQP_BUILD_DIR_PREFIX -DOSQP_CODEGEN_DIR=$OSQP_CODEGEN_DIR_PREFIX/vec
+            cmake -G "Unix Makefiles" \
+                  -S tests/codegen/vector \
+                  -B tests/codegen/vector/build \
+                  -DOSQP_BUILD_DIR=$OSQP_BUILD_DIR_PREFIX \
+                  -DOSQP_CODEGEN_DIR=$OSQP_CODEGEN_DIR_PREFIX/vec
             cmake --build tests/codegen/vector/build
-            ./tests/codegen/vector/build/osqp_codegen_vector
+            ./tests/codegen/vector/build/osqp_codegen_vector_c
+            ./tests/codegen/vector/build/osqp_codegen_vector_cpp
 
         # Test that embedded mode 2 works
         - name: Embedded mode 2 (matrix)
           run: |
-            cmake -G "Unix Makefiles" -S tests/codegen/matrix -B tests/codegen/matrix/build -DOSQP_BUILD_DIR=$OSQP_BUILD_DIR_PREFIX -DOSQP_CODEGEN_DIR=$OSQP_CODEGEN_DIR_PREFIX/mat
+            cmake -G "Unix Makefiles" \
+                  -S tests/codegen/matrix \
+                  -B tests/codegen/matrix/build \
+                  -DOSQP_BUILD_DIR=$OSQP_BUILD_DIR_PREFIX \
+                  -DOSQP_CODEGEN_DIR=$OSQP_CODEGEN_DIR_PREFIX/mat
             cmake --build tests/codegen/matrix/build
-            ./tests/codegen/matrix/build/osqp_codegen_matrix
+            ./tests/codegen/matrix/build/osqp_codegen_matrix_c
+            ./tests/codegen/matrix/build/osqp_codegen_matrix_cpp

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -669,7 +669,15 @@ c_int codegen_inc(OSQPSolver *solver,
   /* Include required headers */
   fprintf(incFile, "#include \"osqp_api_types.h\"\n\n");
 
-  fprintf(incFile, "extern OSQPSolver %ssolver;\n\n", file_prefix);
+  fprintf(incFile, "#ifdef __cplusplus\n");
+  fprintf(incFile, "extern \"C\" {\n");
+  fprintf(incFile, "#endif\n\n");
+
+  fprintf(incFile, "  extern OSQPSolver %ssolver;\n\n", file_prefix);
+
+  fprintf(incFile, "#ifdef __cplusplus\n");
+  fprintf(incFile, "}\n");
+  fprintf(incFile, "#endif\n\n");
 
   /* The endif for the include-guard statement */
   fprintf(incFile, "#endif /* ifndef %s */\n", incGuard);

--- a/tests/codegen/matrix/CMakeLists.txt
+++ b/tests/codegen/matrix/CMakeLists.txt
@@ -38,12 +38,22 @@ endforeach()
 list(POP_BACK CMAKE_MESSAGE_INDENT)
 
 
-add_executable( osqp_codegen_matrix mat_codegen_test.c ${OSQP_SOURCES} ${CODEGEN_SOURCES} )
-target_include_directories( osqp_codegen_matrix
+add_executable( osqp_codegen_matrix_c mat_codegen_test.c ${OSQP_SOURCES} ${CODEGEN_SOURCES} )
+target_include_directories( osqp_codegen_matrix_c
                             PRIVATE
                             ${OSQP_BUILD_DIR}/codegen_src/inc/public
                             ${OSQP_BUILD_DIR}/codegen_src/inc/private
                             ${OSQP_CODEGEN_DIR} )
 
 # Embedded mode 2 needs the sqrt and modf functions from a math library
-target_link_libraries( osqp_codegen_matrix m )
+target_link_libraries( osqp_codegen_matrix_c m )
+
+add_executable( osqp_codegen_matrix_cpp mat_codegen_test.c ${OSQP_SOURCES} ${CODEGEN_SOURCES} )
+target_include_directories( osqp_codegen_matrix_cpp
+                            PRIVATE
+                            ${OSQP_BUILD_DIR}/codegen_src/inc/public
+                            ${OSQP_BUILD_DIR}/codegen_src/inc/private
+                            ${OSQP_CODEGEN_DIR} )
+
+# Embedded mode 2 needs the sqrt and modf functions from a math library
+target_link_libraries( osqp_codegen_matrix_cpp m )

--- a/tests/codegen/matrix/mat_codegen_test.cpp
+++ b/tests/codegen/matrix/mat_codegen_test.cpp
@@ -1,0 +1,75 @@
+#include "osqp.h"
+#include <stdio.h>
+#include <mpc_mat_workspace.h>
+
+int main(void) {
+
+  /* Problem data to use to update the solver */
+  c_float l[3]   = { 0.0, -1.0, -1.0, };
+  c_float u[3]   = { 3.0, 2.0, 2.0, };
+
+  c_float P_x[2] = { 4.5, 2.5, };
+  c_int   P_new_idx[2] = { 0, 2 };
+
+  c_float A_x[2] = { 2.0, 3.0, };
+  c_int   A_new_idx[2] = {0, 2};
+
+  /* Exitflag */
+  c_int exitflag;
+
+  printf( "Embedded test program for matrix updates.\n" );
+
+  /* Solve problem */
+  exitflag = osqp_solve( &mpc_mat_solver );
+
+  if( exitflag > 0 ) {
+    printf( "  OSQP errored: %s\n", osqp_error_message(exitflag) );
+    return (int)exitflag;
+  } else {
+    printf( "  Solved workspace with no error.\n" );
+  }
+
+  /* Update vectors in the workspace */
+  printf( "  Updating l and u vector.\n" );
+  exitflag = osqp_update_data_vec( &mpc_mat_solver, NULL, l, u );
+
+  if( exitflag > 0 ) {
+    printf( "  OSQP errored: %s\n", osqp_error_message(exitflag) );
+    return (int)exitflag;
+  } else {
+    printf( "  Updated workspace vectors with no error.\n" );
+  }
+
+  /* Solve the updated problem */
+  exitflag = osqp_solve( &mpc_mat_solver );
+
+  if( exitflag > 0 ) {
+    printf( "  OSQP errored: %s\n", osqp_error_message(exitflag) );
+    return (int)exitflag;
+  } else {
+    printf( "  Solved updated workspace with no error.\n" );
+  }
+
+    /* Update matrices in the workspace */
+  printf( "  Updating P and A matrices.\n" );
+  exitflag = osqp_update_data_mat( &mpc_mat_solver, P_x, P_new_idx, 2, A_x, A_new_idx, 2 );
+
+  if( exitflag > 0 ) {
+    printf( "  OSQP errored: %s\n", osqp_error_message(exitflag) );
+    return (int)exitflag;
+  } else {
+    printf( "  Updated workspace matrices with no error.\n" );
+  }
+
+  /* Solve the updated problem */
+  exitflag = osqp_solve( &mpc_mat_solver );
+
+  if( exitflag > 0 ) {
+    printf( "  OSQP errored: %s\n", osqp_error_message(exitflag) );
+    return (int)exitflag;
+  } else {
+    printf( "  Solved updated workspace with no error.\n" );
+  }
+
+  return (int)exitflag;
+}

--- a/tests/codegen/vector/CMakeLists.txt
+++ b/tests/codegen/vector/CMakeLists.txt
@@ -38,8 +38,15 @@ endforeach()
 list(POP_BACK CMAKE_MESSAGE_INDENT)
 
 
-add_executable( osqp_codegen_vector vec_codegen_test.c ${OSQP_SOURCES} ${CODEGEN_SOURCES} )
-target_include_directories( osqp_codegen_vector
+add_executable( osqp_codegen_vector_c vec_codegen_test.c ${OSQP_SOURCES} ${CODEGEN_SOURCES} )
+target_include_directories( osqp_codegen_vector_c
+                            PRIVATE
+                            ${OSQP_BUILD_DIR}/codegen_src/inc/public
+                            ${OSQP_BUILD_DIR}/codegen_src/inc/private
+                            ${OSQP_CODEGEN_DIR} )
+
+add_executable( osqp_codegen_vector_cpp vec_codegen_test.cpp ${OSQP_SOURCES} ${CODEGEN_SOURCES} )
+target_include_directories( osqp_codegen_vector_cpp
                             PRIVATE
                             ${OSQP_BUILD_DIR}/codegen_src/inc/public
                             ${OSQP_BUILD_DIR}/codegen_src/inc/private

--- a/tests/codegen/vector/vec_codegen_test.cpp
+++ b/tests/codegen/vector/vec_codegen_test.cpp
@@ -1,0 +1,49 @@
+#include "osqp.h"
+#include <stdio.h>
+#include <mpc_vec_workspace.h>
+
+int main(void) {
+
+  /* Problem data to use to update the solver */
+  c_float l[3]   = { 0.0, -1.0, -1.0, };
+  c_float u[3]   = { 3.0, 2.0, 2.0, };
+
+  /* Exitflag */
+  c_int exitflag;
+
+  printf( "Embedded test program for vector updates.\n" );
+
+  /* Solve problem */
+  exitflag = osqp_solve( &mpc_vec_solver );
+
+  if( exitflag > 0 ) {
+    printf( "  OSQP errored: %s\n", osqp_error_message(exitflag) );
+    return (int)exitflag;
+  } else {
+    printf( "  Solved workspace with no error.\n" );
+  }
+
+  /* Update vectors in the workspace */
+  printf( "  Updating l and u vector.\n" );
+  exitflag = osqp_update_data_vec( &mpc_vec_solver, NULL, l, u );
+
+  if( exitflag > 0 ) {
+    printf( "  OSQP errored: %s\n", osqp_error_message(exitflag) );
+    return (int)exitflag;
+  } else {
+    printf( "  Updated workspace vectors with no error.\n" );
+  }
+
+  /* Solve the updated problem */
+  exitflag = osqp_solve( &mpc_vec_solver );
+
+  if( exitflag > 0 ) {
+    printf( "  OSQP errored: %s\n", osqp_error_message(exitflag) );
+    return (int)exitflag;
+  } else {
+    printf( "  Solved updated workspace with no error.\n" );
+  }
+
+
+  return (int)exitflag;
+}


### PR DESCRIPTION
The generated solver object should have C linkage so that C++ compilers don't mangle its name and then prevent linking against it. This doesn't appear to be a problem for some solvers (like GCC) because they only mangle the names that could possibly have multiple definitions (like static variables and functions), whereas MSVC appears to mangle all names when compiled in a C++ context.

@vineetbansal this should fix the compilation error in the generated Python wrapper you showed me earlier.

(the main change is in the second commit, the first just adds a new test executable compiled with a C++ compiler to make sure the include works in both compilers).