### PR TITLE
Implement more MKL algebra vector functions using VML functions

### DIFF
--- a/algebra/mkl/blas_helpers.h
+++ b/algebra/mkl/blas_helpers.h
@@ -3,8 +3,9 @@
 
 #include "osqp_configure.h"
 
-#include <mkl_blas.h>
+#include <mkl_cblas.h>
 #include <mkl_spblas.h>
+#include <mkl_vml.h>
 
 #include <mkl.h>
 
@@ -23,14 +24,14 @@
 /* Define the blas functions based on the data type we are using */
 #ifdef OSQP_USE_FLOAT
   // MKL Level 1 BLAS functions
-  #define blas_copy  scopy
-  #define blas_dot   sdot
-  #define blas_scale sscal
-  #define blas_swap  sswap
-  #define blas_axpy  saxpy
-  #define blas_2norm snrm2
-  #define blas_asum  sasum
-  #define blas_iamax isamax
+  #define blas_copy  cblas_scopy
+  #define blas_dot   cblas_sdot
+  #define blas_scale cblas_sscal
+  #define blas_swap  cblas_sswap
+  #define blas_axpy  cblas_saxpy
+  #define blas_2norm cblas_snrm2
+  #define blas_asum  cblas_sasum
+  #define blas_iamax cblas_isamax
 
   // MKL Vector Math functions
   #define vml_mul    vsMul
@@ -48,14 +49,14 @@
   #define spblas_mv         mkl_sparse_s_mv
 #else
   // MKL Level 1 BLAS functions
-  #define blas_copy  dcopy
-  #define blas_dot   ddot
-  #define blas_scale dscal
-  #define blas_swap  dswap
-  #define blas_axpy  daxpy
-  #define blas_2norm dnrm2
-  #define blas_asum  dasum
-  #define blas_iamax idamax
+  #define blas_copy  cblas_dcopy
+  #define blas_dot   cblas_ddot
+  #define blas_scale cblas_dscal
+  #define blas_swap  cblas_dswap
+  #define blas_axpy  cblas_daxpy
+  #define blas_2norm cblas_dnrm2
+  #define blas_asum  cblas_dasum
+  #define blas_iamax cblas_idamax
 
   // MKL Vector Math functions
   #define vml_mul    vdMul

--- a/algebra/mkl/blas_helpers.h
+++ b/algebra/mkl/blas_helpers.h
@@ -34,6 +34,8 @@
   #define blas_iamax cblas_isamax
 
   // MKL Vector Math functions
+  #define vml_add    vsAdd
+  #define vml_sub    vsSub
   #define vml_mul    vsMul
   #define vml_max    vsFmax
   #define vml_maxinc vsFmaxI
@@ -59,6 +61,8 @@
   #define blas_iamax cblas_idamax
 
   // MKL Vector Math functions
+  #define vml_add    vdAdd
+  #define vml_sub    vdSub
   #define vml_mul    vdMul
   #define vml_max    vdFmax
   #define vml_maxinc vdFmaxI

--- a/algebra/mkl/blas_helpers.h
+++ b/algebra/mkl/blas_helpers.h
@@ -22,6 +22,7 @@
 
 /* Define the blas functions based on the data type we are using */
 #ifdef OSQP_USE_FLOAT
+  // MKL Level 1 BLAS functions
   #define blas_copy  scopy
   #define blas_dot   sdot
   #define blas_scale sscal
@@ -29,12 +30,24 @@
   #define blas_axpy  saxpy
   #define blas_2norm snrm2
   #define blas_asum  sasum
+  #define blas_iamax isamax
 
+  // MKL Vector Math functions
+  #define vml_mul    vsMul
+  #define vml_max    vsFmax
+  #define vml_maxinc vsFmaxI
+  #define vml_min    vsFmin
+  #define vml_mininc vsFminI
+  #define vml_inv    vsInv
+  #define vml_sqrt   vsSqrt
+
+  // MKL Sparse BLAS functions
   #define spblas_create_csc mkl_sparse_s_create_csc
   #define spblas_set_value  mkl_sparse_s_set_value
   #define spblas_export_csc mkl_sparse_s_export_csc
   #define spblas_mv         mkl_sparse_s_mv
 #else
