### PR TITLE
Fix CUDA vector 1 norm computation

### DIFF
--- a/algebra/cuda/include/cuda_lin_alg.h
+++ b/algebra/cuda/include/cuda_lin_alg.h
@@ -146,11 +146,11 @@ void cuda_vec_diff_norm_inf(const OSQPFloat* d_a,
                                   OSQPFloat* h_res);
 
 /**
- * h_res = sum(d_x) / n
+ * h_res = sum(|d_x|)
  */
-void cuda_vec_mean(const OSQPFloat* d_x,
-                         OSQPInt    n,
-                         OSQPFloat* h_res);
+void cuda_vec_norm_1(const OSQPFloat* d_x,
+                           OSQPInt    n,
+                           OSQPFloat* h_res);
 
 /**
  * h_res = d_a' * d_b

--- a/algebra/cuda/src/cuda_lin_alg.cu
+++ b/algebra/cuda/src/cuda_lin_alg.cu
@@ -686,12 +686,11 @@ void cuda_vec_diff_norm_inf(const OSQPFloat* d_a,
   cuda_free((void **) &d_diff);
 }
 
-void cuda_vec_mean(const OSQPFloat* d_x,
-                         OSQPInt    n,
-                         OSQPFloat* h_res) {
+void cuda_vec_norm_1(const OSQPFloat* d_x,
+                           OSQPInt    n,
+                           OSQPFloat* h_res) {
 
-  cublasTasum(CUDA_handle->cublasHandle, n, d_x, 1, h_res);
-  (*h_res) /= n;
+  checkCudaErrors(cublasTasum(CUDA_handle->cublasHandle, n, d_x, 1, h_res));
 }
 
 void cuda_vec_prod(const OSQPFloat* d_a,

--- a/algebra/cuda/vector.cu
+++ b/algebra/cuda/vector.cu
@@ -310,12 +310,11 @@ OSQPFloat OSQPVectorf_norm_inf_diff(const OSQPVectorf* a,
 
 OSQPFloat OSQPVectorf_norm_1(const OSQPVectorf* a) {
 
-  OSQPFloat mean;
+  OSQPFloat val = 0.0;
 
-  if (a->length) cuda_vec_mean(a->d_val, a->length, &mean);
-  else           mean = 0.0;
+  if (a->length) cuda_vec_norm_1(a->d_val, a->length, &val);
 
-  return mean; 
+  return val;
 }
 
 OSQPFloat OSQPVectorf_dot_prod(const OSQPVectorf* a,


### PR DESCRIPTION
The CUDA computation of the vector 1 norm was never fully changed from being a mean computation to just being the absolute sum, so the linalg tests were failing the vector 1 norm tests.