### PR TITLE
CI: Run all tests compiled for a configuration

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -33,6 +33,7 @@ jobs:
 
       env:
         OSQP_BUILD_DIR_PREFIX: ${{ github.workspace }}/build
+        CTEST_OUTPUT_ON_FAILURE: 1
 
       steps:
         - uses: actions/checkout@v2
@@ -83,7 +84,7 @@ jobs:
 
         - name: Test
           run: |
-            cmake --build $OSQP_BUILD_DIR_PREFIX --target test -- ARGS="--output-on-failure"
+            cmake --build $OSQP_BUILD_DIR_PREFIX --target test
 
         - name: Generate coverage
           uses: imciner2/run-lcov@v1

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -81,10 +81,9 @@ jobs:
                   -DOSQP_ALGEBRA_BACKEND=${{ matrix.algebra }}
             cmake --build $OSQP_BUILD_DIR_PREFIX
 
-
         - name: Test
           run: |
-            $OSQP_BUILD_DIR_PREFIX/out/osqp_tester
+            cmake --build $OSQP_BUILD_DIR_PREFIX --target test -- ARGS="--output-on-failure"
 
         - name: Generate coverage
           uses: imciner2/run-lcov@v1

--- a/.github/workflows/main-cuda.yml
+++ b/.github/workflows/main-cuda.yml
@@ -31,6 +31,7 @@ jobs:
 
       env:
         OSQP_BUILD_DIR_PREFIX: ${{ github.workspace }}/build
+        CTEST_OUTPUT_ON_FAILURE: 1
 
       steps:
         - uses: actions/checkout@v2
@@ -72,5 +73,5 @@ jobs:
 
         - name: Test
           run: |
-            cmake --build $OSQP_BUILD_DIR_PREFIX --target test -- ARGS="--output-on-failure"
+            cmake --build $OSQP_BUILD_DIR_PREFIX --target test
 

--- a/.github/workflows/main-cuda.yml
+++ b/.github/workflows/main-cuda.yml
@@ -29,6 +29,9 @@ jobs:
           # See https://github.com/conda-incubator/setup-miniconda#IMPORTANT
           shell: bash -l {0}
 
+      env:
+        OSQP_BUILD_DIR_PREFIX: ${{ github.workspace }}/build
+
       steps:
         - uses: actions/checkout@v2
           with:
@@ -57,15 +60,17 @@ jobs:
 
         - name: Build
           run: |
-            cmake -G "${{ matrix.cmake_generator }}" -S . -B build ${{ matrix.cmake_flags }}
-            cmake --build build
+            cmake -G "${{ matrix.cmake_generator }}" \
+                  -S . -B $OSQP_BUILD_DIR_PREFIX \
+                  ${{ matrix.cmake_flags }}
+            cmake --build $OSQP_BUILD_DIR_PREFIX
 
         # useful for inspecting the OSQP version information
         - name: OSQP Demo
           run: |
-            ./build/out/osqp_demo
+            $OSQP_BUILD_DIR_PREFIX/out/osqp_demo
 
         - name: Test
           run: |
-            ./build/out/osqp_tester
+            cmake --build $OSQP_BUILD_DIR_PREFIX --target test -- ARGS="--output-on-failure"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,7 +108,7 @@ jobs:
 
         - name: Test
           run: |
-            $OSQP_BUILD_DIR_PREFIX/out/osqp_tester
+            cmake --build $OSQP_BUILD_DIR_PREFIX --target test -- ARGS="--output-on-failure"
 
         - name: Codegen compilation test
           run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,7 @@ jobs:
 
       env:
         OSQP_BUILD_DIR_PREFIX: ${{ github.workspace }}/build
+        CTEST_OUTPUT_ON_FAILURE: 1
 
       steps:
         - uses: actions/checkout@v2
@@ -108,7 +109,7 @@ jobs:
 
         - name: Test
           run: |
-            cmake --build $OSQP_BUILD_DIR_PREFIX --target test -- ARGS="--output-on-failure"
+            cmake --build $OSQP_BUILD_DIR_PREFIX --target test
 
         - name: Codegen compilation test
           run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,10 +30,13 @@ jobs:
           include:
             - os: ubuntu-latest
               cmake_generator: "Unix Makefiles"
+              test_target: "test"
             - os: macos-latest
               cmake_generator: "Unix Makefiles"
+              test_target: "test"
             - os: windows-2022
               cmake_generator: "Visual Studio 17 2022"
+              test_target: "RUN_TESTS"
 
       defaults:
         run:
@@ -109,7 +112,7 @@ jobs:
 
         - name: Test
           run: |
-            cmake --build $OSQP_BUILD_DIR_PREFIX --target test
+            cmake --build $OSQP_BUILD_DIR_PREFIX --target ${{ matrix.test_target }}
 
         - name: Codegen compilation test
           run: |

--- a/.github/workflows/mkl.yaml
+++ b/.github/workflows/mkl.yaml
@@ -113,4 +113,4 @@ jobs:
 
         - name: Test
           run: |
-            $OSQP_BUILD_DIR_PREFIX/out/osqp_tester
+            cmake --build $OSQP_BUILD_DIR_PREFIX --target test -- ARGS="--output-on-failure"

--- a/.github/workflows/mkl.yaml
+++ b/.github/workflows/mkl.yaml
@@ -42,6 +42,7 @@ jobs:
 
       env:
         OSQP_BUILD_DIR_PREFIX: ${{ github.workspace }}/build
+        CTEST_OUTPUT_ON_FAILURE: 1
 
       steps:
         - uses: actions/checkout@v2
@@ -113,4 +114,4 @@ jobs:
 
         - name: Test
           run: |
-            cmake --build $OSQP_BUILD_DIR_PREFIX --target test -- ARGS="--output-on-failure"
+            cmake --build $OSQP_BUILD_DIR_PREFIX --target test

--- a/.github/workflows/mkl.yaml
+++ b/.github/workflows/mkl.yaml
@@ -29,10 +29,13 @@ jobs:
           include:
             - os: ubuntu-latest
               cmake_generator: "Unix Makefiles"
+              test_target: "test"
             - os: macos-latest
               cmake_generator: "Unix Makefiles"
+              test_target: "test"
             - os: windows-2022
               cmake_generator: "Visual Studio 17 2022"
+              test_target: "RUN_TESTS"
 
       defaults:
         run:
@@ -114,4 +117,4 @@ jobs:
 
         - name: Test
           run: |
-            cmake --build $OSQP_BUILD_DIR_PREFIX --target test
+            cmake --build $OSQP_BUILD_DIR_PREFIX --target ${{ matrix.test_target }}


### PR DESCRIPTION
Instead of individually calling the tester, just use the ctest wrapper to call all the tests. Before this change we were skipping the linear algebra tests because they are now a separate tester executable, so with this change we restore the linear algebra tests.