### PR TITLE
Add function to populate fields of OSQPCodegenDefines struct

### DIFF
--- a/examples/osqp_codegen_demo.c
+++ b/examples/osqp_codegen_demo.c
@@ -79,11 +79,8 @@ int main(int argc, char *argv[]) {
   /* Test codegen */
   OSQPCodegenDefines *defs = (OSQPCodegenDefines *)calloc(1, sizeof(OSQPCodegenDefines));
 
-  defs->float_type = 0;         /* Use doubles */
-  defs->printing_enable = 0;    /* Don't enable printing */
-  defs->profiling_enable = 0;   /* Don't enable profiling */
-  defs->interrupt_enable = 0;   /* Don't enable interrupts */
-  defs->derivatives_enable = 0; /* Don't enable derivatives */
+  /* Get the default codegen options */
+  osqp_set_default_codegen_defines( defs );
 
   /* Sample with vector update only */
   defs->embedded_mode = 1;

--- a/include/public/osqp_api_functions.h
+++ b/include/public/osqp_api_functions.h
@@ -50,6 +50,13 @@ OSQP_API void osqp_get_dimensions(OSQPSolver* solver,
 
 
 /**
+ * Set default codegen define values.
+ * Assumes defines is already allocated in memory.
+ * @param defines OSQPCodegenDefines structure
+ */
+OSQP_API void osqp_set_default_codegen_defines(OSQPCodegenDefines* defines);
+
+/**
  * Set default settings from osqp_api_constants.h file.
  * Assumes settings already allocated in memory.
  * @param settings OSQPSettings structure

--- a/src/osqp_api.c
+++ b/src/osqp_api.c
@@ -82,7 +82,26 @@ void osqp_get_dimensions(OSQPSolver* solver,
 }
 
 
+void osqp_set_default_codegen_defines(OSQPCodegenDefines* defines) {
+
+  /* Avoid working with a null pointer */
+  if (!defines)
+    return;
+
+  defines->embedded_mode      = 1;  /* Default to vector updates only */
+  defines->float_type         = 0;  /* Default to double */
+  defines->printing_enable    = 0;  /* Default to no printing */
+  defines->profiling_enable   = 0;  /* Default to no timing */
+  defines->interrupt_enable   = 0;  /* Default to no interrupts */
+  defines->derivatives_enable = 0;  /* Default to no derivatives */
+}
+
+
 void osqp_set_default_settings(OSQPSettings* settings) {
+
+  /* Avoid working with a null pointer */
+  if (!settings)
+    return;
 
   settings->device = 0;                                      /* device identifier */
   settings->linsys_solver  = osqp_algebra_default_linsys();  /* linear system solver */

--- a/tests/codegen/test_codegen.cpp
+++ b/tests/codegen/test_codegen.cpp
@@ -38,12 +38,9 @@ TEST_CASE("Basic codegen", "[codegen]")
   settings->warm_starting = 0;
 
   // Define codegen settings
+  osqp_set_default_codegen_defines(defines.get());
   defines->embedded_mode = 1;      // vector update
-  defines->float_type = 1;         // floats
-  defines->printing_enable = 0;    // no printing
-  defines->profiling_enable = 0;   // no timing
-  defines->interrupt_enable = 0;   // no interrupts
-  defines->derivatives_enable = 0; // no derivatives
+  defines->float_type    = 1;      // floats
 
   // Setup solver
   exitflag = osqp_setup(&tmpSolver, data->P, data->q,
@@ -95,12 +92,9 @@ TEST_CASE("Codegen: Data export", "[codegen],[unconstrained],[lp],[qp],[nonconve
   settings->warm_starting = 0;
 
   // Define codegen settings
+  osqp_set_default_codegen_defines(defines.get());
   defines->embedded_mode = 1;      // vector update
-  defines->float_type = 1;         // floats
-  defines->printing_enable = 0;    // no printing
-  defines->profiling_enable = 0;   // no timing
-  defines->interrupt_enable = 0;   // no interrupts
-  defines->derivatives_enable = 0; // no derivatives
+  defines->float_type    = 1;      // floats
 
   SECTION( "Unconstrained" ) {
     OSQPInt embedded;
@@ -254,12 +248,7 @@ TEST_CASE("Codegen: defines", "[codegen]")
   settings->warm_starting = 0;
 
   // Define codegen settings
-  defines->embedded_mode = 1;      // vector update
-  defines->float_type = 1;         // floats
-  defines->printing_enable = 0;    // no printing
-  defines->profiling_enable = 0;   // no timing
-  defines->interrupt_enable = 0;   // no interrupts
-  defines->derivatives_enable = 0; // no derivatives
+  osqp_set_default_codegen_defines(defines.get());
 
   // Setup solver
   exitflag = osqp_setup(&tmpSolver, data->P, data->q,
@@ -434,12 +423,9 @@ TEST_CASE("Codegen: Error propgatation", "[codegen]")
   settings->warm_starting = 0;
 
   // Define codegen settings
+  osqp_set_default_codegen_defines(defines.get());
   defines->embedded_mode = 1;      // vector update
-  defines->float_type = 1;         // floats
-  defines->printing_enable = 0;    // no printing
-  defines->profiling_enable = 0;   // no timing
-  defines->interrupt_enable = 0;   // no interrupts
-  defines->derivatives_enable = 0; // no derivatives
+  defines->float_type    = 1;      // floats
 
   // Setup solver
   exitflag = osqp_setup(&tmpSolver, data->P, data->q,
@@ -551,12 +537,9 @@ TEST_CASE("Codegen: Settings", "[codegen],[settings]")
   settings->warm_starting = 0;
 
   // Define codegen settings
+  osqp_set_default_codegen_defines(defines.get());
   defines->embedded_mode = 1;      // vector update
-  defines->float_type = 1;         // floats
-  defines->printing_enable = 0;    // no printing
-  defines->profiling_enable = 0;   // no timing
-  defines->interrupt_enable = 0;   // no interrupts
-  defines->derivatives_enable = 0; // no derivatives
+  defines->float_type    = 1;      // floats
 
   // scaling changes some allocations (some vectors become null)
   SECTION( "Scaling setting" ) {


### PR DESCRIPTION
This allows for user code to have a way to initialize all fields of the struct, and be safe against possible future changes, such as adding fields to the struct.

@vineetbansal this should now be used in the interfaces to allocate default settings in a safe manner.