### PR TITLE
Bump version of checkout action to support node 16 by default

### DIFF
--- a/.github/workflows/cmake-install.yaml
+++ b/.github/workflows/cmake-install.yaml
@@ -20,7 +20,7 @@ jobs:
         OSQP_INSTALL_PREFIX: ${{ github.workspace }}/../install
 
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             lfs: false
             submodules: recursive
@@ -63,7 +63,7 @@ jobs:
         OSQP_INSTALL_PREFIX: ${{ github.workspace }}/../install
 
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             lfs: false
             submodules: recursive
@@ -95,7 +95,7 @@ jobs:
         OSQP_INSTALL_PREFIX: ${{ github.workspace }}/../install
 
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             lfs: false
             submodules: recursive

--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -21,7 +21,7 @@ jobs:
         OSQP_CODEGEN_DIR_PREFIX: ${{ github.workspace }}/../codegen
 
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             lfs: false
             submodules: recursive

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -36,7 +36,7 @@ jobs:
         CTEST_OUTPUT_ON_FAILURE: 1
 
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             lfs: false
             submodules: recursive

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
         python: [3.9]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: master
           lfs: false
@@ -44,7 +44,7 @@ jobs:
 
       # Build documentation on the develop-1.0 branch in a subfolder
       # ------------------------------------------------------------
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: develop-1.0
           path: develop-1.0

--- a/.github/workflows/embedded.yaml
+++ b/.github/workflows/embedded.yaml
@@ -35,7 +35,7 @@ jobs:
         OSQP_BUILD_DIR_PREFIX: ${{ github.workspace }}/build
 
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             lfs: false
             submodules: recursive

--- a/.github/workflows/main-cuda.yml
+++ b/.github/workflows/main-cuda.yml
@@ -34,7 +34,7 @@ jobs:
         CTEST_OUTPUT_ON_FAILURE: 1
 
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             lfs: false
             submodules: recursive

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
         CTEST_OUTPUT_ON_FAILURE: 1
 
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             lfs: false
             submodules: recursive

--- a/.github/workflows/mkl.yaml
+++ b/.github/workflows/mkl.yaml
@@ -48,7 +48,7 @@ jobs:
         CTEST_OUTPUT_ON_FAILURE: 1
 
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             lfs: false
             submodules: recursive

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -20,7 +20,7 @@ jobs:
           shell: bash -l {0}
 
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
 
         - name: Set up conda
           uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           lfs: false
           submodules: recursive


### PR DESCRIPTION
GitHub has deprecated actions built on node 12 for their shared runners, so it now triggers warnings on every pipeline they are used. actions/checkout supports node 16 on v3, so bump our version from v2 to v3.

These deprecation warnings can be seen in run https://github.com/osqp/osqp/actions/runs/4554774592.