### PR TITLE
Pre-commit

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -1,0 +1,39 @@
+name: Pre-commit checks
+
+on:
+  push:
+    branches: [ master, develop**, vb/precommit ]
+    tags:
+      - '*'
+  pull_request:
+    branches: [ master, develop** ]
+
+jobs:
+
+  build_and_test:
+      runs-on: ubuntu-latest
+
+      defaults:
+        run:
+          # Required when using an activated conda environment in steps
+          # See https://github.com/conda-incubator/setup-miniconda#IMPORTANT
+          shell: bash -l {0}
+
+      steps:
+        - uses: actions/checkout@v2
+
+        - name: Set up conda
+          uses: conda-incubator/setup-miniconda@v2
+          with:
+            auto-update-conda: true
+            python-version: 3.9
+
+        - name: Install pre-commit
+          run: |
+            conda install -c conda-forge pre-commit
+            conda info
+            conda list
+
+        - name: Run pre-commit
+          run: |
+            pre-commit run --all-files

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -2,7 +2,7 @@ name: Pre-commit checks
 
 on:
   push:
-    branches: [ master, develop**, vb/precommit ]
+    branches: [ master, develop** ]
     tags:
       - '*'
   pull_request:
@@ -10,7 +10,7 @@ on:
 
 jobs:
 
-  build_and_test:
+  precommit:
       runs-on: ubuntu-latest
 
       defaults:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+    - id: check-yaml


### PR DESCRIPTION
A simple `pre-commit` starter configuration that currently checks for `yml` errors. We have a few `yml` files in this repo, and all currently pass the checks.

Use `pre-commit install` when in the `osqp` checkout folder to enable automated checks. For the CI, installing `pre-commit` through `conda` from the `conda-forge` channel seems to me to be a reasonable option. For local development when you don't want to use `conda` unnecessarily, I see that Ubuntu has a `apt install pre-commit` available. Other distros might have it too.

I'll add some python-related hooks in a future PR. C-related hooks seem to be at:
https://github.com/pocc/pre-commit-hooks

No modifications to the new gh-workflow file should be needed as we add more hooks to `.pre-commit-config.yaml` in the root folder.