### PR TITLE
Update FindR.cmake

### DIFF
--- a/configure/cmake/FindR.cmake
+++ b/configure/cmake/FindR.cmake
@@ -8,7 +8,7 @@
 
 set(TEMP_CMAKE_FIND_APPBUNDLE ${CMAKE_FIND_APPBUNDLE})
 set(CMAKE_FIND_APPBUNDLE "NEVER")
-find_program(R_EXEC NAMES R R.exe)
+find_program(R_EXEC NAMES R Rdev R.exe HINTS ENV R_HOME /opt/R-devel PATH_SUFFIXES bin)
 set(CMAKE_FIND_APPBUNDLE ${TEMP_CMAKE_FIND_APPBUNDLE})
 
 #---Find includes and libraries if R exists


### PR DESCRIPTION
In December 2021, we made a similar change (but in a one-off commit/branch) to fix CRAN build issues on Fedora:
https://github.com/osqp/osqp/compare/911605e0b4262dae187d177b61ae21f3161a9319...26ce409bf87c635d61c7cbb1f7fce2d9d68641b0

Getting this change in `develop-1.0` will allow us to make a subsequent PR to the `osqp-r` repo where we change the maintainer etc.