### PR TITLE
Prototype fixes for pardiso

### DIFF
--- a/lin_sys/direct/pardiso/pardiso_interface.c
+++ b/lin_sys/direct/pardiso/pardiso_interface.c
@@ -32,7 +32,7 @@ void pardiso(void**,         // pt
              c_int*          // error
              );
 c_int mkl_set_interface_layer(c_int);
-c_int mkl_get_max_threads();
+c_int mkl_get_max_threads(void);
 
 // Free LDL Factorization structure
 void free_linsys_solver_pardiso(pardiso_solver *s) {

--- a/lin_sys/direct/pardiso/pardiso_loader.c
+++ b/lin_sys/direct/pardiso/pardiso_loader.c
@@ -22,7 +22,7 @@ typedef void (*pardiso_t)(void**, const c_int*, const c_int*, const c_int*,
                           const c_int*, c_int*, const c_int*, c_float*,
                           c_float*, c_int*);
 typedef int (*mkl_set_ifl_t)(int);
-typedef int (*mkl_get_mt_t)();
+typedef int (*mkl_get_mt_t)(void);
 
 
 // Handlers are static variables
@@ -55,7 +55,7 @@ c_int mkl_set_interface_layer(c_int code) {
     return (c_int)func_mkl_set_interface_layer((int)code);
 }
 
-c_int mkl_get_max_threads() {
+c_int mkl_get_max_threads(void) {
     return (c_int)func_mkl_get_max_threads();
 }
 
@@ -87,7 +87,7 @@ c_int lh_load_pardiso(const char* libname) {
     return 0;
 }
 
-c_int lh_unload_pardiso() {
+c_int lh_unload_pardiso(void) {
 
     if (Pardiso_handle == OSQP_NULL) return 0;
 

--- a/lin_sys/direct/pardiso/pardiso_loader.h
+++ b/lin_sys/direct/pardiso/pardiso_loader.h
@@ -19,7 +19,7 @@ c_int lh_load_pardiso(const char* libname);
  * Unloads the loaded Pardiso shared library.
  * @return Zero on success, nonzero on failure.
  */
-c_int lh_unload_pardiso();
+c_int lh_unload_pardiso(void);
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
The R interface required these prototype fixes (among a few others) as CRAN enables prototype checks.  Reference: https://discourse.llvm.org/t/rfc-enabling-wstrict-prototypes-by-default-in-c/60521/20

The fixes here are very trivial.