### PR TITLE
Renamed osqp_capabilities enum to osqp_capabilities_type

### DIFF
--- a/include/public/osqp_api_constants.h
+++ b/include/public/osqp_api_constants.h
@@ -6,7 +6,7 @@
 /***********************
 * Solver capabilities *
 ***********************/
-enum osqp_capabilities {
+enum osqp_capabilities_type {
     /* This enum serves as a bit-flag definition, so each capability must be represented by
        a different bit in an int variable */
     OSQP_CAPABILITIY_DIRECT_SOLVER = 0x01,      /* A direct linear solver is present in the algebra */


### PR DESCRIPTION
 I'm starting to incorporate supported capabilities in the python wrapper so as to better handle unsupported calls at runtime. I noticed that this renaming needs to happen for to avoid naming conflicts when compiling in the wrapper (since there's an `osqp_capabilities` api function already).
 
 There seems to be no place in the `osqp` codebase itself where this renaming affects anything though.