+  // MKL Level 1 BLAS functions
   #define blas_copy  dcopy
   #define blas_dot   ddot
   #define blas_scale dscal
@@ -42,7 +55,18 @@
   #define blas_axpy  daxpy
   #define blas_2norm dnrm2
   #define blas_asum  dasum
+  #define blas_iamax idamax
 
+  // MKL Vector Math functions
+  #define vml_mul    vdMul
+  #define vml_max    vdFmax
+  #define vml_maxinc vdFmaxI
+  #define vml_min    vdFmin
+  #define vml_mininc vdFminI
+  #define vml_inv    vdInv
+  #define vml_sqrt   vdSqrt
+
+  // MKL Sparse BLAS functions
   #define spblas_create_csc mkl_sparse_d_create_csc
   #define spblas_set_value  mkl_sparse_d_set_value
   #define spblas_export_csc mkl_sparse_d_export_csc

--- a/algebra/mkl/vector.c
+++ b/algebra/mkl/vector.c
@@ -256,38 +256,18 @@ void OSQPVectorf_plus(OSQPVectorf*      x,
                      const OSQPVectorf* a,
                      const OSQPVectorf* b) {
 
-  OSQPInt     length = a->length;
-  OSQPFloat*  av = a->values;
-  OSQPFloat*  bv = b->values;
-  OSQPFloat*  xv = x->values;
-
-  if (x == a){
-    // Don't scale the b vector
-    blas_axpy(a->length, 1.0, b->values, 1, x->values, 1);
-  }
-  else {
-    blas_copy(a->length, a->values, 1, x->values, 1); // Copy av into xv
-
-    // Don't scale the b vector
-    blas_axpy(a->length, 1.0, b->values, 1, x->values, 1); // Final addition
-  }
+  // Compute x = a + b. If x == a, compute x += b.
+  // VML can support in-place operations, so it is valid to do this when x == a to accumulate.
+  vml_add(a->length, a->values, b->values, x->values);
 }
 
 void OSQPVectorf_minus(OSQPVectorf*       x,
                        const OSQPVectorf* a,
                        const OSQPVectorf* b) {
 
-  if (x == a){
-    blas_axpy(a->length, -1.0, b->values, 1, x->values, 1);
-  }
-  else if (x == b){
-    OSQPVectorf_mult_scalar(x,-1.);
-    blas_axpy(a->length, 1.0, a->values, 1, x->values, 1);
-  }
-  else {
-    blas_copy(a->length, a->values, 1, x->values, 1);
-    blas_axpy(a->length, -1.0, b->values, 1, x->values, 1);
-  }
+  // Compute x = a - b. If x == a, compute x -= b.
+  // VML can support in-place operations, so it is valid to do this when x == a to accumulate.
+  vml_sub(a->length, a->values, b->values, x->values);
 }
 
 void OSQPVectorf_add_scaled(OSQPVectorf*       x,

--- a/algebra/mkl/vector.c
+++ b/algebra/mkl/vector.c
@@ -484,8 +484,17 @@ void OSQPVectorf_ew_bound_vec(OSQPVectorf*       x,
                               const OSQPVectorf* l,
                               const OSQPVectorf* u) {
 
-  vml_max(x->length, z->values, l->values, x->values);
-  vml_min(x->length, x->values, u->values, x->values);
+  OSQPInt i;
+  OSQPInt length = x->length;
+
+  OSQPFloat* xv = x->values;
+  OSQPFloat* zv = z->values;
+  OSQPFloat* lv = l->values;
+  OSQPFloat* uv = u->values;
+
+  for (i = 0; i < length; i++) {
+    xv[i] = c_min(c_max(zv[i], lv[i]), uv[i]);
+  }
 }
 
 void OSQPVectorf_project_polar_reccone(OSQPVectorf*       y,

--- a/algebra/mkl/vector.c
+++ b/algebra/mkl/vector.c
@@ -12,21 +12,19 @@ OSQPInt OSQPVectorf_is_eq(const OSQPVectorf* A,
                           const OSQPVectorf* B,
                                 OSQPFloat    tol) {
     OSQPInt i;
-    OSQPInt retval = 1;
-
 
     if (A->length != B->length) return 0;
 
     for (i=0; i < A->length; i++) {
         if (c_absval(A->values[i] - B->values[i]) > tol) {
-            retval = 0;
+            return 0;
         }
     }
-    return retval;
+    return 1;
 }
 
 OSQPVectorf* OSQPVectorf_new(const OSQPFloat* a,
-                             OSQPInt          length) {
+                                   OSQPInt    length) {
 
   OSQPVectorf* out = OSQPVectorf_malloc(length);
   if(!out) return OSQP_NULL;
@@ -38,7 +36,7 @@ OSQPVectorf* OSQPVectorf_new(const OSQPFloat* a,
 }
 
 OSQPVectori* OSQPVectori_new(const OSQPInt* a,
-                             OSQPInt        length) {
+                                   OSQPInt  length) {
 
   OSQPVectori* out = OSQPVectori_malloc(length);
   if(!out) return OSQP_NULL;
@@ -163,7 +161,7 @@ void OSQPVectorf_view_update(OSQPVectorf*       a,
                              OSQPInt            head,
                              OSQPInt            length) {
     a->length = length;
-    a->values   = b->values + head;
+    a->values = b->values + head;
 }
 
 void OSQPVectorf_view_free(OSQPVectorf* a) {
@@ -172,7 +170,7 @@ void OSQPVectorf_view_free(OSQPVectorf* a) {
 
 
 OSQPInt OSQPVectorf_length(const OSQPVectorf* a) {return a->length;}
-OSQPInt OSQPVectori_length(const OSQPVectori *a){return a->length;}
+OSQPInt OSQPVectori_length(const OSQPVectori *a) {return a->length;}
 
 /* Pointer to vector data (floats) */
 OSQPFloat* OSQPVectorf_data(const OSQPVectorf* a) {return a->values;}
@@ -225,8 +223,6 @@ void OSQPVectorf_set_scalar(OSQPVectorf* a,
             &sc, 0, // 0 increment to treat X argument as a scalar
             a->values, 1);
 }
-
-// I seem to have the same problem here, if I try to exploit the copy function, I will still need to compare the values and populate an initial vector
 
 void OSQPVectorf_set_scalar_conditional(OSQPVectorf*       a,
                                         const OSQPVectori* test,
@@ -439,7 +435,7 @@ OSQPFloat OSQPVectorf_dot_prod_signed(const OSQPVectorf* a,
                                       OSQPInt            sign) {
 
   OSQPInt i;
-  OSQPInt length = a->length;\
+  OSQPInt length = a->length;
 
   OSQPFloat* av = a->values;
   OSQPFloat* bv = b->values;

--- a/include/private/algebra_vector.h
+++ b/include/private/algebra_vector.h
@@ -140,7 +140,7 @@ void OSQPVectorf_plus(OSQPVectorf*       x,
                       const OSQPVectorf* a,
                       const OSQPVectorf* b);
 
-/* x = a - b.  x==a or x==-b at entry is possible */
+/* x = a - b.  Set x==a for x -= b. */
 void OSQPVectorf_minus(OSQPVectorf*      x,
                       const OSQPVectorf* a,
                       const OSQPVectorf* b);


### PR DESCRIPTION
Calling the Vector Math functions should provide more performance on some systems compared to hand-rolled loops. This isn't always true however, so we can't just replace everything. For instance, replacing a single for loop with two VML calls (such as for the elementwise bounding) might actually be more inefficient than the loop.

Also switch over to using the cblas wrapper to simplify the calling code (no need to pass pointers to integers, just pass the integers themselves).