### PR TITLE
Improve algebra backend naming and device information

### DIFF
--- a/algebra/builtin/algebra_libs.c
+++ b/algebra/builtin/algebra_libs.c
@@ -16,8 +16,25 @@ OSQPInt osqp_algebra_init_libs(OSQPInt device) {return 0;}
 
 void osqp_algebra_free_libs(void) {return;}
 
-const char* osqp_algebra_name(void) {
-  return "Built-in";
+OSQPInt osqp_algebra_name(char* name, OSQPInt nameLen) {
+  // Manually assign into the buffer to avoid using strcpy
+  name[0] = 'B';
+  name[1] = 'u';
+  name[2] = 'i';
+  name[3] = 'l';
+  name[4] = 't';
+  name[5] = '-';
+  name[6] = 'i';
+  name[7] = 'n';
+  name[8] = 0;
+
+  return 9;
+}
+
+OSQPInt osqp_algebra_device_name(char* name, OSQPInt nameLen) {
+  /* No device name for built-in algebra */
+  name[0] = 0;
+  return 0;
 }
 
 #ifndef OSQP_EMBEDDED_MODE

--- a/algebra/cuda/algebra_libs.cu
+++ b/algebra/cuda/algebra_libs.cu
@@ -21,6 +21,8 @@
 #include "cuda_handler.h"
 #include "cuda_pcg_interface.h"
 
+ #include <stdio.h>
+
 
 CUDA_Handle_t *CUDA_handle = OSQP_NULL;
 
@@ -51,8 +53,23 @@ void osqp_algebra_free_libs(void) {
   CUDA_handle = OSQP_NULL;
 }
 
-const char* osqp_algebra_name(void) {
-  return "CUDA";
+OSQPInt osqp_algebra_name(char* name, OSQPInt nameLen) {
+  OSQPInt runtimeVersion = 0;
+
+  cudaRuntimeGetVersion(&runtimeVersion);
+
+  return snprintf(name, nameLen, "CUDA %d.%d",
+                  runtimeVersion / 1000, (runtimeVersion % 100) / 10);
+}
+
+OSQPInt osqp_algebra_device_name(char* name, OSQPInt nameLen) {
+  OSQPInt dev;
+  cudaDeviceProp deviceProp;
+
+  cudaGetDevice(&dev);
+  cudaGetDeviceProperties(&deviceProp, dev);
+
+  return snprintf(name, nameLen, "%s (Compute capability %d.%d)", deviceProp.name, deviceProp.major, deviceProp.minor);
 }
 
 // Initialize linear system solver structure

--- a/algebra/mkl/algebra_libs.c
+++ b/algebra/mkl/algebra_libs.c
@@ -7,6 +7,8 @@
 
 #include <mkl.h>
 
+#include <stdio.h>
+
 OSQPInt osqp_algebra_linsys_supported(void) {
   /* Has both Paradiso (direct solver) and a PCG solver (indirect solver) */
   return OSQP_CAPABILITY_DIRECT_SOLVER | OSQP_CAPABILITY_INDIRECT_SOLVER;
@@ -35,8 +37,20 @@ OSQPInt osqp_algebra_init_libs(OSQPInt device) {
 
 void osqp_algebra_free_libs(void) {return;}
 
-const char* osqp_algebra_name(void) {
-  return "MKL";
+OSQPInt osqp_algebra_name(char* name, OSQPInt nameLen) {
+    MKLVersion ver;
+
+    mkl_get_version(&ver);
+
+    return snprintf(name, nameLen, "Intel oneAPI MKL %d.%d.%d", ver.MajorVersion, ver.MinorVersion, ver.UpdateVersion);
+}
+
+OSQPInt osqp_algebra_device_name(char* name, OSQPInt nameLen) {
+  MKLVersion ver;
+
+  mkl_get_version(&ver);
+
+  return snprintf(name, nameLen, "%s", ver.Processor);
 }
 
 // Initialize linear system solver structure

--- a/include/private/lin_alg.h
+++ b/include/private/lin_alg.h
@@ -22,7 +22,10 @@ OSQPInt osqp_algebra_init_libs(OSQPInt device);
 void osqp_algebra_free_libs(void);
 
 /* Get the name of the linear algebra backend */
-const char* osqp_algebra_name(void);
+OSQPInt osqp_algebra_name(char* name, OSQPInt nameLen);
+
+/* Get the name of the device the linear algebra backend is using */
+OSQPInt osqp_algebra_device_name(char* name, OSQPInt nameLen);
 
 /* KKT linear system definition and solution */
 

--- a/src/util.c
+++ b/src/util.c
@@ -61,6 +61,15 @@ void print_setup_header(const OSQPSolver* solver) {
 
   OSQPInt nnz; // Number of nonzeros in the problem
 
+#define NAMEBUFLEN 30
+  char namebuf[NAMEBUFLEN];
+
+/* Disable device printing in embedded mode to save stack space */
+#ifndef OSQP_EMBEDDED_MODE
+  #define DEVICEBUFLEN 150
+  char devicebuf[DEVICEBUFLEN];
+#endif
+
   work     = solver->work;
   data     = solver->work->data;
   settings = solver->settings;
@@ -84,8 +93,19 @@ void print_setup_header(const OSQPSolver* solver) {
 
   // Print Settings
   c_print("settings: ");
-  c_print("algebra = %s", osqp_algebra_name());
+
+  osqp_algebra_name(namebuf, NAMEBUFLEN);
+  c_print("algebra = %s", namebuf);
   c_print(",\n          ");
+
+#ifndef OSQP_EMBEDDED_MODE
+  osqp_algebra_device_name(devicebuf, DEVICEBUFLEN);
+
+  if (devicebuf[0] != 0 ) {
+    c_print("device = %s", devicebuf);
+    c_print(",\n          ");
+  }
+#endif
 
   c_print("linear system solver = %s", work->linsys_solver->name(work->linsys_solver));
 


### PR DESCRIPTION
This PR improves the device name to now include version information for the libraries being used (e.g. MKL version and CUDA version), and also includes information about the device OSQP is configured to run on. The device information isn't included in the embedded mode (compiled out), and is blank for the built-in algebra. This information is useful to see what the type of GPU is when using CUDA and what optimizations are used with MKL.

Sample MKL output from an Intel Xeon:
```
This OSQP library supports:
    A direct linear algebra solver
    An indirect linear algebra solver

-----------------------------------------------------------------
           OSQP v0.0.0  -  Operator Splitting QP Solver
              (c) Bartolomeo Stellato,  Goran Banjac
        University of Oxford  -  Stanford University 2021
-----------------------------------------------------------------
problem:  variables n = 2, constraints m = 3
          nnz(P) + nnz(A) = 7
settings: algebra = Intel oneAPI MKL 2023.0.1,
          device = Intel(R) Advanced Vector Extensions 512 (Intel(R) AVX-512) with support of Intel(R) Deep Learning Boost (Intel(R) DL Boost),
          linear system solver = Pardiso (10 threads),
          eps_abs = 1.0e-03, eps_rel = 1.0e-03,
          eps_prim_inf = 1.0e-04, eps_dual_inf = 1.0e-04,
          rho = 1.00e-01 (adaptive),
          sigma = 1.00e-06, alpha = 1.60, max_iter = 4000
          check_termination: on (interval 25),
          time_limit: 1.00e+10 sec,
          scaling: on, scaled_termination: off
          warm starting: on, polishing: on, 
iter   objective    prim res   dual res   rho        time
   1  -7.8808e-03   1.01e+00   2.00e+02   1.00e-01   2.89e-02s
  25   1.8797e+00   1.60e-03   9.48e-04   1.00e-01   2.90e-02s
plsh   1.8800e+00   0.00e+00   3.14e-16   --------   2.94e-02s

status:               solved
solution polishing:   successful
number of iterations: 25
optimal objective:    1.8800
run time:             2.94e-02s
optimal rho estimate: 2.14e-01
```

Sample CUDA output:
```
This OSQP library supports:
    An indirect linear algebra solver

-----------------------------------------------------------------
           OSQP v0.0.0  -  Operator Splitting QP Solver
              (c) Bartolomeo Stellato,  Goran Banjac
        University of Oxford  -  Stanford University 2021
-----------------------------------------------------------------
problem:  variables n = 2, constraints m = 3
          nnz(P) + nnz(A) = 7
settings: algebra = CUDA 12.1,
          device = NVIDIA T1000 (Compute capability 7.5),
          linear system solver = CUDA Conjugate Gradient - Diagonal preconditioner,
          eps_abs = 1.0e-03, eps_rel = 1.0e-03,
          eps_prim_inf = 1.0e-04, eps_dual_inf = 1.0e-04,
          rho = 1.00e-01 (adaptive),
          sigma = 1.00e-06, alpha = 1.60, max_iter = 4000
          check_termination: on (interval 5),
          time_limit: 1.00e+10 sec,
          scaling: on, scaled_termination: off
          warm starting: on, polishing: on, 
iter   objective    prim res   dual res   rho        time
   1  -2.4617e-01   1.76e+00   9.87e-01   1.00e-01   9.56e-01s
  30   1.8769e+00   1.02e-03   4.72e-04   4.15e-01   9.70e-01s
plsh   1.8800e+00   0.00e+00   0.00e+00   --------   9.73e-01s

status:               solved
solution polishing:   successful
number of iterations: 30
optimal objective:    1.8800
run time:             9.73e-01s
optimal rho estimate: 1.19e+00
```