### PR TITLE
Add workflow to automatically check website links

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -1,0 +1,18 @@
+name: Documentation and Site Link Checker (Periodic)
+
+on:
+  schedule:
+    # Run daily at 2am
+    - cron: '0 2 * * *'
+
+jobs:
+  check-links-periodic:
+    name: Check links (Periodic run)
+    runs-on: ubuntu-latest
+    steps:
+      # Just running the check on the main website will also include the docs, since they
+      # live at osqp.org/docs.
+      - name: Check OSQP website links
+        uses: filiph/linkcheck@2.0.23
+        with:
+          arguments: https://osqp.org -e


### PR DESCRIPTION
This adds a simple workflow that will run at 2am everyday to test all the links on the OSQP website (both internal links and external links) to ensure they are valid. It operates by crawling the hosted website instead of our local copy, so we can get in-situ results and it can check both the stable and develop-1.0 docs as well, hopefully.

I need to push this to the master branch directly to allow the scheduled workflow to run properly (scheduled workflows only operate on the main/default branch).

Fixes https://github.com/osqp/osqp/issues/334