### PR TITLE
Skip polishing when there is no active set detected

### DIFF
--- a/algebra/builtin/vector.c
+++ b/algebra/builtin/vector.c
@@ -757,7 +757,7 @@ OSQPInt OSQPVectorf_in_reccone(const OSQPVectorf* y,
 
 #if OSQP_EMBEDDED_MODE != 1
 
-OSQPFloat OSQPVectorf_pos_mean(const OSQPVectorf* a) {
+OSQPFloat OSQPVectorf_norm_1(const OSQPVectorf* a) {
 
   OSQPInt i;
   OSQPInt length = a->length;
@@ -767,11 +767,11 @@ OSQPFloat OSQPVectorf_pos_mean(const OSQPVectorf* a) {
 
   if (length) {
     for (i = 0; i < length; i++) {
-      val += av[i];
+      val += c_absval(av[i]);
     }
-    return val / length;
   }
-  else return val;
+
+  return val;
 }
 
 void OSQPVectorf_ew_reciprocal(OSQPVectorf*       b,

--- a/algebra/builtin/vector.c
+++ b/algebra/builtin/vector.c
@@ -757,7 +757,7 @@ OSQPInt OSQPVectorf_in_reccone(const OSQPVectorf* y,
 
 #if OSQP_EMBEDDED_MODE != 1
 
-OSQPFloat OSQPVectorf_mean(const OSQPVectorf* a) {
+OSQPFloat OSQPVectorf_pos_mean(const OSQPVectorf* a) {
 
   OSQPInt i;
   OSQPInt length = a->length;

--- a/algebra/cuda/vector.cu
+++ b/algebra/cuda/vector.cu
@@ -308,7 +308,7 @@ OSQPFloat OSQPVectorf_norm_inf_diff(const OSQPVectorf* a,
   return normDiff;
 }
 
-OSQPFloat OSQPVectorf_pos_mean(const OSQPVectorf* a) {
+OSQPFloat OSQPVectorf_norm_1(const OSQPVectorf* a) {
 
   OSQPFloat mean;
 

--- a/algebra/cuda/vector.cu
+++ b/algebra/cuda/vector.cu
@@ -308,7 +308,7 @@ OSQPFloat OSQPVectorf_norm_inf_diff(const OSQPVectorf* a,
   return normDiff;
 }
 
-OSQPFloat OSQPVectorf_mean(const OSQPVectorf* a) {
+OSQPFloat OSQPVectorf_pos_mean(const OSQPVectorf* a) {
 
   OSQPFloat mean;
 

--- a/algebra/mkl/blas_helpers.h
+++ b/algebra/mkl/blas_helpers.h
@@ -28,6 +28,7 @@
   #define blas_swap  sswap
   #define blas_axpy  saxpy
   #define blas_2norm snrm2
+  #define blas_asum  sasum
 
   #define spblas_create_csc mkl_sparse_s_create_csc
   #define spblas_set_value  mkl_sparse_s_set_value
@@ -40,6 +41,7 @@
   #define blas_swap  dswap
   #define blas_axpy  daxpy
   #define blas_2norm dnrm2
+  #define blas_asum  dasum
 
   #define spblas_create_csc mkl_sparse_d_create_csc
   #define spblas_set_value  mkl_sparse_d_set_value

--- a/algebra/mkl/vector.c
+++ b/algebra/mkl/vector.c
@@ -701,21 +701,19 @@ OSQPInt OSQPVectorf_in_reccone(const OSQPVectorf* y,
 //   }
 // }
 
-OSQPFloat OSQPVectorf_mean(const OSQPVectorf* a) {
+OSQPFloat OSQPVectorf_pos_mean(const OSQPVectorf* a) {
 
-  OSQPInt i;
   OSQPInt length = a->length;
+  const MKL_INT inca = 1; //How long should the spacing be (?)
 
-  OSQPFloat* av  = a->values;
-  OSQPFloat  val = 0.0;
+  OSQPFloat val = 0.0;
 
   if (length) {
-    for (i = 0; i < length; i++) {
-      val += av[i];
-    }
-    return val / length;
+    val = blas_asum(&length, a->values, &inca);
+    val = val / length;
   }
-  else return val;
+
+  return val;
 }
 
 void OSQPVectorf_ew_reciprocal(OSQPVectorf*       b,

--- a/algebra/mkl/vector.c
+++ b/algebra/mkl/vector.c
@@ -701,16 +701,15 @@ OSQPInt OSQPVectorf_in_reccone(const OSQPVectorf* y,
 //   }
 // }
 
-OSQPFloat OSQPVectorf_pos_mean(const OSQPVectorf* a) {
+OSQPFloat OSQPVectorf_norm_1(const OSQPVectorf* a) {
 
-  OSQPInt length = a->length;
-  const MKL_INT inca = 1; //How long should the spacing be (?)
+  OSQPInt       length = a->length;
+  const MKL_INT inca   = 1;
 
   OSQPFloat val = 0.0;
 
   if (length) {
     val = blas_asum(&length, a->values, &inca);
-    val = val / length;
   }
 
   return val;

--- a/include/private/algebra_vector.h
+++ b/include/private/algebra_vector.h
@@ -166,8 +166,8 @@ OSQPFloat OSQPVectorf_norm_inf_diff(const OSQPVectorf* a,
 /* ||v||2 */
 OSQPFloat OSQPVectorf_norm_2(const OSQPVectorf* v);
 
-/* mean of vector elements - assumes all elements are positive */
-OSQPFloat OSQPVectorf_pos_mean(const OSQPVectorf* a);
+/* ||v||1 */
+OSQPFloat OSQPVectorf_norm_1(const OSQPVectorf* a);
 
 /* Inner product a'b */
 OSQPFloat OSQPVectorf_dot_prod(const OSQPVectorf* a,
@@ -224,9 +224,6 @@ OSQPInt OSQPVectorf_in_reccone(const OSQPVectorf* y,
                                OSQPFloat          tol);
 
 # if OSQP_EMBEDDED_MODE != 1
-
-/* Vector mean value*/
-OSQPFloat OSQPVectorf_pos_mean(const OSQPVectorf* a);
 
 /* Vector elementwise reciprocal b = 1./a (needed for scaling)*/
 void OSQPVectorf_ew_reciprocal(OSQPVectorf*       b,

--- a/include/private/algebra_vector.h
+++ b/include/private/algebra_vector.h
@@ -166,8 +166,8 @@ OSQPFloat OSQPVectorf_norm_inf_diff(const OSQPVectorf* a,
 /* ||v||2 */
 OSQPFloat OSQPVectorf_norm_2(const OSQPVectorf* v);
 
-/* mean of vector elements */
-OSQPFloat OSQPVectorf_mean(const OSQPVectorf* a);
+/* mean of vector elements - assumes all elements are positive */
+OSQPFloat OSQPVectorf_pos_mean(const OSQPVectorf* a);
 
 /* Inner product a'b */
 OSQPFloat OSQPVectorf_dot_prod(const OSQPVectorf* a,
@@ -226,7 +226,7 @@ OSQPInt OSQPVectorf_in_reccone(const OSQPVectorf* y,
 # if OSQP_EMBEDDED_MODE != 1
 
 /* Vector mean value*/
-OSQPFloat OSQPVectorf_mean(const OSQPVectorf* a);
+OSQPFloat OSQPVectorf_pos_mean(const OSQPVectorf* a);
 
 /* Vector elementwise reciprocal b = 1./a (needed for scaling)*/
 void OSQPVectorf_ew_reciprocal(OSQPVectorf*       b,

--- a/include/public/osqp_api_constants.h
+++ b/include/public/osqp_api_constants.h
@@ -35,6 +35,17 @@ enum osqp_status_type {
 };
 extern const char * OSQP_STATUS_MESSAGE[];
 
+/******************
+* Polish Status  *
+******************/
+enum osqp_polish_status_type {
+    OSQP_POLISH_LINSYS_ERROR = -2,
+    OSQP_POLISH_FAILED = -1,
+    OSQP_POLISHING_UNPERFORMED = 0,
+    OSQP_POLISH_SUCCESS = 1,
+    OSQP_POLISH_NO_ACTIVE_SET = 2  /* No active set detected, polishing skipped (not an error) */
+};
+
 /*************************
 * Linear System Solvers *
 *************************/

--- a/include/public/osqp_api_constants.h
+++ b/include/public/osqp_api_constants.h
@@ -41,9 +41,9 @@ extern const char * OSQP_STATUS_MESSAGE[];
 enum osqp_polish_status_type {
     OSQP_POLISH_LINSYS_ERROR = -2,
     OSQP_POLISH_FAILED = -1,
-    OSQP_POLISHING_UNPERFORMED = 0,
+    OSQP_POLISH_NOT_PERFORMED = 0,
     OSQP_POLISH_SUCCESS = 1,
-    OSQP_POLISH_NO_ACTIVE_SET = 2  /* No active set detected, polishing skipped (not an error) */
+    OSQP_POLISH_NO_ACTIVE_SET_FOUND = 2  /* No active set detected, polishing skipped (not an error) */
 };
 
 /*************************

--- a/src/osqp_api.c
+++ b/src/osqp_api.c
@@ -320,7 +320,7 @@ OSQPInt osqp_setup(OSQPSolver**         solverp,
     return osqp_error(OSQP_MEM_ALLOC_ERROR);
 
   // Initialize information
-  solver->info->status_polish = 0;              // Polishing not performed
+  solver->info->status_polish = OSQP_POLISHING_UNPERFORMED; // Polishing not performed
   update_status(solver->info, OSQP_UNSOLVED);
 # ifdef OSQP_ENABLE_PROFILING
   solver->info->solve_time  = 0.0;                   // Solve time to zero

--- a/src/osqp_api.c
+++ b/src/osqp_api.c
@@ -320,7 +320,7 @@ OSQPInt osqp_setup(OSQPSolver**         solverp,
     return osqp_error(OSQP_MEM_ALLOC_ERROR);
 
   // Initialize information
-  solver->info->status_polish = OSQP_POLISHING_UNPERFORMED; // Polishing not performed
+  solver->info->status_polish = OSQP_POLISH_NOT_PERFORMED; // Polishing not performed
   update_status(solver->info, OSQP_UNSOLVED);
 # ifdef OSQP_ENABLE_PROFILING
   solver->info->solve_time  = 0.0;                   // Solve time to zero

--- a/src/polish.c
+++ b/src/polish.c
@@ -301,13 +301,13 @@ OSQPInt polish(OSQPSolver* solver) {
     return OSQP_POLISH_FAILED;
   } else if (mred == 0) {
     /* No active constraints, so skip polishing */
-    c_print("Polishing skipped - no active set detected at optimal point\n");
-    info->status_polish = OSQP_POLISH_NO_ACTIVE_SET;
+    c_print("Polishing not needed - no active set detected at optimal point\n");
+    info->status_polish = OSQP_POLISH_NO_ACTIVE_SET_FOUND;
 
     // Memory clean-up
     OSQPMatrix_free(work->pol->Ared);
 
-    return OSQP_POLISH_NO_ACTIVE_SET;
+    return OSQP_POLISH_NO_ACTIVE_SET_FOUND;
   }
 
   // Form and factorize reduced KKT

--- a/src/scaling.c
+++ b/src/scaling.c
@@ -120,9 +120,10 @@ OSQPInt scale_data(OSQPSolver* solver) {
     // Cost normalization step
     //
 
-    // Compute avg norm of cols of P
+    // Compute avg norm of cols of P. These norms are all positive, so use average
+    // that assumes positivity for performance.
     OSQPMatrix_col_norm_inf(work->data->P, work->D_temp);
-    c_temp = OSQPVectorf_mean(work->D_temp);
+    c_temp = OSQPVectorf_pos_mean(work->D_temp);
 
     // Compute inf norm of q
     inf_norm_q = OSQPVectorf_norm_inf(work->data->q);

--- a/src/scaling.c
+++ b/src/scaling.c
@@ -120,10 +120,10 @@ OSQPInt scale_data(OSQPSolver* solver) {
     // Cost normalization step
     //
 
-    // Compute avg norm of cols of P. These norms are all positive, so use average
-    // that assumes positivity for performance.
+    // Compute avg norm of cols of P.
     OSQPMatrix_col_norm_inf(work->data->P, work->D_temp);
-    c_temp = OSQPVectorf_pos_mean(work->D_temp);
+    c_temp = OSQPVectorf_norm_1(work->D_temp);
+    c_temp = c_temp / n;
 
     // Compute inf norm of q
     inf_norm_q = OSQPVectorf_norm_inf(work->data->q);

--- a/src/util.c
+++ b/src/util.c
@@ -216,8 +216,8 @@ void print_footer(OSQPInfo* info,
       c_print("solution polishing:   successful\n");
     } else if (info->status_polish < 0) {
       c_print("solution polishing:   unsuccessful\n");
-    } else if (info->status_polish == OSQP_POLISH_NO_ACTIVE_SET) {
-      c_print("solution polishing:   skipped\n");
+    } else if (info->status_polish == OSQP_POLISH_NO_ACTIVE_SET_FOUND) {
+      c_print("solution polishing:   not needed\n");
     }
   }
 

--- a/src/util.c
+++ b/src/util.c
@@ -212,10 +212,12 @@ void print_footer(OSQPInfo* info,
   c_print("status:               %s\n", info->status);
 
   if (polishing && (info->status_val == OSQP_SOLVED)) {
-    if (info->status_polish == 1) {
+    if (info->status_polish == OSQP_POLISH_SUCCESS) {
       c_print("solution polishing:   successful\n");
     } else if (info->status_polish < 0) {
       c_print("solution polishing:   unsuccessful\n");
+    } else if (info->status_polish == OSQP_POLISH_NO_ACTIVE_SET) {
+      c_print("solution polishing:   skipped\n");
     }
   }
 

--- a/tests/basic_lp/test_basic_lp.cpp
+++ b/tests/basic_lp/test_basic_lp.cpp
@@ -37,7 +37,7 @@ TEST_CASE( "Basic LP", "[solve][lp]" )
   std::tie( polish, expectedPolishStatus ) =
       GENERATE( table<OSQPInt, OSQPInt>(
           { /* first is polish enabled, second is expected status */
-            std::make_tuple( 0, OSQP_POLISHING_UNPERFORMED ),
+            std::make_tuple( 0, OSQP_POLISH_NOT_PERFORMED ),
             std::make_tuple( 1, OSQP_POLISH_SUCCESS ) } ) );
 
   settings->polishing = polish;

--- a/tests/basic_qp2/test_basic_qp2.cpp
+++ b/tests/basic_qp2/test_basic_qp2.cpp
@@ -31,7 +31,16 @@ TEST_CASE("Basic QP2 solve", "[solve],[qp]")
   settings->eps_rel = 1e-5;
 
   /* Test with and without polishing */
-  settings->polishing = GENERATE(0, 1);
+  OSQPInt polish;
+  OSQPInt expectedPolishStatus;
+
+  std::tie( polish, expectedPolishStatus ) =
+      GENERATE( table<OSQPInt, OSQPInt>(
+          { /* first is polish enabled, second is expected status */
+            std::make_tuple( 0, OSQP_POLISHING_UNPERFORMED ),
+            std::make_tuple( 1, OSQP_POLISH_SUCCESS ) } ) );
+
+  settings->polishing = polish;
   settings->polish_refine_iter = 4;
 
   /* Test all possible linear system solvers in this test case */
@@ -71,6 +80,10 @@ TEST_CASE("Basic QP2 solve", "[solve],[qp]")
   // Compare objective values
   mu_assert("Basic QP 2 test solve: Error in objective value!",
             c_absval(solver->info->obj_val - sols_data->obj_value_test)/(c_absval(sols_data->obj_value_test)) < TESTS_TOL);
+
+  // Check polishing status
+  mu_assert("Basic QP 2 test solve: Error in polish status!",
+            solver->info->status_polish == expectedPolishStatus);
 }
 
 TEST_CASE("Basic QP2: Update vectors", "[solve],[qp],[update]")
@@ -138,4 +151,8 @@ TEST_CASE("Basic QP2: Update vectors", "[solve],[qp],[update]")
   mu_assert("Basic QP 2 test update: Error in objective value!",
             c_absval(
               solver->info->obj_val - sols_data->obj_value_test_new)/(c_absval(sols_data->obj_value_test_new)) < TESTS_TOL);
+
+  // Check polishing status
+  mu_assert("Basic QP 2 test solve: Error in polish status!",
+            solver->info->status_polish == OSQP_POLISH_SUCCESS);
 }

--- a/tests/basic_qp2/test_basic_qp2.cpp
+++ b/tests/basic_qp2/test_basic_qp2.cpp
@@ -37,7 +37,7 @@ TEST_CASE("Basic QP2 solve", "[solve],[qp]")
   std::tie( polish, expectedPolishStatus ) =
       GENERATE( table<OSQPInt, OSQPInt>(
           { /* first is polish enabled, second is expected status */
-            std::make_tuple( 0, OSQP_POLISHING_UNPERFORMED ),
+            std::make_tuple( 0, OSQP_POLISH_NOT_PERFORMED ),
             std::make_tuple( 1, OSQP_POLISH_SUCCESS ) } ) );
 
   settings->polishing = polish;

--- a/tests/lin_alg/generate_problem.py
+++ b/tests/lin_alg/generate_problem.py
@@ -33,7 +33,9 @@ test_vec_ops_sc2 = rg.standard_normal()
 test_vec_ops_sc3 = rg.standard_normal()
 test_vec_ops_same = np.zeros(test_vec_ops_n)
 test_vec_ops_same.fill(test_vec_ops_sc1)
-test_vec_ops_pos_mean = np.mean(test_vec_ops_pos_v1)
+test_vec_ops_norm_1 = np.linalg.norm(test_vec_ops_v1, 1)
+test_vec_ops_pos_norm_1 = np.linalg.norm(test_vec_ops_pos_v1, 1)
+test_vec_ops_neg_norm_1 = np.linalg.norm(test_vec_ops_neg_v1, 1)
 test_vec_ops_norm_2 = np.linalg.norm(test_vec_ops_v1, 2)
 test_vec_ops_norm_inf = np.linalg.norm(test_vec_ops_v1, np.inf)
 test_vec_ops_norm_inf_scaled = np.linalg.norm(test_vec_ops_v1 * test_vec_ops_v2, np.inf)
@@ -177,7 +179,9 @@ data = {'test_sp_matrix_A': test_sp_matrix_A,
         'test_vec_ops_sc2': test_vec_ops_sc2,
         'test_vec_ops_sc3': test_vec_ops_sc3,
         'test_vec_ops_same': test_vec_ops_same,
-        'test_vec_ops_pos_mean': test_vec_ops_pos_mean,
+        'test_vec_ops_norm_1': test_vec_ops_norm_1,
+        'test_vec_ops_pos_norm_1': test_vec_ops_pos_norm_1,
+        'test_vec_ops_neg_norm_1': test_vec_ops_neg_norm_1,
         'test_vec_ops_norm_2': test_vec_ops_norm_2,
         'test_vec_ops_norm_inf': test_vec_ops_norm_inf,
         'test_vec_ops_norm_inf_scaled': test_vec_ops_norm_inf_scaled,

--- a/tests/lin_alg/generate_problem.py
+++ b/tests/lin_alg/generate_problem.py
@@ -22,6 +22,7 @@ test_vec_ops_zero_int = test_vec_ops_zero.astype(int)
 test_vec_ops_v1 = rg.standard_normal(test_vec_ops_n)
 test_vec_ops_v2 = rg.standard_normal(test_vec_ops_n)
 test_vec_ops_v3 = rg.standard_normal(test_vec_ops_n)
+test_vec_ops_pos_v1 = abs(test_vec_ops_v1)
 test_vec_ops_neg_v1 = -test_vec_ops_v1
 test_vec_ops_neg_v2 = -test_vec_ops_v2
 test_vec_ops_neg_v3 = -test_vec_ops_v3
@@ -32,7 +33,7 @@ test_vec_ops_sc2 = rg.standard_normal()
 test_vec_ops_sc3 = rg.standard_normal()
 test_vec_ops_same = np.zeros(test_vec_ops_n)
 test_vec_ops_same.fill(test_vec_ops_sc1)
-test_vec_ops_mean = np.mean(test_vec_ops_v1)
+test_vec_ops_pos_mean = np.mean(test_vec_ops_pos_v1)
 test_vec_ops_norm_2 = np.linalg.norm(test_vec_ops_v1, 2)
 test_vec_ops_norm_inf = np.linalg.norm(test_vec_ops_v1, np.inf)
 test_vec_ops_norm_inf_scaled = np.linalg.norm(test_vec_ops_v1 * test_vec_ops_v2, np.inf)
@@ -166,6 +167,7 @@ data = {'test_sp_matrix_A': test_sp_matrix_A,
         'test_vec_ops_v1': test_vec_ops_v1,
         'test_vec_ops_v2': test_vec_ops_v2,
         'test_vec_ops_v3': test_vec_ops_v3,
+        'test_vec_ops_pos_v1': test_vec_ops_pos_v1,
         'test_vec_ops_neg_v1': test_vec_ops_neg_v1,
         'test_vec_ops_neg_v2': test_vec_ops_neg_v2,
         'test_vec_ops_neg_v3': test_vec_ops_neg_v3,
@@ -175,7 +177,7 @@ data = {'test_sp_matrix_A': test_sp_matrix_A,
         'test_vec_ops_sc2': test_vec_ops_sc2,
         'test_vec_ops_sc3': test_vec_ops_sc3,
         'test_vec_ops_same': test_vec_ops_same,
-        'test_vec_ops_mean': test_vec_ops_mean,
+        'test_vec_ops_pos_mean': test_vec_ops_pos_mean,
         'test_vec_ops_norm_2': test_vec_ops_norm_2,
         'test_vec_ops_norm_inf': test_vec_ops_norm_inf,
         'test_vec_ops_norm_inf_scaled': test_vec_ops_norm_inf_scaled,

--- a/tests/lin_alg/testcases/test_vector_math_ops.cpp
+++ b/tests/lin_alg/testcases/test_vector_math_ops.cpp
@@ -426,63 +426,69 @@ TEST_CASE("Vector: Elementwise bound vector", "[vector],[operation]")
   }
 }
 
-TEST_CASE("Vector: Mean assuming positive")
-{
-  lin_alg_sols_data_ptr data{generate_problem_lin_alg_sols_data()};
-
-  SECTION("Easy computation")
-  {
-    OSQPVectorf_ptr vn{OSQPVectorf_new(data->test_vec_ops_vn, data->test_vec_ops_n)};
-
-    OSQPFloat mean = OSQPVectorf_pos_mean(vn.get());
-
-    mu_assert("Mean computation failed",
-              c_absval(mean - data->test_vec_ops_n) < TESTS_TOL);
-  }
-
-  SECTION("Full vector")
-  {
-    OSQPVectorf_ptr v1{OSQPVectorf_new(data->test_vec_ops_pos_v1, data->test_vec_ops_n)};
-
-    OSQPFloat mean = OSQPVectorf_pos_mean(v1.get());
-
-    mu_assert("Mean computation failed",
-              c_absval(mean - data->test_vec_ops_pos_mean) < TESTS_TOL);
-  }
-
-  SECTION("Single element")
-  {
-    OSQPVectorf_ptr v1{OSQPVectorf_new(data->test_vec_ops_pos_v1, 1)};
-
-    OSQPFloat mean = OSQPVectorf_pos_mean(v1.get());
-
-    mu_assert("Mean computation failed",
-              c_absval(mean - data->test_vec_ops_pos_v1[0]) < TESTS_TOL);
-  }
-
-  SECTION("No data")
-  {
-    OSQPVectorf_ptr v1{OSQPVectorf_malloc(0)};
-
-    OSQPFloat mean = OSQPVectorf_pos_mean(v1.get());
-
-    mu_assert("Mean computation failed",
-              c_absval(mean - 0.0) < TESTS_TOL);
-  }
-}
-
 TEST_CASE("Vector: Norms")
 {
   lin_alg_sols_data_ptr data{generate_problem_lin_alg_sols_data()};
 
   // Create all the vectors we will use
+  OSQPVectorf_ptr vn{OSQPVectorf_new(data->test_vec_ops_vn, data->test_vec_ops_n)};
   OSQPVectorf_ptr v1{OSQPVectorf_new(data->test_vec_ops_v1, data->test_vec_ops_n)};
   OSQPVectorf_ptr v2{OSQPVectorf_new(data->test_vec_ops_v2, data->test_vec_ops_n)};
   OSQPVectorf_ptr v3{OSQPVectorf_new(data->test_vec_ops_v3, data->test_vec_ops_n)};
+  OSQPVectorf_ptr pv1{OSQPVectorf_new(data->test_vec_ops_pos_v1, data->test_vec_ops_n)};
   OSQPVectorf_ptr nv1{OSQPVectorf_new(data->test_vec_ops_neg_v1, data->test_vec_ops_n)};
   OSQPVectorf_ptr nv2{OSQPVectorf_new(data->test_vec_ops_neg_v2, data->test_vec_ops_n)};
   OSQPVectorf_ptr nv3{OSQPVectorf_new(data->test_vec_ops_neg_v3, data->test_vec_ops_n)};
   OSQPVectorf_ptr result{OSQPVectorf_malloc(data->test_vec_ops_n)};
+
+  SECTION("1-norm: Easy computation")
+  {
+    OSQPFloat asum = OSQPVectorf_norm_1(vn.get());
+    OSQPFloat ref  = data->test_vec_ops_n * data->test_vec_ops_n;
+
+    mu_assert("1-norm computation failed",
+              c_absval(asum - ref) < TESTS_TOL);
+  }
+
+  SECTION("1-norm: Full negative vector")
+  {
+    OSQPFloat asum = OSQPVectorf_norm_1(nv1.get());
+    OSQPFloat ref  = data->test_vec_ops_neg_norm_1;
+
+    mu_assert("1-norm computation failed",
+              c_absval(asum - ref) < TESTS_TOL);
+  }
+
+  SECTION("1-norm: Full positive vector")
+  {
+    OSQPFloat asum = OSQPVectorf_norm_1(pv1.get());
+    OSQPFloat ref  = data->test_vec_ops_pos_norm_1;
+
+    mu_assert("1-norm computation failed",
+              c_absval(asum - ref) < TESTS_TOL);
+  }
+
+  SECTION("1-norm: Single element")
+  {
+    OSQPVectorf_ptr sv1{OSQPVectorf_new(data->test_vec_ops_pos_v1, 1)};
+
+    OSQPFloat asum = OSQPVectorf_norm_1(sv1.get());
+    OSQPFloat ref  = data->test_vec_ops_pos_v1[0];
+
+    mu_assert("1-norm computation failed",
+              c_absval(asum - ref) < TESTS_TOL);
+  }
+
+  SECTION("1-norm: No data")
+  {
+    OSQPVectorf_ptr ev1{OSQPVectorf_new(data->test_vec_ops_pos_v1, 0)};
+
+    OSQPFloat asum = OSQPVectorf_norm_1(ev1.get());
+    OSQPFloat ref  = 0.0;
+
+    mu_assert("1-norm computation failed",
+              c_absval(asum - ref) < TESTS_TOL );
+  }
 
 #ifdef OSQP_ALGEBRA_BUILTIN
   SECTION("2-norm")

--- a/tests/lin_alg/testcases/test_vector_math_ops.cpp
+++ b/tests/lin_alg/testcases/test_vector_math_ops.cpp
@@ -426,7 +426,7 @@ TEST_CASE("Vector: Elementwise bound vector", "[vector],[operation]")
   }
 }
 
-TEST_CASE("Vector: Mean")
+TEST_CASE("Vector: Mean assuming positive")
 {
   lin_alg_sols_data_ptr data{generate_problem_lin_alg_sols_data()};
 
@@ -434,7 +434,7 @@ TEST_CASE("Vector: Mean")
   {
     OSQPVectorf_ptr vn{OSQPVectorf_new(data->test_vec_ops_vn, data->test_vec_ops_n)};
 
-    OSQPFloat mean = OSQPVectorf_mean(vn.get());
+    OSQPFloat mean = OSQPVectorf_pos_mean(vn.get());
 
     mu_assert("Mean computation failed",
               c_absval(mean - data->test_vec_ops_n) < TESTS_TOL);
@@ -442,29 +442,29 @@ TEST_CASE("Vector: Mean")
 
   SECTION("Full vector")
   {
-    OSQPVectorf_ptr v1{OSQPVectorf_new(data->test_vec_ops_v1, data->test_vec_ops_n)};
+    OSQPVectorf_ptr v1{OSQPVectorf_new(data->test_vec_ops_pos_v1, data->test_vec_ops_n)};
 
-    OSQPFloat mean = OSQPVectorf_mean(v1.get());
+    OSQPFloat mean = OSQPVectorf_pos_mean(v1.get());
 
     mu_assert("Mean computation failed",
-              c_absval(mean - data->test_vec_ops_mean) < TESTS_TOL);
+              c_absval(mean - data->test_vec_ops_pos_mean) < TESTS_TOL);
   }
 
   SECTION("Single element")
   {
-    OSQPVectorf_ptr v1{OSQPVectorf_new(data->test_vec_ops_v1, 1)};
+    OSQPVectorf_ptr v1{OSQPVectorf_new(data->test_vec_ops_pos_v1, 1)};
 
-    OSQPFloat mean = OSQPVectorf_mean(v1.get());
+    OSQPFloat mean = OSQPVectorf_pos_mean(v1.get());
 
     mu_assert("Mean computation failed",
-              c_absval(mean - data->test_vec_ops_v1[0]) < TESTS_TOL);
+              c_absval(mean - data->test_vec_ops_pos_v1[0]) < TESTS_TOL);
   }
 
   SECTION("No data")
   {
     OSQPVectorf_ptr v1{OSQPVectorf_malloc(0)};
 
-    OSQPFloat mean = OSQPVectorf_mean(v1.get());
+    OSQPFloat mean = OSQPVectorf_pos_mean(v1.get());
 
     mu_assert("Mean computation failed",
               c_absval(mean - 0.0) < TESTS_TOL);

--- a/tests/no_active_set/test_no_active_set.cpp
+++ b/tests/no_active_set/test_no_active_set.cpp
@@ -35,8 +35,8 @@ TEST_CASE( "No active set", "[optimization][no active set]" )
   std::tie( polish, expectedPolishStatus ) =
       GENERATE( table<OSQPInt, OSQPInt>(
           { /* first is polish enabled, second is expected status */
-            std::make_tuple( 0, OSQP_POLISHING_UNPERFORMED ),
-            std::make_tuple( 1, OSQP_POLISH_NO_ACTIVE_SET ) } ) );
+            std::make_tuple( 0, OSQP_POLISH_NOT_PERFORMED ),
+            std::make_tuple( 1, OSQP_POLISH_NO_ACTIVE_SET_FOUND ) } ) );
 
   settings->polishing = polish;
   settings->polish_refine_iter = 4;

--- a/tests/no_active_set/test_no_active_set.cpp
+++ b/tests/no_active_set/test_no_active_set.cpp
@@ -29,7 +29,16 @@ TEST_CASE( "No active set", "[optimization][no active set]" )
   settings->verbose = 1;
 
   /* Test with and without polishing */
-  settings->polishing = GENERATE(0, 1);
+  OSQPInt polish;
+  OSQPInt expectedPolishStatus;
+
+  std::tie( polish, expectedPolishStatus ) =
+      GENERATE( table<OSQPInt, OSQPInt>(
+          { /* first is polish enabled, second is expected status */
+            std::make_tuple( 0, OSQP_POLISHING_UNPERFORMED ),
+            std::make_tuple( 1, OSQP_POLISH_NO_ACTIVE_SET ) } ) );
+
+  settings->polishing = polish;
   settings->polish_refine_iter = 4;
 
   /* Test all possible linear system solvers in this test case */
@@ -62,4 +71,8 @@ TEST_CASE( "No active set", "[optimization][no active set]" )
   mu_assert("Unconstrained test solve: Error in objective value!",
             c_absval(solver->info->obj_val - sols_data->obj_value_test) <
             TESTS_TOL);
+
+  // Check polishing status
+  mu_assert("Unconstrained test solve: Error in polish status!",
+            solver->info->status_polish == expectedPolishStatus);
 }

--- a/tests/unconstrained/test_unconstrained.cpp
+++ b/tests/unconstrained/test_unconstrained.cpp
@@ -35,8 +35,8 @@ TEST_CASE("Unconstrained solve", "[unconstrained],[solve]")
   std::tie( polish, expectedPolishStatus ) =
       GENERATE( table<OSQPInt, OSQPInt>(
           { /* first is polish enabled, second is expected status */
-            std::make_tuple( 0, OSQP_POLISHING_UNPERFORMED ),
-            std::make_tuple( 1, OSQP_POLISH_NO_ACTIVE_SET ) } ) );
+            std::make_tuple( 0, OSQP_POLISH_NOT_PERFORMED ),
+            std::make_tuple( 1, OSQP_POLISH_NO_ACTIVE_SET_FOUND ) } ) );
 
   settings->polishing = polish;
   settings->polish_refine_iter = 4;

--- a/tests/unconstrained/test_unconstrained.cpp
+++ b/tests/unconstrained/test_unconstrained.cpp
@@ -29,7 +29,16 @@ TEST_CASE("Unconstrained solve", "[unconstrained],[solve]")
   settings->verbose = 1;
 
   /* Test with and without polishing */
-  settings->polishing = GENERATE(0, 1);
+  OSQPInt polish;
+  OSQPInt expectedPolishStatus;
+
+  std::tie( polish, expectedPolishStatus ) =
+      GENERATE( table<OSQPInt, OSQPInt>(
+          { /* first is polish enabled, second is expected status */
+            std::make_tuple( 0, OSQP_POLISHING_UNPERFORMED ),
+            std::make_tuple( 1, OSQP_POLISH_NO_ACTIVE_SET ) } ) );
+
+  settings->polishing = polish;
   settings->polish_refine_iter = 4;
 
   /* Test all possible linear system solvers in this test case */
@@ -62,4 +71,8 @@ TEST_CASE("Unconstrained solve", "[unconstrained],[solve]")
   mu_assert("Unconstrained test solve: Error in objective value!",
             c_absval(solver->info->obj_val - sols_data->obj_value_test) <
             TESTS_TOL);
+
+  // Check polishing status
+  mu_assert("Unconstrained test solve: Error in polish status!",
+            solver->info->status_polish == expectedPolishStatus);
 }


### PR DESCRIPTION
Polishing really only makes logical sense when there is an active set to polish against, so to prevent issues with the linear algebra when the A matrix is 0, just don't polish the solution if there is no active set. This is shown to the user through a notification and a new return status for the solution polishing variable:

```
-----------------------------------------------------------------
        OSQP v0.0.0  -  Operator Splitting QP Solver
           (c) Bartolomeo Stellato,  Goran Banjac
     University of Oxford  -  Stanford University 2021
-----------------------------------------------------------------
problem:  variables n = 5, constraints m = 0
       nnz(P) + nnz(A) = 5
settings: algebra = Built-in,
       linear system solver = QDLDL v0.1.6,
       eps_abs = 1.0e-05, eps_rel = 1.0e-05,
       eps_prim_inf = 1.0e-04, eps_dual_inf = 1.0e-04,
       rho = 1.00e-01 (adaptive),
       sigma = 1.00e-06, alpha = 1.60, max_iter = 4000
       check_termination: on (interval 25),
       time_limit: 1.00e+10 sec,
       scaling: on, scaled_termination: off
       warm starting: on, polishing: on, 
iter   objective    prim res   dual res   rho        time
1  -1.2294e+01   0.00e+00   1.42e+00   1.00e-01   8.11e-05s
25  -1.9210e+01   0.00e+00   6.72e-06   1.00e-01   1.05e-04s
Polishing skipped - no active set detected at optimal point

status:               solved
solution polishing:   skipped
number of iterations: 25
optimal objective:    -19.2098
run time:             1.11e-04s
optimal rho estimate: 1.00e-06
```

This PR also renames the `OSQPVectorf_mean` function to `OSQPVectorf_pos_mean` to make clear there is an assumption that all values of the vector are positive. This is because assuming all positive values allows us to optimize both BLAS_based backends and the builtin backend (BLAS backends can call `asum` and the builtin can avoid a call to `abs`). We can do this because we only ever want the average of a positive vector - since the vector contains the infinity norms of the matrix columns of P.