### PR TITLE
Add diagonal preconditioner to MKL CG

### DIFF
--- a/algebra/_common/csc_math.c
+++ b/algebra/_common/csc_math.c
@@ -90,6 +90,26 @@ void csc_rmult_diag(OSQPCscMatrix* A, const OSQPFloat* d){
   }
 }
 
+// d = diag(At*diag(D)*A)
+void csc_AtDA_extract_diag(const OSQPCscMatrix* A,
+                           const OSQPFloat*     D,
+                                 OSQPFloat*     d) {
+  OSQPInt    j, i;
+  OSQPInt    n  = A->n;
+  OSQPInt*   Ap = A->p;
+  OSQPInt*   Ai = A->i;
+  OSQPFloat* Ax = A->x;
+
+  // Each entry of output vector is for a column, so cycle over columns
+  for (j = 0; j < n; j++) {
+    d[j] = 0;
+    // Iterate over each entry in the column
+    for (i = Ap[j]; i < Ap[j + 1]; i++) {
+      d[j] += Ax[i]*Ax[i]*D[Ai[i]];
+    }
+  }
+}
+
 //y = alpha*A*x + beta*y, where A is symmetric and only triu is stored
 void csc_Axpy_sym_triu(const OSQPCscMatrix* A,
                        const OSQPFloat*     x,

--- a/algebra/_common/csc_math.h
+++ b/algebra/_common/csc_math.h
@@ -43,6 +43,11 @@ void csc_lmult_diag(OSQPCscMatrix* A, const OSQPFloat* L);
 // A = A*diag(R)
 void csc_rmult_diag(OSQPCscMatrix* A, const OSQPFloat* R);
 
+// d = diag(At*diag(D)*A)
+void csc_AtDA_extract_diag(const OSQPCscMatrix* A,
+                           const OSQPFloat*     D,
+                                 OSQPFloat*     d);
+
 //y = alpha*A*x + beta*y, where A is symmetric and only triu is stored
 void csc_Axpy_sym_triu(const OSQPCscMatrix* A,
                        const OSQPFloat*     x,

--- a/algebra/_common/csc_utils.c
+++ b/algebra/_common/csc_utils.c
@@ -33,6 +33,8 @@ OSQPInt csc_is_eq(OSQPCscMatrix* A,
 
 //========= Internal utility functions  ===========
 
+#ifndef OSQP_EMBEDDED_MODE
+
 static void* csc_malloc(OSQPInt n, OSQPInt size) {
   return c_malloc(n * size);
 }
@@ -40,6 +42,8 @@ static void* csc_malloc(OSQPInt n, OSQPInt size) {
 static void* csc_calloc(OSQPInt n, OSQPInt size) {
   return c_calloc(n, size);
 }
+
+#endif /* OSQP_EMBEDDED_MODE */
 
 static void prea_int_vec_copy(const OSQPInt* a, OSQPInt* b, OSQPInt n) {
   OSQPInt i;
@@ -93,6 +97,8 @@ OSQPInt csc_cumsum(OSQPInt* p, OSQPInt* c, OSQPInt n) {
 //   M->p     = p;
 //   return M;
 // }
+
+#ifndef OSQP_EMBEDDED_MODE
 
 OSQPCscMatrix* csc_spalloc(OSQPInt m,
                            OSQPInt n,
@@ -275,6 +281,8 @@ OSQPCscMatrix* triplet_to_csr(const OSQPCscMatrix* T, OSQPInt* TtoC) {
   return csc_done(C, w, OSQP_NULL, 1);     /* success; free w and return C */
 }
 
+#endif /* OSQP_EMBEDDED_MODE */
+
 void csc_extract_diag(const OSQPCscMatrix* A,
                             OSQPFloat*     d) {
   OSQPInt    i, ptr;
@@ -294,6 +302,8 @@ void csc_extract_diag(const OSQPCscMatrix* A,
     }
   }
 }
+
+#ifndef OSQP_EMBEDDED_MODE
 
 OSQPInt* csc_pinv(const OSQPInt* p, OSQPInt n) {
   OSQPInt  k;
@@ -433,6 +443,8 @@ OSQPCscMatrix* csc_done(OSQPCscMatrix* C,
   }
 }
 
+#endif /* OSQP_EMBEDDED_MODE */
+
 // OSQPCscMatrix* csc_to_triu(OSQPCscMatrix *M) {
 //   OSQPCscMatrix  *M_trip;    // Matrix in triplet format
 //   OSQPCscMatrix  *M_triu;    // Resulting upper triangular matrix
@@ -511,6 +523,7 @@ OSQPCscMatrix* csc_done(OSQPCscMatrix* C,
 //   return M_triu;
 // }
 
+#ifndef OSQP_EMBEDDED_MODE
 
 OSQPCscMatrix* triu_to_csc(OSQPCscMatrix* M) {
     OSQPCscMatrix* M_trip;    // Matrix in triplet format
@@ -610,3 +623,5 @@ OSQPCscMatrix* vstack(OSQPCscMatrix* A, OSQPCscMatrix* B) {
     csc_spfree(M_trip);
     return M;
 }
+
+#endif /* OSQP_EMBEDDED_MODE */

--- a/algebra/_common/csc_utils.c
+++ b/algebra/_common/csc_utils.c
@@ -51,6 +51,11 @@ static void prea_vec_copy(const OSQPFloat* a, OSQPFloat* b, OSQPInt n) {
   for (i = 0; i < n; i++)  b[i] = a[i];
 }
 
+static void float_vec_set_scalar(OSQPFloat* a, OSQPFloat sc, OSQPInt n) {
+  OSQPInt i;
+  for (i = 0; i < n; i++) a[i] = sc;
+}
+
 static void int_vec_set_scalar(OSQPInt* a, OSQPInt sc, OSQPInt n) {
   OSQPInt i;
   for (i = 0; i < n; i++) a[i] = sc;
@@ -268,6 +273,26 @@ OSQPCscMatrix* triplet_to_csr(const OSQPCscMatrix* T, OSQPInt* TtoC) {
     }
   }
   return csc_done(C, w, OSQP_NULL, 1);     /* success; free w and return C */
+}
+
+void csc_extract_diag(const OSQPCscMatrix* A,
+                            OSQPFloat*     d) {
+  OSQPInt    i, ptr;
+  OSQPInt    n  = A->n;
+  OSQPInt*   Ap = A->p;
+  OSQPInt*   Ai = A->i;
+  OSQPFloat* Ax = A->x;
+
+  /* Initialize output vector to 0 */
+  float_vec_set_scalar(d, 0.0, n);
+
+  /* Loop over columns to find when the row index equals column index */
+  for(i = 0; i < n; i++) {
+    for (ptr = Ap[i]; ptr < Ap[i + 1]; ptr++) {
+      if (Ai[ptr] == i)
+        d[i] = Ax[ptr];
+    }
+  }
 }
 
 OSQPInt* csc_pinv(const OSQPInt* p, OSQPInt n) {

--- a/algebra/_common/csc_utils.h
+++ b/algebra/_common/csc_utils.h
@@ -14,6 +14,8 @@ OSQPInt csc_is_eq(OSQPCscMatrix* A, OSQPCscMatrix* B, OSQPFloat tol);
 * Create and free CSC Matrices                                              *
 *****************************************************************************/
 
+#ifndef OSQP_EMBEDDED_MODE
+
 /**
  * Create uninitialized CSC matrix structure
     (uses MALLOC to create inner arrays x, i, p)
@@ -62,10 +64,13 @@ OSQPCscMatrix* csc_done(OSQPCscMatrix* C,
                         void*          w,
                         void*          x,
                         OSQPInt        ok);
+#endif /* OSQP_EMBEDDED_MODE */
 
 /*****************************************************************************
 * Copy Matrices                                                             *
 *****************************************************************************/
+
+#ifndef OSQP_EMBEDDED_MODE
 
 /**
  *  Copy sparse CSC matrix A to output.
@@ -82,10 +87,13 @@ OSQPCscMatrix* csc_copy(const OSQPCscMatrix* A);
 /* Convert sparse CSC to dense (uses MALLOC)*/
 OSQPFloat* csc_to_dns(OSQPCscMatrix* M);
 
+#endif /* OSQP_EMBEDDED_MODE */
+
 /*****************************************************************************
 * Matrices Conversion                                                       *
 *****************************************************************************/
 
+#ifndef OSQP_EMBEDDED_MODE
 
 /**
  * C = compressed-column CSC from matrix T in triplet form
@@ -143,6 +151,7 @@ OSQPCscMatrix* triu_to_csc(OSQPCscMatrix* M);
 OSQPCscMatrix* vstack(OSQPCscMatrix* A,
                       OSQPCscMatrix* B);
 
+#endif /* OSQP_EMBEDDED_MODE */
 
 /*****************************************************************************
 * Extra operations                                                          *
@@ -166,9 +175,12 @@ OSQPCscMatrix* vstack(OSQPCscMatrix* A,
 void csc_extract_diag(const OSQPCscMatrix* A,
                             OSQPFloat*     d);
 
+#ifndef OSQP_EMBEDDED_MODE
+
 /**
  * Compute inverse of permutation matrix stored in the vector p.
  * The computed inverse is also stored in a vector.
+ * Allocates return vector (uses MALLOC)
  */
 OSQPInt* csc_pinv(const OSQPInt* p,
                         OSQPInt  n);
@@ -187,5 +199,6 @@ OSQPCscMatrix* csc_symperm(const OSQPCscMatrix* A,
                                  OSQPInt*       AtoC,
                                  OSQPInt        values);
 
+#endif /* OSQP_EMBEDDED_MODE */
 
 #endif /* ifndef CSC_UTILS_H */

--- a/algebra/_common/csc_utils.h
+++ b/algebra/_common/csc_utils.h
@@ -161,6 +161,12 @@ OSQPCscMatrix* vstack(OSQPCscMatrix* A,
 //                  OSQPInt  n);
 
 /**
+ * Extract main diagonal from matrix A into vector d.
+ */
+void csc_extract_diag(const OSQPCscMatrix* A,
+                            OSQPFloat*     d);
+
+/**
  * Compute inverse of permutation matrix stored in the vector p.
  * The computed inverse is also stored in a vector.
  */

--- a/algebra/_common/lin_sys/qdldl/qdldl_interface.c
+++ b/algebra/_common/lin_sys/qdldl/qdldl_interface.c
@@ -371,7 +371,7 @@ OSQPInt init_linsys_solver_qdldl(qdldl_solver**      sp,
 
 #endif  // OSQP_EMBEDDED_MODE
 
-const char* name_qdldl() {
+const char* name_qdldl(qdldl_solver* s) {
   return "QDLDL v" STRINGIZE(QDLDL_VERSION_MAJOR) "." STRINGIZE(QDLDL_VERSION_MINOR) "." STRINGIZE(QDLDL_VERSION_PATCH);
 }
 

--- a/algebra/_common/lin_sys/qdldl/qdldl_interface.h
+++ b/algebra/_common/lin_sys/qdldl/qdldl_interface.h
@@ -18,7 +18,7 @@ struct qdldl {
      * @name Functions
      * @{
      */
-    const char* (*name)(void);
+    const char* (*name)(struct qdldl* s);
 
     OSQPInt (*solve)(struct qdldl*       self,
                             OSQPVectorf* b,
@@ -118,7 +118,7 @@ OSQPInt init_linsys_solver_qdldl(qdldl_solver**      sp,
  * Get the user-friendly name of the QDLDL solver.
  * @return The user-friendly name
  */
-const char* name_qdldl();
+const char* name_qdldl(qdldl_solver* s);
 
 /**
  * Solve linear system and store result in b

--- a/algebra/_common/reduced_kkt.c
+++ b/algebra/_common/reduced_kkt.c
@@ -49,3 +49,17 @@ void reduced_kkt_diagonal(const OSQPMatrix*  P,
   /* 4th part: Invert the diagonal */
   OSQPVectorf_ew_reciprocal(diag_inv, diag);
 }
+
+
+void reduced_kkt_compute_rhs(const OSQPMatrix*  A,
+                             const OSQPVectorf* rho_vec,
+                                   OSQPVectorf* b1,
+                             const OSQPVectorf* b2,
+                                   OSQPVectorf* work) {
+
+  /* 1st par: Set work = rho.*b2 */
+  OSQPVectorf_ew_prod(work, b2, rho_vec);
+
+  /* 2nd part: Compute b1 = b1 + A' (rho.*b2) */
+  OSQPMatrix_Atxpy(A, work, b1, 1.0, 1.0);
+}

--- a/algebra/_common/reduced_kkt.c
+++ b/algebra/_common/reduced_kkt.c
@@ -57,7 +57,7 @@ void reduced_kkt_compute_rhs(const OSQPMatrix*  A,
                              const OSQPVectorf* b2,
                                    OSQPVectorf* work) {
 
-  /* 1st par: Set work = rho.*b2 */
+  /* 1st part: Set work = rho.*b2 */
   OSQPVectorf_ew_prod(work, b2, rho_vec);
 
   /* 2nd part: Compute b1 = b1 + A' (rho.*b2) */

--- a/algebra/_common/reduced_kkt.c
+++ b/algebra/_common/reduced_kkt.c
@@ -1,0 +1,51 @@
+#include "reduced_kkt.h"
+#include "algebra_matrix.h"
+#include "algebra_vector.h"
+
+
+/*
+ * Compute v = (P + sigma*I + A'*diag(rho)*A)*x
+ */
+void reduced_kkt_mv_times(const OSQPMatrix*  P,
+                          const OSQPMatrix*  A,
+                          const OSQPVectorf* rho_vec,
+                                OSQPFloat    sigma,
+                          const OSQPVectorf* x,
+                                OSQPVectorf* v,
+                                OSQPVectorf* work) {
+
+  /* x and v are successive columns of tmp in the MKL CG, unclear if
+     we can overwrite x, so avoid it by using the work vector. */
+  OSQPMatrix_Axpy(A, x, work, 1.0, 0.0);    /* scratch space for (rho)*A*x */
+  OSQPVectorf_ew_prod(work, work, rho_vec);
+  OSQPVectorf_copy(v, x);
+  OSQPMatrix_Axpy(P, x, v, 1.0, sigma);     /* v = (P + sigma*I) x */
+  OSQPMatrix_Atxpy(A, work, v, 1.0, 1.0);
+}
+
+
+/*
+ * Compute the diagonal and its inverse for
+ *  P + sigma*I + A'*diag(rho)*A
+ */
+void reduced_kkt_diagonal(const OSQPMatrix*  P,
+                          const OSQPMatrix*  A,
+                          const OSQPVectorf* rho_vec,
+                                OSQPFloat    sigma,
+                                OSQPVectorf* diag,
+                                OSQPVectorf* diag_inv) {
+
+  /* 1st part: sigma */
+  OSQPVectorf_set_scalar(diag, sigma);
+
+  /* 2nd part: P matrix diagonal */
+  OSQPMatrix_extract_diag(P, diag_inv);
+  OSQPVectorf_plus(diag, diag, diag_inv);
+
+  /* 3rd part: Diagonal of At*rho*A */
+  OSQPMatrix_AtDA_extract_diag(A, rho_vec, diag_inv);
+  OSQPVectorf_plus(diag, diag, diag_inv);
+
+  /* 4th part: Invert the diagonal */
+  OSQPVectorf_ew_reciprocal(diag_inv, diag);
+}

--- a/algebra/_common/reduced_kkt.h
+++ b/algebra/_common/reduced_kkt.h
@@ -1,0 +1,52 @@
+#ifndef REDUCED_KKT_H_
+#define REDUCED_KKT_H_
+
+#include "algebra_matrix.h"
+#include "algebra_vector.h"
+
+/**
+ * Mathematical functions for performing operations using the reduced
+ * KKT system.
+ */
+
+/**
+ * Compute a matrix-vector multiplication with the matrix from the
+ * reduced KKT:
+ *   v = (P + sigma*I + A'*diag(rho)*A)*x
+ *
+ * @param P       The P matrix in the KKT matrix
+ * @param A       The A matrix in the KKT matrix
+ * @param rho_vec The vector containing the rho values
+ * @param sigma   The value of sigma
+ * @param x       The vector to multiply against
+ * @param v       The output vector
+ * @param work    Temporary work vector (same size as rho_vec)
+ */
+void reduced_kkt_mv_times(const OSQPMatrix*  P,
+                          const OSQPMatrix*  A,
+                          const OSQPVectorf* rho_vec,
+                                OSQPFloat    sigma,
+                          const OSQPVectorf* x,
+                                OSQPVectorf* v,
+                                OSQPVectorf* work);
+
+/**
+ * Compute the diagonal (and its inverse) of the reduced KKT:
+ *   P + sigma*I + A'*diag(rho)*A
+ *
+ * @param P        The P matrix in the KKT matrix
+ * @param A        The A matrix in the KKT matrix
+ * @param rho_vec  The vector containing the rho values
+ * @param sigma    The value of sigma
+ * @param diag     The vector to store the diagonal in
+ * @param diag_inv The vector to store the inverse of the diagonal in
+ */
+void reduced_kkt_diagonal(const OSQPMatrix*  P,
+                          const OSQPMatrix*  A,
+                          const OSQPVectorf* rho_vec,
+                                OSQPFloat    sigma,
+                                OSQPVectorf* diag,
+                                OSQPVectorf* diag_inv);
+
+
+#endif /* REDUCED_SYSTEM_H_ */

--- a/algebra/_common/reduced_kkt.h
+++ b/algebra/_common/reduced_kkt.h
@@ -48,5 +48,24 @@ void reduced_kkt_diagonal(const OSQPMatrix*  P,
                                 OSQPVectorf* diag,
                                 OSQPVectorf* diag_inv);
 
+/**
+ * Compute the right-hand side of the reduced KKT system:
+ *     b1 = b1 + A' (rho.*b2)
+ * where b1 and b2 are the upper and lower parts of the normal KKT
+ * RHS, respectively.
+ *
+ * Note: This function overwrites b1 with the output value.
+ *
+ * @param A        The A matrix in the KKT matrix
+ * @param rho_vec  The vector containing the rho values
+ * @param b1       The upper part of the normal KKT RHS
+ * @param b2       The lower part of the normal KKT RHS
+ * @param work     Temporary work vector (same size as b2)
+ */
+void reduced_kkt_compute_rhs(const OSQPMatrix*  A,
+                             const OSQPVectorf* rho_vec,
+                                   OSQPVectorf* b1,
+                             const OSQPVectorf* b2,
+                                   OSQPVectorf* work);
 
 #endif /* REDUCED_SYSTEM_H_ */

--- a/algebra/builtin/CMakeLists.txt
+++ b/algebra/builtin/CMakeLists.txt
@@ -3,8 +3,6 @@ include(${OSQP_ALGEBRA_ROOT}/_common/lin_sys/qdldl/qdldl.cmake)
 
 if(NOT OSQP_EMBEDDED_MODE)
   set( NON_EMBEDDED_SRC_FILES
-       ../_common/csc_utils.h
-       ../_common/csc_utils.c
        ${LIN_SYS_QDLDL_NON_EMBEDDED_SRC_FILES} )
 endif()
 
@@ -12,6 +10,8 @@ target_sources(
   OSQPLIB
   PRIVATE ../_common/csc_math.h
           ../_common/csc_math.c
+          ../_common/csc_utils.h
+          ../_common/csc_utils.c
           algebra_impl.h
           algebra_libs.c
           vector.c
@@ -36,6 +36,8 @@ if( OSQP_CODEGEN )
        ${CMAKE_CURRENT_SOURCE_DIR}/matrix.c
        ${OSQP_ALGEBRA_ROOT}/_common/csc_math.h
        ${OSQP_ALGEBRA_ROOT}/_common/csc_math.c
+       ${OSQP_ALGEBRA_ROOT}/_common/csc_utils.h
+       ${OSQP_ALGEBRA_ROOT}/_common/csc_utils.c
        ${OSQP_ALGEBRA_ROOT}/_common/kkt.h
        ${OSQP_ALGEBRA_ROOT}/_common/kkt.c
        ${OSQP_ALGEBRA_ROOT}/_common/lin_sys/qdldl/qdldl_interface.h

--- a/algebra/builtin/matrix.c
+++ b/algebra/builtin/matrix.c
@@ -142,6 +142,11 @@ void OSQPMatrix_rmult_diag(OSQPMatrix* A,
   csc_rmult_diag(A->csc, R->values);
 }
 
+void OSQPMatrix_extract_diag(const OSQPMatrix*  A,
+                                   OSQPVectorf* d) {
+  csc_extract_diag(A->csc, OSQPVectorf_data(d));
+}
+
 //y = alpha*A*x + beta*y
 void OSQPMatrix_Axpy(const OSQPMatrix*  A,
                      const OSQPVectorf* x,

--- a/algebra/builtin/matrix.c
+++ b/algebra/builtin/matrix.c
@@ -2,12 +2,11 @@
 #include "lin_alg.h"
 #include "algebra_impl.h"
 #include "csc_math.h"
+#include "csc_utils.h"
 #include "printing.h"
 
 
 #ifndef OSQP_EMBEDDED_MODE
-
-#include "csc_utils.h"
 
 /*  logical test functions ----------------------------------------------------*/
 

--- a/algebra/builtin/matrix.c
+++ b/algebra/builtin/matrix.c
@@ -142,6 +142,12 @@ void OSQPMatrix_rmult_diag(OSQPMatrix* A,
   csc_rmult_diag(A->csc, R->values);
 }
 
+void OSQPMatrix_AtDA_extract_diag(const OSQPMatrix*  A,
+                                  const OSQPVectorf* D,
+                                        OSQPVectorf* d) {
+    csc_AtDA_extract_diag(A->csc, OSQPVectorf_data(D), OSQPVectorf_data(d));
+}
+
 void OSQPMatrix_extract_diag(const OSQPMatrix*  A,
                                    OSQPVectorf* d) {
   csc_extract_diag(A->csc, OSQPVectorf_data(d));

--- a/algebra/cuda/lin_sys/indirect/cuda_pcg.cu
+++ b/algebra/cuda/lin_sys/indirect/cuda_pcg.cu
@@ -203,10 +203,10 @@ OSQPInt cuda_pcg_alg(cudapcg_solver* s,
 }
 
 
-void cuda_pcg_update_precond(cudapcg_solver* s,
-                             OSQPInt         P_updated,
-                             OSQPInt         A_updated,
-                             OSQPInt         R_updated) {
+void cuda_pcg_update_precond_diagonal(cudapcg_solver* s,
+                                      OSQPInt         P_updated,
+                                      OSQPInt         A_updated,
+                                      OSQPInt         R_updated) {
 
   void*      buffer;
   OSQPFloat* tmp;
@@ -258,4 +258,23 @@ void cuda_pcg_update_precond(cudapcg_solver* s,
 
   /* d_diag_precond_inv = 1 / d_diag_precond */
   cuda_vec_reciprocal(s->d_diag_precond_inv, s->d_diag_precond, n);
+}
+
+
+void cuda_pcg_update_precond(cudapcg_solver* s,
+                             OSQPInt         P_updated,
+                             OSQPInt         A_updated,
+                             OSQPInt         R_updated) {
+
+  switch(s->precond_type) {
+  /* No preconditioner, just initialize the inverse vector to all 1s */
+  case OSQP_NO_PRECONDITIONER:
+    cuda_vec_set_sc(s->d_diag_precond_inv, 1.0, s->n);
+    break;
+
+  /* Diagonal preconditioner computation */
+  case OSQP_DIAGONAL_PRECONDITIONER:
+    cuda_pcg_update_precond_diagonal(s, P_updated, A_updated, R_updated);
+    break;
+  }
 }

--- a/algebra/cuda/lin_sys/indirect/cuda_pcg_interface.cu
+++ b/algebra/cuda/lin_sys/indirect/cuda_pcg_interface.cu
@@ -212,8 +212,15 @@ OSQPInt init_linsys_solver_cudapcg(cudapcg_solver**    sp,
 }
 
 
-const char* name_cudapcg() {
-  return "CUDA Preconditioned Conjugate Gradient";
+const char* name_cudapcg(cudapcg_solver* s) {
+  switch(s->precond_type) {
+  case OSQP_NO_PRECONDITIONER:
+    return "CUDA Conjugate Gradient - No preconditioner";
+  case OSQP_DIAGONAL_PRECONDITIONER:
+    return "CUDA Conjugate Gradient - Diagonal preconditioner";
+  }
+
+  return "CUDA Conjugate Gradient - Unknown preconditioner";
 }
 
 

--- a/algebra/cuda/lin_sys/indirect/cuda_pcg_interface.cu
+++ b/algebra/cuda/lin_sys/indirect/cuda_pcg_interface.cu
@@ -273,6 +273,13 @@ void update_settings_linsys_solver_cudapcg(cudapcg_solver*     s,
   s->max_iter            = settings->cg_max_iter;
   s->reduction_threshold = settings->cg_tol_reduction;
   s->tol_fraction        = settings->cg_tol_fraction;
+
+  // Update preconditioner
+  if (s->precond_type != settings->cg_precond) {
+    s->precond_type = settings->cg_precond;
+
+    cuda_pcg_update_precond(s, 1, 1, 1);
+  }
 }
 
 

--- a/algebra/cuda/lin_sys/indirect/cuda_pcg_interface.cu
+++ b/algebra/cuda/lin_sys/indirect/cuda_pcg_interface.cu
@@ -128,6 +128,9 @@ OSQPInt init_linsys_solver_cudapcg(cudapcg_solver**    sp,
   /* Maximum number of PCG iterations */
   s->max_iter = settings->cg_max_iter;
 
+  /* Preconditioner to use */
+  s->precond_type = settings->cg_precond;
+
   /* Tolerance strategy parameters */
   s->reduction_threshold = settings->cg_tol_reduction;
   s->tol_fraction        = settings->cg_tol_fraction;

--- a/algebra/cuda/lin_sys/indirect/cuda_pcg_interface.h
+++ b/algebra/cuda/lin_sys/indirect/cuda_pcg_interface.h
@@ -36,7 +36,7 @@ typedef struct cudapcg_solver_ {
    * @name Functions
    * @{
    */
-  const char* (*name)(void);
+  const char* (*name)(struct cudapcg_solver_* self);
 
   OSQPInt (*solve)(struct cudapcg_solver_* self,
                           OSQPVectorf*     b,
@@ -162,7 +162,7 @@ OSQPInt init_linsys_solver_cudapcg(cudapcg_solver**    sp,
  * Get the user-friendly name of the PCG solver.
  * @return The user-friendly name
  */
-const char* name_cudapcg();
+const char* name_cudapcg(cudapcg_solver* s);
 
 
 OSQPInt solve_linsys_cudapcg(cudapcg_solver* s,

--- a/algebra/cuda/lin_sys/indirect/cuda_pcg_interface.h
+++ b/algebra/cuda/lin_sys/indirect/cuda_pcg_interface.h
@@ -76,8 +76,9 @@ typedef struct cudapcg_solver_ {
   OSQPInt zero_pcg_iters;     ///<  state that counts zero PCG iterations
 
   /* Settings */
-  OSQPInt max_iter;
-  
+  OSQPInt           max_iter;
+  osqp_precond_type precond_type;
+
   /* Residual tolerance strategy parameters */
   OSQPInt    reduction_threshold;
   OSQPFloat  tol_fraction;

--- a/algebra/mkl/CMakeLists.txt
+++ b/algebra/mkl/CMakeLists.txt
@@ -17,6 +17,8 @@ target_sources(
           ../_common/csc_utils.c
           ../_common/kkt.h
           ../_common/kkt.c
+          ../_common/reduced_kkt.h
+          ../_common/reduced_kkt.c
           vector.c
           matrix.c
           algebra_impl.h
@@ -26,7 +28,11 @@ target_sources(
           lin_sys/indirect/mkl-cg_interface.h
           lin_sys/indirect/mkl-cg_interface.c)
 
-target_include_directories(OSQPLIB PRIVATE ../_common ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/lin_sys/direct ${CMAKE_CURRENT_SOURCE_DIR}/lin_sys/indirect)
+target_include_directories(OSQPLIB PRIVATE
+                           ../_common
+                           ${CMAKE_CURRENT_SOURCE_DIR}
+                           ${CMAKE_CURRENT_SOURCE_DIR}/lin_sys/direct
+                           ${CMAKE_CURRENT_SOURCE_DIR}/lin_sys/indirect)
 
 target_include_directories(OSQPLIB PUBLIC $<TARGET_PROPERTY:MKL::MKL,INTERFACE_INCLUDE_DIRECTORIES>)
 target_compile_options(OSQPLIB PUBLIC $<TARGET_PROPERTY:MKL::MKL,INTERFACE_COMPILE_OPTIONS>)

--- a/algebra/mkl/algebra_libs.c
+++ b/algebra/mkl/algebra_libs.c
@@ -56,6 +56,11 @@ OSQPInt osqp_algebra_init_linsys_solver(LinSysSolver**      s,
         return init_linsys_solver_pardiso((pardiso_solver **)s, P, A, rho_vec, settings, polishing);
 
     case OSQP_INDIRECT_SOLVER:
-        return init_linsys_mklcg((mklcg_solver **)s, P, A, rho_vec, settings, polishing);
+        return init_linsys_mklcg((mklcg_solver **) s,
+                                 P, A, rho_vec,
+                                 settings,
+                                 scaled_prim_res,
+                                 scaled_dual_res,
+                                 polishing);
     }
 }

--- a/algebra/mkl/lin_sys/direct/pardiso_interface.c
+++ b/algebra/mkl/lin_sys/direct/pardiso_interface.c
@@ -230,7 +230,7 @@ OSQPInt init_linsys_solver_pardiso(pardiso_solver**    sp,
   return 0;
 }
 
-const char* name_pardiso() {
+const char* name_pardiso(pardiso_solver* s) {
   return "Pardiso";
 }
 

--- a/algebra/mkl/lin_sys/direct/pardiso_interface.h
+++ b/algebra/mkl/lin_sys/direct/pardiso_interface.h
@@ -19,7 +19,7 @@ struct pardiso {
      * @name Functions
      * @{
      */
-    const char* (*name)(void);
+    const char* (*name)(struct pardiso* self);
 
     OSQPInt (*solve)(struct pardiso* self,
                      OSQPVectorf*    b,
@@ -114,7 +114,7 @@ OSQPInt init_linsys_solver_pardiso(pardiso_solver**    sp,
  * Get the user-friendly name of the MKL Pardiso solver.
  * @return The user-friendly name
  */
-const char* name_pardiso();
+const char* name_pardiso(pardiso_solver* s);
 
 
 /**

--- a/algebra/mkl/lin_sys/indirect/mkl-cg_interface.c
+++ b/algebra/mkl/lin_sys/indirect/mkl-cg_interface.c
@@ -165,12 +165,8 @@ OSQPInt solve_linsys_mklcg(mklcg_solver* s,
   OSQPVectorf_view_update(s->r1, b,    0, s->n);
   OSQPVectorf_view_update(s->r2, b, s->n, s->m);
 
-  //Set ywork = rho . *r_2
-  OSQPVectorf_ew_prod(s->ywork, s->r2, s->rho_vec);
-
-  //Compute r_1 = r_1 + A' (rho.*r_2)
-  //This is the RHS for our CG solve
-  OSQPMatrix_Atxpy(s->A, s->ywork, s->r1, 1.0, 1.0);
+  // Compute the RHS for the CG solve
+  reduced_kkt_compute_rhs(s->A, s->rho_vec, s->r1, s->r2, s->ywork);
 
   // Solve the CG system
   // -------------------

--- a/algebra/mkl/lin_sys/indirect/mkl-cg_interface.c
+++ b/algebra/mkl/lin_sys/indirect/mkl-cg_interface.c
@@ -11,14 +11,17 @@ MKL_INT cg_solver_init(mklcg_solver* s) {
   dcg_init(&mkln, NULL, NULL, &rci_request,
            s->iparm, s->dparm, OSQPVectorf_data(s->tmp));
 
-  //Set MKL control parameters
-  s->iparm[7] = 1;        // maximum iteration stopping test
-  s->iparm[8] = 0;        // residual stopping test
-  s->iparm[9] = 0;        // user defined stopping test
-  s->dparm[0] = 1.E-5;    // relative tolerance (default)
+  // Set MKL control parameters
+  s->iparm[4] = s->max_iter; // Maximum number of iterations
+  s->iparm[7] = 1;           // Enable maximum iteration stopping test
+  s->iparm[8] = 0;           // Disable residual stopping test
+  s->iparm[9] = 0;           // Disable user defined stopping test
 
   // Enable the preconditioner if requested
   s->iparm[10] = (s->precond_type == OSQP_NO_PRECONDITIONER) ? 0 : 1;
+
+  // Relative tolerance (default)
+  s->dparm[0] = 1.E-5;
 
   //returns -1 for dcg failure, 0 otherwise
   dcg_check(&mkln, NULL, NULL, &rci_request,
@@ -126,6 +129,9 @@ OSQPInt init_linsys_mklcg(mklcg_solver**      sp,
 
   // Assign preconditioner
   s->precond_type = settings->cg_precond;
+
+  // Assign iteration limit
+  s->max_iter = settings->cg_max_iter;
 
   //Don't know the thread count.  Just use
   //the same thing as the pardiso solver
@@ -258,6 +264,10 @@ void update_settings_linsys_solver_mklcg(struct mklcg_solver_* s,
     // Compute the new preconditioner
     cg_update_precond(s);
   }
+
+  // Maximum number of iterations
+  s->max_iter = settings->cg_max_iter;
+  s->iparm[4] = settings->cg_max_iter;
 
   //returns -1 for dcg failure, 0 otherwise
   dcg_check(&mkln, NULL, NULL, &rci_request,

--- a/algebra/mkl/lin_sys/indirect/mkl-cg_interface.c
+++ b/algebra/mkl/lin_sys/indirect/mkl-cg_interface.c
@@ -1,7 +1,36 @@
 #include "algebra_impl.h"
+#include "algebra_vector.h"
 #include "reduced_kkt.h"
 #include "mkl-cg_interface.h"
 #include <mkl_rci.h>
+
+OSQPFloat cg_compute_tolerance(OSQPInt    admm_iter,
+                               OSQPFloat  rhs_norm,
+                               OSQPFloat  scaled_prim_res,
+                               OSQPFloat  scaled_dual_res,
+                               OSQPFloat  reduction_factor,
+                               OSQPFloat* eps_prev) {
+
+  OSQPFloat eps = 1.0;
+
+  if (admm_iter == 1) {
+    // In case rhs = 0.0 we don't want to set eps_prev to 0.0
+    if (rhs_norm < OSQP_CG_TOL_MIN)
+      *eps_prev = 1.0;
+    else
+      *eps_prev = rhs_norm * reduction_factor;
+
+    // Return early since scaled_prim_res and scaled_dual_res are meaningless before the first ADMM iteration
+    return *eps_prev;
+  }
+
+  eps = reduction_factor * sqrt(scaled_prim_res * scaled_dual_res);
+  eps = c_max(c_min(eps, (*eps_prev)), OSQP_CG_TOL_MIN);
+  *eps_prev = eps;
+
+  return eps;
+}
+
 
 MKL_INT cg_solver_init(mklcg_solver* s) {
 
@@ -15,8 +44,8 @@ MKL_INT cg_solver_init(mklcg_solver* s) {
   // Set MKL control parameters
   s->iparm[4] = s->max_iter; // Maximum number of iterations
   s->iparm[7] = 1;           // Enable maximum iteration stopping test
-  s->iparm[8] = 1;           // Enable residual stopping test
-  s->iparm[9] = 0;           // Disable user defined stopping test
+  s->iparm[8] = 0;           // Disable built-in residual stopping test
+  s->iparm[9] = 1;           // Enable user defined stopping test
 
   // Enable the preconditioner if requested
   s->iparm[10] = (s->precond_type == OSQP_NO_PRECONDITIONER) ? 0 : 1;
@@ -48,12 +77,14 @@ void cg_update_precond(mklcg_solver* s) {
 }
 
 
-OSQPInt init_linsys_mklcg(mklcg_solver**      sp,
-                          const OSQPMatrix*   P,
-                          const OSQPMatrix*   A,
-                          const OSQPVectorf*  rho_vec,
-                          const OSQPSettings* settings,
-                          OSQPInt             polish) {
+OSQPInt init_linsys_mklcg(mklcg_solver**     sp,
+                          const OSQPMatrix*  P,
+                          const OSQPMatrix*  A,
+                          const OSQPVectorf* rho_vec,
+                          const OSQPSettings*settings,
+                                OSQPFloat*   scaled_prim_res,
+                                OSQPFloat*   scaled_dual_res,
+                                OSQPInt      polish) {
 
   OSQPInt m = A->csc->m;
   OSQPInt n = P->csc->n;
@@ -70,6 +101,9 @@ OSQPInt init_linsys_mklcg(mklcg_solver**      sp,
   s->polish  = polish;
   s->m       = m;
   s->n       = n;
+
+  s->scaled_prim_res = scaled_prim_res;
+  s->scaled_dual_res = scaled_dual_res;
 
   //if polish is false, use the rho_vec we get.
   //Otherwise, use rho_vec = ones.*(1/sigma)
@@ -97,6 +131,12 @@ OSQPInt init_linsys_mklcg(mklcg_solver**      sp,
 
   // Assign iteration limit
   s->max_iter = settings->cg_max_iter;
+
+  // Assign tolerance-related settings
+  s->reduction_interval = settings->cg_tol_reduction;
+  s->tol_fraction       = settings->cg_tol_fraction;
+  s->reduction_factor   = settings->cg_tol_fraction;
+  s->cg_zero_iters      = 0;
 
   //Don't know the thread count.  Just use
   //the same thing as the pardiso solver
@@ -158,15 +198,39 @@ OSQPInt solve_linsys_mklcg(mklcg_solver* s,
                            OSQPVectorf*  b,
                            OSQPInt       admm_iter) {
 
-  MKL_INT  rci_request = 1;
-  MKL_INT  mkln        = s->n;
+  MKL_INT   rci_request = 1;
+  MKL_INT   mkln        = s->n;
+  OSQPFloat rhs_norm    = 0.0;
+  OSQPFloat res_norm    = 0.0;
+  OSQPFloat eps         = 1.0;
 
   //Point our subviews at the OSQP RHS
   OSQPVectorf_view_update(s->r1, b,    0, s->n);
   OSQPVectorf_view_update(s->r2, b, s->n, s->m);
 
-  // Compute the RHS for the CG solve
+  // Compute the RHS for the CG solve and its norm
   reduced_kkt_compute_rhs(s->A, s->rho_vec, s->r1, s->r2, s->ywork);
+  rhs_norm = OSQPVectorf_norm_inf(s->r1);
+
+  // Compute the desired solution precision
+  if (s->polish) {
+    eps = c_max(rhs_norm * OSQP_CG_POLISH_TOL, OSQP_CG_TOL_MIN);
+  } else {
+    if (admm_iter == 1) {
+      // On the first iteration, set reduction_factor to its default value
+      s->reduction_factor = s->tol_fraction;
+    } else if (s->cg_zero_iters >= s->reduction_interval) {
+      // Otherwise. check to see if the tolerance reduction factor should be adapted.
+      // This is done if CG is consistently never having to actually run.
+      s->reduction_factor /= 2;
+      s->cg_zero_iters = 0;
+    }
+
+    // Compute the new tolerance
+    eps = cg_compute_tolerance(admm_iter, rhs_norm,
+                               *(s->scaled_prim_res), *(s->scaled_dual_res),
+                               s->reduction_factor, &(s->eps_prev));
+  }
 
   // Solve the CG system
   // -------------------
@@ -178,19 +242,27 @@ OSQPInt solve_linsys_mklcg(mklcg_solver* s,
     //Call dcg to get the search direction
     dcg (&mkln, OSQPVectorf_data(s->x), OSQPVectorf_data(s->r1),
          &rci_request, s->iparm, s->dparm, OSQPVectorf_data(s->tmp));
+
     if (rci_request == 1) {
-        // Multiply for reduced system.
-        // mvm_pre and mvm_post are subviews of the cg workspace variable s->tmp.
-        reduced_kkt_mv_times(s->P, s->A, s->rho_vec, s->sigma, s->mvm_pre, s->mvm_post, s->ywork );
+      // Multiply for reduced system.
+      // mvm_pre and mvm_post are subviews of the cg workspace variable s->tmp.
+      reduced_kkt_mv_times(s->P, s->A, s->rho_vec, s->sigma, s->mvm_pre, s->mvm_post, s->ywork );
+    } else if (rci_request == 2) {
+      // Check the stopping criteria, precond_pre contains the residual vector
+      res_norm = OSQPVectorf_norm_inf(s->precond_pre);
+
+      // It is our responsibility to break out of the loop once tolerance is reached
+      if (res_norm < eps)
+        break;
     } else if (rci_request == 3) {
-        // Apply the preconditioner as (precond_post = precond.*precond_pre)
-        OSQPVectorf_ew_prod(s->precond_post, s->precond_inv, s->precond_pre);
+      // Apply the preconditioner as (precond_post = precond.*precond_pre)
+      OSQPVectorf_ew_prod(s->precond_post, s->precond_inv, s->precond_pre);
     } else {
       break;
     }
   }
 
-  if (rci_request == 0) {  //solution was found for x.
+  if ( (rci_request == 0) || (rci_request == 2) ) {  //solution was found for x.
 
     OSQPVectorf_copy(s->r1, s->x);
 
@@ -203,6 +275,12 @@ OSQPInt solve_linsys_mklcg(mklcg_solver* s,
       OSQPMatrix_Axpy(s->A, s->x, s->r2, 1.0, -1.0);
       OSQPVectorf_ew_prod(s->r2, s->r2, s->rho_vec);
     }
+
+    // Record if no CG iterations were performed
+    if (s->iparm[3] == 0)
+      s->cg_zero_iters++;
+    else
+      s->cg_zero_iters = 0;
   }
 
   return rci_request; //0 on succcess, otherwise MKL CG error code
@@ -229,6 +307,10 @@ void update_settings_linsys_solver_mklcg(struct mklcg_solver_* s,
   // Maximum number of iterations
   s->max_iter = settings->cg_max_iter;
   s->iparm[4] = settings->cg_max_iter;
+
+  // Update adaptive tolerance parameters
+  s->reduction_interval = settings->cg_tol_reduction;
+  s->tol_fraction       = settings->cg_tol_fraction;
 
   //returns -1 for dcg failure, 0 otherwise
   dcg_check(&mkln, NULL, NULL, &rci_request,

--- a/algebra/mkl/lin_sys/indirect/mkl-cg_interface.c
+++ b/algebra/mkl/lin_sys/indirect/mkl-cg_interface.c
@@ -15,7 +15,7 @@ MKL_INT cg_solver_init(mklcg_solver* s) {
   // Set MKL control parameters
   s->iparm[4] = s->max_iter; // Maximum number of iterations
   s->iparm[7] = 1;           // Enable maximum iteration stopping test
-  s->iparm[8] = 0;           // Disable residual stopping test
+  s->iparm[8] = 1;           // Enable residual stopping test
   s->iparm[9] = 0;           // Disable user defined stopping test
 
   // Enable the preconditioner if requested

--- a/algebra/mkl/lin_sys/indirect/mkl-cg_interface.c
+++ b/algebra/mkl/lin_sys/indirect/mkl-cg_interface.c
@@ -51,7 +51,6 @@ void cg_times(OSQPMatrix*  P,
 
 
 void cg_update_precond_diagonal(mklcg_solver* s) {
-
   /* 1st part: sigma */
   OSQPVectorf_set_scalar(s->precond, s->sigma);
 
@@ -60,7 +59,8 @@ void cg_update_precond_diagonal(mklcg_solver* s) {
   OSQPVectorf_plus(s->precond, s->precond, s->precond_inv);
 
   /* 3rd part: Diagonal of At*rho*A */
-  // TODO
+  OSQPMatrix_AtDA_extract_diag(s->A, s->rho_vec, s->precond_inv);
+  OSQPVectorf_plus(s->precond, s->precond, s->precond_inv);
 
   /* 4th part: Invert the preconditioner */
   OSQPVectorf_ew_reciprocal(s->precond_inv, s->precond);

--- a/algebra/mkl/lin_sys/indirect/mkl-cg_interface.c
+++ b/algebra/mkl/lin_sys/indirect/mkl-cg_interface.c
@@ -121,7 +121,7 @@ OSQPInt init_linsys_mklcg(mklcg_solver**      sp,
 }
 
 
-const char* name_mklcg() {
+const char* name_mklcg(mklcg_solver* s) {
   return "MKL RCI Conjugate Gradient";
 }
 

--- a/algebra/mkl/lin_sys/indirect/mkl-cg_interface.h
+++ b/algebra/mkl/lin_sys/indirect/mkl-cg_interface.h
@@ -15,7 +15,7 @@ typedef struct mklcg_solver_ {
    * @name Functions
    * @{
    */
-  const char* (*name)(void);
+  const char* (*name)(struct mklcg_solver_* self);
   OSQPInt (*solve)(struct mklcg_solver_* self, OSQPVectorf* b, OSQPInt admm_iter);
   void    (*update_settings)(struct mklcg_solver_* self, const OSQPSettings* settings);
   void    (*warm_start)(struct mklcg_solver_* self, const OSQPVectorf* x);
@@ -98,7 +98,7 @@ OSQPInt init_linsys_mklcg(mklcg_solver**      sp,
  * Get the user-friendly name of the MKL CG solver.
  * @return The user-friendly name
  */
-const char* name_mklcg();
+const char* name_mklcg(mklcg_solver* s);
 
 
 /**

--- a/algebra/mkl/lin_sys/indirect/mkl-cg_interface.h
+++ b/algebra/mkl/lin_sys/indirect/mkl-cg_interface.h
@@ -47,6 +47,8 @@ typedef struct mklcg_solver_ {
   OSQPInt      n;       // number of variables
   OSQPInt      polish;  //polishing or not?
 
+  osqp_precond_type precond_type; // Preconditioner to use
+
   // Hold an internal copy of the solution x to
   // enable warm starting between successive solves
   OSQPVectorf* x;
@@ -63,14 +65,21 @@ typedef struct mklcg_solver_ {
   // its underlying pointer, but we make it an OSQPVectorf
   // so that we can make some views into it for multiplication
 
-  // Vector views into tmp for K*v1 = v2
-  OSQPVectorf* v1;
-  OSQPVectorf* v2;
+  // Vector views into tmp for K*mvm_pre = mvm_post
+  OSQPVectorf* mvm_pre;
+  OSQPVectorf* mvm_post;
+
+  // Vector views into tmp for preconditioner application
+  OSQPVectorf* precond_pre;
+  OSQPVectorf* precond_post;
 
   // Vector views of the input vector
   OSQPVectorf* r1;
   OSQPVectorf* r2;
 
+  // Preconditioner vector
+  OSQPVectorf* precond;
+  OSQPVectorf* precond_inv;
 } mklcg_solver;
 
 

--- a/algebra/mkl/lin_sys/indirect/mkl-cg_interface.h
+++ b/algebra/mkl/lin_sys/indirect/mkl-cg_interface.h
@@ -35,6 +35,9 @@ typedef struct mklcg_solver_ {
   //threads count
   OSQPInt nthreads;
 
+  // Maximum number of iterations
+  OSQPInt max_iter;
+
    /* @name Attributes
    * @{
    */

--- a/algebra/mkl/matrix.c
+++ b/algebra/mkl/matrix.c
@@ -193,6 +193,13 @@ void OSQPMatrix_rmult_diag(OSQPMatrix*        A,
   csc_rmult_diag(A->csc, OSQPVectorf_data(R));
 }
 
+void OSQPMatrix_extract_diag(const OSQPMatrix*  A,
+                                   OSQPVectorf* d) {
+  /* This operates on the assumption that the stored shadow csc matrix is the backing memory for
+     the actual MKL matrix handle, which seems to be the case in all the testing done. */
+  csc_extract_diag(A->csc, OSQPVectorf_data(d));
+}
+
 //y = alpha*A*x + beta*y
 void OSQPMatrix_Axpy(const OSQPMatrix*  A,
                      const OSQPVectorf* x,

--- a/algebra/mkl/matrix.c
+++ b/algebra/mkl/matrix.c
@@ -193,6 +193,14 @@ void OSQPMatrix_rmult_diag(OSQPMatrix*        A,
   csc_rmult_diag(A->csc, OSQPVectorf_data(R));
 }
 
+void OSQPMatrix_AtDA_extract_diag(const OSQPMatrix*  A,
+                                  const OSQPVectorf* D,
+                                        OSQPVectorf* d) {
+  /* This operates on the assumption that the stored shadow csc matrix is the backing memory for
+     the actual MKL matrix handle, which seems to be the case in all the testing done. */
+    csc_AtDA_extract_diag(A->csc, OSQPVectorf_data(D), OSQPVectorf_data(d));
+}
+
 void OSQPMatrix_extract_diag(const OSQPMatrix*  A,
                                    OSQPVectorf* d) {
   /* This operates on the assumption that the stored shadow csc matrix is the backing memory for

--- a/include/private/algebra_matrix.h
+++ b/include/private/algebra_matrix.h
@@ -93,6 +93,10 @@ void OSQPMatrix_lmult_diag(OSQPMatrix*        A,
 void OSQPMatrix_rmult_diag(OSQPMatrix*        A,
                            const OSQPVectorf* R);
 
+// Extract the main diagonal of A into d
+void OSQPMatrix_extract_diag(const OSQPMatrix*  A,
+                                   OSQPVectorf* d);
+
 //y = alpha*A*x + beta*y
 void OSQPMatrix_Axpy(const OSQPMatrix*  A,
                      const OSQPVectorf* x,

--- a/include/private/algebra_matrix.h
+++ b/include/private/algebra_matrix.h
@@ -93,6 +93,11 @@ void OSQPMatrix_lmult_diag(OSQPMatrix*        A,
 void OSQPMatrix_rmult_diag(OSQPMatrix*        A,
                            const OSQPVectorf* R);
 
+// d = diag(At*diag(D)*A)
+void OSQPMatrix_AtDA_extract_diag(const OSQPMatrix*  A,
+                                  const OSQPVectorf* D,
+                                        OSQPVectorf* d);
+
 // Extract the main diagonal of A into d
 void OSQPMatrix_extract_diag(const OSQPMatrix*  A,
                                    OSQPVectorf* d);

--- a/include/private/types.h
+++ b/include/private/types.h
@@ -206,7 +206,7 @@ struct OSQPWorkspace_ {
 struct linsys_solver {
   enum osqp_linsys_solver_type type;             ///< linear system solver type functions
 
-  const char* (*name)(void);
+  const char* (*name)(LinSysSolver* self);
 
   OSQPInt (*solve)(LinSysSolver* self,
                    OSQPVectorf*  b,

--- a/include/public/osqp_api_constants.h
+++ b/include/public/osqp_api_constants.h
@@ -55,6 +55,13 @@ enum osqp_linsys_solver_type {
     OSQP_INDIRECT_SOLVER,
 };
 
+/*********************************
+* Preconditioners for CG method *
+*********************************/
+typedef enum {
+    OSQP_NO_PRECONDITIONER = 0,      /* Don't use a preconditioner */
+    OSQP_DIAGONAL_PRECONDITIONER,    /* Diagonal (Jacobi) preconditioner */
+} osqp_precond_type;
 
 /******************
 * Solver Errors  *

--- a/include/public/osqp_api_types.h
+++ b/include/public/osqp_api_types.h
@@ -42,6 +42,7 @@ typedef struct {
  * User settings
  */
 typedef struct {
+  /* Note: If this struct is updated, ensure update_settings is also updated */
   OSQPInt device;                             ///< device identifier; currently used for CUDA devices
   enum osqp_linsys_solver_type linsys_solver; ///< linear system solver to use
   OSQPInt verbose;                            ///< boolean; write out progress
@@ -56,9 +57,10 @@ typedef struct {
   OSQPFloat alpha;                  ///< ADMM relaxation parameter
 
   // CG settings
-  OSQPInt   cg_max_iter;            ///< maximum number of CG iterations per solve
-  OSQPInt   cg_tol_reduction;       ///< number of consecutive zero CG iterations before the tolerance gets halved
-  OSQPFloat cg_tol_fraction;        ///< CG tolerance (fraction of ADMM residuals)
+  OSQPInt           cg_max_iter;      ///< maximum number of CG iterations per solve
+  OSQPInt           cg_tol_reduction; ///< number of consecutive zero CG iterations before the tolerance gets halved
+  OSQPFloat         cg_tol_fraction;  ///< CG tolerance (fraction of ADMM residuals)
+  osqp_precond_type cg_precond;       ///< Preconditioner to use in the CG method
 
   // adaptive rho logic
   OSQPInt   adaptive_rho;           ///< boolean, is rho step size adaptive?

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -181,6 +181,7 @@ static OSQPInt write_settings(FILE*               f,
   fprintf(f, "  %d,\n", settings->cg_max_iter);
   fprintf(f, "  %d,\n", settings->cg_tol_reduction);
   fprintf(f, "  (OSQPFloat)%.20f,\n", settings->cg_tol_fraction);
+  fprintf(f, "  %d,\n", settings->cg_precond);
   fprintf(f, "  %d,\n", settings->adaptive_rho);
   fprintf(f, "  %d,\n", settings->adaptive_rho_interval);
   fprintf(f, "  (OSQPFloat)%.20f,\n", settings->adaptive_rho_fraction);

--- a/src/osqp_api.c
+++ b/src/osqp_api.c
@@ -1179,6 +1179,7 @@ OSQPInt osqp_update_settings(OSQPSolver*         solver,
   settings->cg_max_iter      = new_settings->cg_max_iter;
   settings->cg_tol_reduction = new_settings->cg_tol_reduction;
   settings->cg_tol_fraction  = new_settings->cg_tol_fraction;
+  settings->cg_precond       = new_settings->cg_precond;
 
   // adaptive_rho           ignored
   // adaptive_rho_interval  ignored

--- a/src/osqp_api.c
+++ b/src/osqp_api.c
@@ -96,9 +96,10 @@ void osqp_set_default_settings(OSQPSettings* settings) {
   settings->sigma         = (OSQPFloat)OSQP_SIGMA;  /* ADMM step */
   settings->alpha         = (OSQPFloat)OSQP_ALPHA;  /* relaxation parameter */
 
-  settings->cg_max_iter      = OSQP_CG_MAX_ITER;      /* maximum number of CG iterations */
-  settings->cg_tol_reduction = OSQP_CG_TOL_REDUCTION; /* CG tolerance parameter */
-  settings->cg_tol_fraction  = OSQP_CG_TOL_FRACTION;  /* CG tolerance parameter */
+  settings->cg_max_iter      = OSQP_CG_MAX_ITER;             /* maximum number of CG iterations */
+  settings->cg_tol_reduction = OSQP_CG_TOL_REDUCTION;        /* CG tolerance parameter */
+  settings->cg_tol_fraction  = OSQP_CG_TOL_FRACTION;         /* CG tolerance parameter */
+  settings->cg_precond       = OSQP_DIAGONAL_PRECONDITIONER; /* Preconditioner to use in CG */
 
   settings->adaptive_rho           = OSQP_ADAPTIVE_RHO;
   settings->adaptive_rho_interval  = OSQP_ADAPTIVE_RHO_INTERVAL;

--- a/src/util.c
+++ b/src/util.c
@@ -252,6 +252,7 @@ OSQPSettings* copy_settings(const OSQPSettings *settings) {
    * NB: Copying them explicitly because memcpy is not
    * defined when OSQP_ENABLE_PRINTING is disabled (appears in string.h)
    */
+  new->device        = settings->device;
   new->linsys_solver = settings->linsys_solver;
   new->verbose       = settings->verbose;
   new->warm_starting = settings->warm_starting;

--- a/src/util.c
+++ b/src/util.c
@@ -266,6 +266,7 @@ OSQPSettings* copy_settings(const OSQPSettings *settings) {
   new->cg_max_iter      = settings->cg_max_iter;
   new->cg_tol_reduction = settings->cg_tol_reduction;
   new->cg_tol_fraction  = settings->cg_tol_fraction;
+  new->cg_precond       = settings->cg_precond;
 
   new->adaptive_rho           = settings->adaptive_rho;
   new->adaptive_rho_interval  = settings->adaptive_rho_interval;

--- a/src/util.c
+++ b/src/util.c
@@ -87,7 +87,7 @@ void print_setup_header(const OSQPSolver* solver) {
   c_print("algebra = %s", osqp_algebra_name());
   c_print(",\n          ");
 
-  c_print("linear system solver = %s", work->linsys_solver->name());
+  c_print("linear system solver = %s", work->linsys_solver->name(work->linsys_solver));
 
   if (work->linsys_solver->nthreads != 1) {
     c_print(" (%d threads)", (int)work->linsys_solver->nthreads);

--- a/tests/lin_alg/generate_problem.py
+++ b/tests/lin_alg/generate_problem.py
@@ -97,12 +97,19 @@ test_mat_ops_inf_norm_cols = np.amax(np.abs(
 test_mat_ops_inf_norm_rows = np.amax(np.abs(
     np.asarray(test_mat_ops_A.todense())), axis=1)
 
+test_mat_ops_diag_m = test_vec_ops_n
 test_mat_ops_diag_n = 6
 test_mat_ops_diag_A = sparse.random(test_mat_ops_diag_n, test_mat_ops_diag_n, density=0.8, format='csc', random_state=rg)
+test_mat_ops_diag_Ar = sparse.random(test_mat_ops_diag_m, test_mat_ops_diag_n, density=0.8, format='csc', random_state=rg)
 test_mat_ops_diag_P = test_mat_ops_diag_A + test_mat_ops_diag_A.T
 test_mat_ops_diag_Pu = sparse.triu(test_mat_ops_diag_P, format='csc')
 test_mat_ops_diag_dA = np.diag(sparse.csc_matrix.toarray(test_mat_ops_diag_A))
 test_mat_ops_diag_dP = np.diag(sparse.csc_matrix.toarray(test_mat_ops_diag_Pu))
+test_mat_ops_diag_AtA = np.diag((test_mat_ops_diag_Ar.T@test_mat_ops_diag_Ar).todense())
+tmpR = sparse.diags(test_vec_ops_vn, format='csc')
+test_mat_ops_diag_AtRnA = np.diag((test_mat_ops_diag_Ar.T@tmpR@test_mat_ops_diag_Ar).todense())
+tmpR = sparse.diags(test_vec_ops_v1, format='csc')
+test_mat_ops_diag_AtRA = np.diag((test_mat_ops_diag_Ar.T@tmpR@test_mat_ops_diag_Ar).todense())
 
 # Special cases for matrices/vectors with no size or entries
 test_mat_no_entries = sparse.csc_matrix([[0., 0.], [0., 0.]])
@@ -233,12 +240,17 @@ data = {'test_sp_matrix_A': test_sp_matrix_A,
         'test_mat_ops_scaled' : test_mat_ops_scaled,
         'test_mat_ops_inf_norm_cols': test_mat_ops_inf_norm_cols,
         'test_mat_ops_inf_norm_rows': test_mat_ops_inf_norm_rows,
+        'test_mat_ops_diag_m': test_mat_ops_diag_m,
         'test_mat_ops_diag_n': test_mat_ops_diag_n,
         'test_mat_ops_diag_A': test_mat_ops_diag_A,
+        'test_mat_ops_diag_Ar': test_mat_ops_diag_Ar,
         'test_mat_ops_diag_P': test_mat_ops_diag_P,
         'test_mat_ops_diag_Pu': test_mat_ops_diag_Pu,
         'test_mat_ops_diag_dA': test_mat_ops_diag_dA,
         'test_mat_ops_diag_dP': test_mat_ops_diag_dP,
+        'test_mat_ops_diag_AtA': test_mat_ops_diag_AtA,
+        'test_mat_ops_diag_AtRnA': test_mat_ops_diag_AtRnA,
+        'test_mat_ops_diag_AtRA': test_mat_ops_diag_AtRA,
         'test_mat_vec_n': test_mat_vec_n,
         'test_mat_vec_m': test_mat_vec_m,
         'test_mat_vec_A': test_mat_vec_A,

--- a/tests/lin_alg/generate_problem.py
+++ b/tests/lin_alg/generate_problem.py
@@ -97,6 +97,13 @@ test_mat_ops_inf_norm_cols = np.amax(np.abs(
 test_mat_ops_inf_norm_rows = np.amax(np.abs(
     np.asarray(test_mat_ops_A.todense())), axis=1)
 
+test_mat_ops_diag_n = 6
+test_mat_ops_diag_A = sparse.random(test_mat_ops_diag_n, test_mat_ops_diag_n, density=0.8, format='csc', random_state=rg)
+test_mat_ops_diag_P = test_mat_ops_diag_A + test_mat_ops_diag_A.T
+test_mat_ops_diag_Pu = sparse.triu(test_mat_ops_diag_P, format='csc')
+test_mat_ops_diag_dA = np.diag(sparse.csc_matrix.toarray(test_mat_ops_diag_A))
+test_mat_ops_diag_dP = np.diag(sparse.csc_matrix.toarray(test_mat_ops_diag_Pu))
+
 # Special cases for matrices/vectors with no size or entries
 test_mat_no_entries = sparse.csc_matrix([[0., 0.], [0., 0.]])
 test_mat_no_rows = sparse.csc_matrix((0,2))
@@ -226,6 +233,12 @@ data = {'test_sp_matrix_A': test_sp_matrix_A,
         'test_mat_ops_scaled' : test_mat_ops_scaled,
         'test_mat_ops_inf_norm_cols': test_mat_ops_inf_norm_cols,
         'test_mat_ops_inf_norm_rows': test_mat_ops_inf_norm_rows,
+        'test_mat_ops_diag_n': test_mat_ops_diag_n,
+        'test_mat_ops_diag_A': test_mat_ops_diag_A,
+        'test_mat_ops_diag_P': test_mat_ops_diag_P,
+        'test_mat_ops_diag_Pu': test_mat_ops_diag_Pu,
+        'test_mat_ops_diag_dA': test_mat_ops_diag_dA,
+        'test_mat_ops_diag_dP': test_mat_ops_diag_dP,
         'test_mat_vec_n': test_mat_vec_n,
         'test_mat_vec_m': test_mat_vec_m,
         'test_mat_vec_A': test_mat_vec_A,

--- a/tests/lin_alg/test_matrix.cpp
+++ b/tests/lin_alg/test_matrix.cpp
@@ -151,8 +151,53 @@ TEST_CASE("Matrix: Diagonal extraction", "[matrix]") {
 
     OSQPMatrix_extract_diag(P.get(), res.get());
 
-      mu_assert("Error in extracted diagonal",
-                OSQPVectorf_is_eq(ref.get(), res.get(), TESTS_TOL));
+    mu_assert("Error in extracted diagonal",
+              OSQPVectorf_is_eq(ref.get(), res.get(), TESTS_TOL));
+  }
+}
+#endif
+
+#ifndef OSQP_ALGEBRA_CUDA
+TEST_CASE("Matrix: AtDA Diagonal extraction", "[matrix]") {
+  lin_alg_sols_data_ptr data{generate_problem_lin_alg_sols_data()};
+
+  OSQPInt m = data->test_mat_ops_diag_m;
+  OSQPInt n = data->test_mat_ops_diag_n;
+
+  // Matrix to use
+  OSQPMatrix_ptr A{OSQPMatrix_new_from_csc(data->test_mat_ops_diag_Ar, 0)};
+
+  // Result vector
+  OSQPVectorf_ptr res{OSQPVectorf_malloc(n)};
+
+  SECTION("Unity diagonal element") {
+    OSQPVectorf_ptr D{OSQPVectorf_new(data->test_vec_ops_ones, m)};         // Diagonal
+    OSQPVectorf_ptr ref{OSQPVectorf_new(data->test_mat_ops_diag_AtA, n)};   // Reference
+
+    OSQPMatrix_AtDA_extract_diag(A.get(), D.get(), res.get());
+
+    mu_assert("Error in extracted diagonal",
+              OSQPVectorf_is_eq(ref.get(), res.get(), TESTS_TOL));
+  }
+
+  SECTION("Simple diagonal scaling") {
+    OSQPVectorf_ptr D{OSQPVectorf_new(data->test_vec_ops_vn, m)};           // Diagonal
+    OSQPVectorf_ptr ref{OSQPVectorf_new(data->test_mat_ops_diag_AtRnA, n)}; // Reference
+
+    OSQPMatrix_AtDA_extract_diag(A.get(), D.get(), res.get());
+
+    mu_assert("Error in extracted diagonal",
+              OSQPVectorf_is_eq(ref.get(), res.get(), TESTS_TOL));
+  }
+
+  SECTION("Complicated diagonal scaling") {
+    OSQPVectorf_ptr D{OSQPVectorf_new(data->test_vec_ops_v1, m)};          // Diagonal
+    OSQPVectorf_ptr ref{OSQPVectorf_new(data->test_mat_ops_diag_AtRA, n)}; // Reference
+
+    OSQPMatrix_AtDA_extract_diag(A.get(), D.get(), res.get());
+
+    mu_assert("Error in extracted diagonal",
+              OSQPVectorf_is_eq(ref.get(), res.get(), TESTS_TOL));
   }
 }
 #endif

--- a/tests/lin_alg/test_matrix.cpp
+++ b/tests/lin_alg/test_matrix.cpp
@@ -132,24 +132,24 @@ TEST_CASE("Matrix: Diagonal extraction", "[matrix]") {
   lin_alg_sols_data_ptr data{generate_problem_lin_alg_sols_data()};
 
   SECTION("Square non-symmetric") {
-      OSQPMatrix_ptr A{OSQPMatrix_new_from_csc(data->test_mat_ops_diag_A, 0)};
-      OSQPVectorf_ptr ref{OSQPVectorf_new(data->test_mat_ops_diag_dA, data->test_mat_ops_diag_n)};
+    OSQPMatrix_ptr A{OSQPMatrix_new_from_csc(data->test_mat_ops_diag_A, 0)};
+    OSQPVectorf_ptr ref{OSQPVectorf_new(data->test_mat_ops_diag_dA, data->test_mat_ops_diag_n)};
 
-      OSQPVectorf_ptr res{OSQPVectorf_malloc(data->test_mat_ops_diag_n)};
+    OSQPVectorf_ptr res{OSQPVectorf_malloc(data->test_mat_ops_diag_n)};
 
-      OSQPMatrix_extract_diag(A.get(), res.get());
+    OSQPMatrix_extract_diag(A.get(), res.get());
 
-      mu_assert("Error in extracted diagonal",
-                OSQPVectorf_is_eq(ref.get(), res.get(), TESTS_TOL));
+    mu_assert("Error in extracted diagonal",
+              OSQPVectorf_is_eq(ref.get(), res.get(), TESTS_TOL));
   }
 
   SECTION("Square symmetric, triangular") {
-      OSQPMatrix_ptr P{OSQPMatrix_new_from_csc(data->test_mat_ops_diag_Pu, 1)};
-      OSQPVectorf_ptr ref{OSQPVectorf_new(data->test_mat_ops_diag_dP, data->test_mat_ops_diag_n)};
+    OSQPMatrix_ptr P{OSQPMatrix_new_from_csc(data->test_mat_ops_diag_Pu, 1)};
+    OSQPVectorf_ptr ref{OSQPVectorf_new(data->test_mat_ops_diag_dP, data->test_mat_ops_diag_n)};
 
-      OSQPVectorf_ptr res{OSQPVectorf_malloc(data->test_mat_ops_diag_n)};
+    OSQPVectorf_ptr res{OSQPVectorf_malloc(data->test_mat_ops_diag_n)};
 
-      OSQPMatrix_extract_diag(P.get(), res.get());
+    OSQPMatrix_extract_diag(P.get(), res.get());
 
       mu_assert("Error in extracted diagonal",
                 OSQPVectorf_is_eq(ref.get(), res.get(), TESTS_TOL));

--- a/tests/lin_alg/test_matrix.cpp
+++ b/tests/lin_alg/test_matrix.cpp
@@ -127,6 +127,36 @@ TEST_CASE("Matrix: Submatrix creation", "[matrix][creation") {
   }
 }
 
+#ifndef OSQP_ALGEBRA_CUDA
+TEST_CASE("Matrix: Diagonal extraction", "[matrix]") {
+  lin_alg_sols_data_ptr data{generate_problem_lin_alg_sols_data()};
+
+  SECTION("Square non-symmetric") {
+      OSQPMatrix_ptr A{OSQPMatrix_new_from_csc(data->test_mat_ops_diag_A, 0)};
+      OSQPVectorf_ptr ref{OSQPVectorf_new(data->test_mat_ops_diag_dA, data->test_mat_ops_diag_n)};
+
+      OSQPVectorf_ptr res{OSQPVectorf_malloc(data->test_mat_ops_diag_n)};
+
+      OSQPMatrix_extract_diag(A.get(), res.get());
+
+      mu_assert("Error in extracted diagonal",
+                OSQPVectorf_is_eq(ref.get(), res.get(), TESTS_TOL));
+  }
+
+  SECTION("Square symmetric, triangular") {
+      OSQPMatrix_ptr P{OSQPMatrix_new_from_csc(data->test_mat_ops_diag_Pu, 1)};
+      OSQPVectorf_ptr ref{OSQPVectorf_new(data->test_mat_ops_diag_dP, data->test_mat_ops_diag_n)};
+
+      OSQPVectorf_ptr res{OSQPVectorf_malloc(data->test_mat_ops_diag_n)};
+
+      OSQPMatrix_extract_diag(P.get(), res.get());
+
+      mu_assert("Error in extracted diagonal",
+                OSQPVectorf_is_eq(ref.get(), res.get(), TESTS_TOL));
+  }
+}
+#endif
+
 TEST_CASE("Matrix: Equality test", "[matrix]") {
   lin_alg_sols_data_ptr data{generate_problem_lin_alg_sols_data()};
 


### PR DESCRIPTION
This PR implements a diagonal (Jacobi) preconditioner for the MKL CG method. It takes a slightly different approach to doing the computation than the CUDA version does, with the main difference being there is no more conditional computation of parts of the preconditioner based on what parts were updated. This makes more sense since the only part that was really being saved was the extraction of the P matrix diagonal, since changing either rho or A would result in the same A'*D(rho)*A computation being done. This is done in a way that is still agnostic to the algebra backend, so it can theoretically be moved into a common routine when we get a CG method for the builtin algebras.

I have also added a new setting `cg_precond` for choosing the preconditioner to use, and it currently only has two options: no preconditioner or diagonal preconditioner. This probably won't be used much in practice, but it is useful for benchmarks/comparisons. It also allows future expandability to more preconditioners (such as seeing about the MKL ILU or triangular preconditioners).

@vineetbansal can you run the benchmarks on this with/without the preconditioner enabled? (it should be a simple change to update the wrapper with the new setting).

Fixes https://github.com/osqp/osqp/pull/479