### PR TITLE
Allow CUDA to be fully statically linked

### DIFF
--- a/algebra/cuda/CMakeLists.txt
+++ b/algebra/cuda/CMakeLists.txt
@@ -12,10 +12,10 @@ target_sources(OSQPLIB PRIVATE ${SRC_FILES})
 
 target_include_directories(OSQPLIB PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} include lin_sys/indirect)
 
-option(OSQP_CUDA_STATIC_LINKAGE "Statically link all CUDA libraries" OFF)
-mark_as_advanced(OSQP_CUDA_STATIC_LINKAGE)
+option(OSQP_CUDA_STATIC_LINKING "Statically link all CUDA libraries (WARNING: This will greatly increase the file size of the library)" OFF)
+mark_as_advanced(OSQP_CUDA_STATIC_LINKING)
 
-if(OSQP_CUDA_STATIC_LINKAGE)
+if(OSQP_CUDA_STATIC_LINKING)
   message(STATUS "Statically linking CUDA libraries")
 
   # cublasLt_static is a dependency of cublas_static.

--- a/algebra/cuda/CMakeLists.txt
+++ b/algebra/cuda/CMakeLists.txt
@@ -12,4 +12,14 @@ target_sources(OSQPLIB PRIVATE ${SRC_FILES})
 
 target_include_directories(OSQPLIB PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} include lin_sys/indirect)
 
-target_link_libraries(OSQPLIB cublas cusparse)
+option(OSQP_CUDA_STATIC_LINKAGE "Statically link all CUDA libraries" OFF)
+mark_as_advanced(OSQP_CUDA_STATIC_LINKAGE)
+
+if(OSQP_CUDA_STATIC_LINKAGE)
+  message(STATUS "Statically linking CUDA libraries")
+
+  # cublasLt_static is a dependency of cublas_static.
+  target_link_libraries(OSQPLIB cublas_static cusparse_static cublasLt_static)
+else()
+  target_link_libraries(OSQPLIB cublas cusparse)
+endif()


### PR DESCRIPTION
This adds a new option `OSQP_CUDA_STATIC_LINKAGE` that will statically link against the CUDA numerical libraries, meaning all CUDA libraries are now statically linked. This removes the need for a CUDA runtime on the computer that runs the library.