### PR TITLE
Building docs for develop-1.0 in a subfolder

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Docs
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, develop-1.0 ]
     tags:
       - '*'
 
@@ -38,6 +38,9 @@ jobs:
             if [[ $GITHUB_REF = "refs/tags/"* ]] ; then echo "OSQP_NAME=osqp-${GITHUB_REF/refs\/tags\//}-${{ runner.os }}" ; else echo "OSQP_NAME=osqp-0.0.0-${{ runner.os }}" ; fi >> $GITHUB_ENV
 
       - name: Build docs
+        # Run step only if the branch is not develop-1.0,
+        # because we handle it separately in subsequent steps. 
+        if: github.ref != 'refs/heads/develop-1.0'
         run: |
           cd docs && make HTMLCOPYDIR=../site/docs html && touch ../site/docs/.nojekyll
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,6 +41,20 @@ jobs:
         run: |
           cd docs && make HTMLCOPYDIR=../site/docs html && touch ../site/docs/.nojekyll
 
+      # Build documentation on the develop-1.0 branch in a subfolder
+      # ------------------------------------------------------------
+      - uses: actions/checkout@v2
+        with:
+          ref: develop-1.0
+          path: develop-1.0
+          clean: false
+
+      - name: Build docs on develop-1.0
+        run: |
+          rm -rf develop-1.0/.git
+          cd develop-1.0/docs && make HTMLCOPYDIR=../../site/docs/develop-1.0 html
+      # ------------------------------------------------------------
+
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@4.1.1
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          ref: master
           lfs: false
 
       - name: Install OS dependencies
@@ -38,9 +39,6 @@ jobs:
             if [[ $GITHUB_REF = "refs/tags/"* ]] ; then echo "OSQP_NAME=osqp-${GITHUB_REF/refs\/tags\//}-${{ runner.os }}" ; else echo "OSQP_NAME=osqp-0.0.0-${{ runner.os }}" ; fi >> $GITHUB_ENV
 
       - name: Build docs
-        # Run step only if the branch is not develop-1.0,
-        # because we handle it separately in subsequent steps. 
-        if: github.ref != 'refs/heads/develop-1.0'
         run: |
           cd docs && make HTMLCOPYDIR=../site/docs html && touch ../site/docs/.nojekyll
 


### PR DESCRIPTION
This pair of steps (which **have** to run in the same workflow action as the main documentation), check out the `develop-1.0` branch of the repo, and build its documentation in a `develop-1.0` folder inside the current `docs` folder on the target `gh-pages` branch. I've tested this workflow in another repo and it seems to work well (and is the only way to do this AFAIK).

If all goes well, we should see, in addition to:
https://osqp.org/docs/

a parallel link:
https://osqp.org/docs/develop-1.0