### PR TITLE
Fix spelling errors in capability defines

### DIFF
--- a/algebra/builtin/algebra_libs.c
+++ b/algebra/builtin/algebra_libs.c
@@ -4,7 +4,7 @@
 
 OSQPInt osqp_algebra_linsys_supported(void) {
   /* Only has QDLDL (direct solver) */
-  return OSQP_CAPABILITIY_DIRECT_SOLVER;
+  return OSQP_CAPABILITY_DIRECT_SOLVER;
 }
 
 enum osqp_linsys_solver_type osqp_algebra_default_linsys(void) {

--- a/algebra/cuda/algebra_libs.cu
+++ b/algebra/cuda/algebra_libs.cu
@@ -26,7 +26,7 @@ CUDA_Handle_t *CUDA_handle = OSQP_NULL;
 
 OSQPInt osqp_algebra_linsys_supported(void) {
   /* Only has a PCG (indirect) solver */
-  return OSQP_CAPABILITIY_INDIRECT_SOLVER;
+  return OSQP_CAPABILITY_INDIRECT_SOLVER;
 }
 
 enum osqp_linsys_solver_type osqp_algebra_default_linsys(void) {

--- a/algebra/mkl/algebra_libs.c
+++ b/algebra/mkl/algebra_libs.c
@@ -9,7 +9,7 @@
 
 OSQPInt osqp_algebra_linsys_supported(void) {
   /* Has both Paradiso (direct solver) and a PCG solver (indirect solver) */
-  return OSQP_CAPABILITIY_DIRECT_SOLVER | OSQP_CAPABILITIY_INDIRECT_SOLVER;
+  return OSQP_CAPABILITY_DIRECT_SOLVER | OSQP_CAPABILITY_INDIRECT_SOLVER;
 }
 
 enum osqp_linsys_solver_type osqp_algebra_default_linsys(void) {

--- a/examples/osqp_demo.c
+++ b/examples/osqp_demo.c
@@ -45,16 +45,16 @@ int main(void) {
   OSQPInt cap = osqp_capabilities();
 
   printf("This OSQP library supports:\n");
-  if(cap & OSQP_CAPABILITIY_DIRECT_SOLVER) {
+  if(cap & OSQP_CAPABILITY_DIRECT_SOLVER) {
     printf("    A direct linear algebra solver\n");
   }
-  if(cap & OSQP_CAPABILITIY_INDIRECT_SOLVER) {
+  if(cap & OSQP_CAPABILITY_INDIRECT_SOLVER) {
     printf("    An indirect linear algebra solver\n");
   }
-  if(cap & OSQP_CAPABILITIY_CODEGEN) {
+  if(cap & OSQP_CAPABILITY_CODEGEN) {
     printf("    Code generation\n");
   }
-  if(cap & OSQP_CAPABILITIY_DERIVATIVES) {
+  if(cap & OSQP_CAPABILITY_DERIVATIVES) {
     printf("    Derivatives calculation\n");
   }
   printf("\n");

--- a/include/public/osqp_api_constants.h
+++ b/include/public/osqp_api_constants.h
@@ -9,11 +9,11 @@
 enum osqp_capabilities_type {
     /* This enum serves as a bit-flag definition, so each capability must be represented by
        a different bit in an int variable */
-    OSQP_CAPABILITIY_DIRECT_SOLVER = 0x01,      /* A direct linear solver is present in the algebra */
-    OSQP_CAPABILITIY_INDIRECT_SOLVER = 0x02,    /* An indirect linear solver is present in the algebra */
-    OSQP_CAPABILITIY_CODEGEN = 0x04,            /* Code generation is present */
-    OSQP_CAPABILITIY_UPDATE_MATRICES = 0x08,    /* The problem matrices can be updated */
-    OSQP_CAPABILITIY_DERIVATIVES = 0x10         /* Solution derivatives w.r.t P/q/A/l/u are available */
+    OSQP_CAPABILITY_DIRECT_SOLVER = 0x01,      /* A direct linear solver is present in the algebra */
+    OSQP_CAPABILITY_INDIRECT_SOLVER = 0x02,    /* An indirect linear solver is present in the algebra */
+    OSQP_CAPABILITY_CODEGEN = 0x04,            /* Code generation is present */
+    OSQP_CAPABILITY_UPDATE_MATRICES = 0x08,    /* The problem matrices can be updated */
+    OSQP_CAPABILITY_DERIVATIVES = 0x10         /* Solution derivatives w.r.t P/q/A/l/u are available */
 };
 
 

--- a/src/auxil.c
+++ b/src/auxil.c
@@ -932,13 +932,13 @@ OSQPInt validate_data(const OSQPCscMatrix* P,
 OSQPInt validate_linsys_solver(OSQPInt linsys_solver) {
   /* Verify the algebra backend supports the requested indirect solver */
   if ( (linsys_solver == OSQP_INDIRECT_SOLVER) &&
-     (osqp_algebra_linsys_supported() & OSQP_CAPABILITIY_INDIRECT_SOLVER) ) {
+     (osqp_algebra_linsys_supported() & OSQP_CAPABILITY_INDIRECT_SOLVER) ) {
     return 0;
   }
 
   /* Verify the algebra backend supports the requested direct solver */
   if ( (linsys_solver == OSQP_DIRECT_SOLVER) &&
-     (osqp_algebra_linsys_supported() & OSQP_CAPABILITIY_DIRECT_SOLVER) ) {
+     (osqp_algebra_linsys_supported() & OSQP_CAPABILITY_DIRECT_SOLVER) ) {
     return 0;
   }
 

--- a/src/osqp_api.c
+++ b/src/osqp_api.c
@@ -37,15 +37,15 @@ OSQPInt osqp_capabilities(void) {
   capabilities |= osqp_algebra_linsys_supported();
 
 #if OSQP_EMBEDDED_MODE != 1
-  capabilities |= OSQP_CAPABILITIY_UPDATE_MATRICES;
+  capabilities |= OSQP_CAPABILITY_UPDATE_MATRICES;
 #endif
 
 #ifdef OSQP_CODEGEN
-  capabilities |= OSQP_CAPABILITIY_CODEGEN;
+  capabilities |= OSQP_CAPABILITY_CODEGEN;
 #endif
 
 #ifdef OSQP_ENABLE_DERIVATIVES
-    capabilities |= OSQP_CAPABILITIY_DERIVATIVES;
+    capabilities |= OSQP_CAPABILITY_DERIVATIVES;
 #endif
 
   return capabilities;

--- a/tests/utils/test_utils.cpp
+++ b/tests/utils/test_utils.cpp
@@ -33,11 +33,11 @@ OSQPFloat vec_norm_inf_diff(const OSQPFloat* a, const OSQPFloat* b, OSQPInt l) {
 OSQPInt isLinsysSupported(enum osqp_linsys_solver_type solver) {
   OSQPInt caps = osqp_capabilities();
 
-  if((caps & OSQP_CAPABILITIY_DIRECT_SOLVER) && (solver == OSQP_DIRECT_SOLVER)) {
+  if((caps & OSQP_CAPABILITY_DIRECT_SOLVER) && (solver == OSQP_DIRECT_SOLVER)) {
     return 1;
   }
 
-  if((caps & OSQP_CAPABILITIY_INDIRECT_SOLVER) && (solver == OSQP_INDIRECT_SOLVER)) {
+  if((caps & OSQP_CAPABILITY_INDIRECT_SOLVER) && (solver == OSQP_INDIRECT_SOLVER)) {
     return 1;
   }
 


### PR DESCRIPTION
I made a spelling mistake in the original implementation of the capability definitions, so this fixes it in all places now.