### PR TITLE
CUDA: Don't allow creating cusparse matrices with a 0 dimension

### DIFF
--- a/algebra/cuda/matrix.cu
+++ b/algebra/cuda/matrix.cu
@@ -105,7 +105,10 @@ void OSQPMatrix_Axpy(const OSQPMatrix*  mat,
     cuda_vec_mult_sc(y->d_val, beta, y->length);
     return;
   }
-  cuda_mat_Axpy(mat->S, x->vec, y->vec, alpha, beta);
+
+  if ((x->length > 0) && (y->length > 0)) {
+    cuda_mat_Axpy(mat->S, x->vec, y->vec, alpha, beta);
+  }
 }
 
 void OSQPMatrix_Atxpy(const OSQPMatrix*  mat,
@@ -119,7 +122,10 @@ void OSQPMatrix_Atxpy(const OSQPMatrix*  mat,
     cuda_vec_mult_sc(y->d_val, beta, y->length);
     return;
   }
-  cuda_mat_Axpy(mat->At, x->vec, y->vec, alpha, beta);
+
+  if ((x->length > 0) && (y->length > 0)) {
+    cuda_mat_Axpy(mat->At, x->vec, y->vec, alpha, beta);
+  }
 }
 
 void OSQPMatrix_col_norm_inf(const OSQPMatrix*  mat,

--- a/algebra/cuda/src/cuda_lin_alg.cu
+++ b/algebra/cuda/src/cuda_lin_alg.cu
@@ -491,7 +491,13 @@ void cuda_vec_create(cusparseDnVecDescr_t* vec,
                      const OSQPFloat*      d_x,
                      OSQPInt               n) {
 
-  checkCudaErrors(cusparseCreateDnVec(vec, n, (void*)d_x, CUDA_FLOAT));
+  /* Some versions of CUDA don't accept n=0 as a valid size (e.g. can't accept a
+   * zero-length vector), so don't create the vector in that case.
+   */
+  if (n > 0)
+    checkCudaErrors(cusparseCreateDnVec(vec, n, (void*)d_x, CUDA_FLOAT));
+  else
+    vec = NULL;
 }
 
 void cuda_vec_destroy(cusparseDnVecDescr_t vec) {


### PR DESCRIPTION
Some versions of cuSPARSE have problems with creating dense vectors with length 0 (they say it is an invalid input) and sparse matrices with any dimension of 0 length, so we need to avoid creating them. Instead, don't create them and just never perform the operations if there are no values in the matrices.

Hopefully this will fix the assertions we are seeing with the CUDA CI. (I can't test that locally because I haven't been able to trigger those on my machine, only on the CI machine).