### PR TITLE
Allow tests to run on a specified compute device & modernize tests

### DIFF
--- a/algebra/cuda/lin_sys/indirect/cuda_pcg_interface.cu
+++ b/algebra/cuda/lin_sys/indirect/cuda_pcg_interface.cu
@@ -145,13 +145,13 @@ OSQPInt init_linsys_solver_cudapcg(cudapcg_solver**    sp,
   s->d_P_diag_ind = P->d_P_diag_ind;
   s->d_rho_vec    = rho_vec ? rho_vec->d_val : NULL;
 
-  if (!polishing) {
-    s->h_sigma = settings->sigma;
-    s->h_rho   = settings->rho;
-  }
-  else {
+  if (polishing) {
     s->h_sigma = settings->delta;
     s->h_rho   = 1. / settings->delta;
+  }
+  else {
+    s->h_sigma = settings->sigma;
+    s->h_rho   = settings->rho;
   }
 
   /* Allocate raw PCG iterates */

--- a/algebra/cuda/lin_sys/indirect/cuda_pcg_interface.cu
+++ b/algebra/cuda/lin_sys/indirect/cuda_pcg_interface.cu
@@ -143,8 +143,8 @@ OSQPInt init_linsys_solver_cudapcg(cudapcg_solver**    sp,
   s->At           = A->At;
   s->P            = P->S;
   s->d_P_diag_ind = P->d_P_diag_ind;
-  if (rho_vec)
-    s->d_rho_vec  = rho_vec->d_val;
+  s->d_rho_vec    = rho_vec ? rho_vec->d_val : NULL;
+
   if (!polishing) {
     s->h_sigma = settings->sigma;
     s->h_rho   = settings->rho;
@@ -194,6 +194,7 @@ OSQPInt init_linsys_solver_cudapcg(cudapcg_solver**    sp,
   cuda_malloc((void **) &s->d_diag_precond,     n * sizeof(OSQPFloat));
   cuda_malloc((void **) &s->d_diag_precond_inv, n * sizeof(OSQPFloat));
   if (!s->d_rho_vec) cuda_malloc((void **) &s->d_AtA_diag_val, n * sizeof(OSQPFloat));
+  else s->d_AtA_diag_val = NULL;
 
   /* Link functions */
   s->name            = &name_cudapcg;

--- a/src/osqp_api.c
+++ b/src/osqp_api.c
@@ -217,6 +217,10 @@ OSQPInt osqp_setup(OSQPSolver**         solverp,
     work->constr_type = OSQPVectori_calloc(m);
     if (!(work->constr_type)) return osqp_error(OSQP_MEM_ALLOC_ERROR);
   }
+  else {
+    work->rho_vec     = OSQP_NULL;
+    work->rho_inv_vec = OSQP_NULL;
+  }
 
   // Allocate internal solver variables (ADMM steps)
   work->x           = OSQPVectorf_calloc(n);

--- a/tests/basic_lp/test_basic_lp.cpp
+++ b/tests/basic_lp/test_basic_lp.cpp
@@ -15,13 +15,6 @@ TEST_CASE_METHOD(OSQPTestFixture, "Basic LP", "[solve][lp]" )
   basic_lp_problem_ptr data{generate_problem_basic_lp()};
   basic_lp_sols_data_ptr sols_data{generate_problem_basic_lp_sols_data()};
 
-  // Define Solver settings as default
-  settings->max_iter = 2000;
-  settings->scaling  = 1;
-  settings->verbose  = 1;
-  settings->eps_abs  = 1e-5;
-  settings->eps_rel  = 1e-5;
-
   /* Test with and without polishing */
   OSQPInt polish;
   OSQPInt expectedPolishStatus;

--- a/tests/basic_lp/test_basic_lp.cpp
+++ b/tests/basic_lp/test_basic_lp.cpp
@@ -7,23 +7,15 @@
 #include "basic_lp_data.h"
 
 
-TEST_CASE( "Basic LP", "[solve][lp]" )
+TEST_CASE_METHOD(OSQPTestFixture, "Basic LP", "[solve][lp]" )
 {
   OSQPInt exitflag;
-
-  // Problem settings
-  OSQPSettings_ptr settings{(OSQPSettings *)c_malloc(sizeof(OSQPSettings))};
-
-  // Structures
-  OSQPSolver*    tmpSolver = nullptr;
-  OSQPSolver_ptr solver{nullptr};   // Wrap solver inside memory management
 
   // Populate data
   basic_lp_problem_ptr data{generate_problem_basic_lp()};
   basic_lp_sols_data_ptr sols_data{generate_problem_basic_lp_sols_data()};
 
   // Define Solver settings as default
-  osqp_set_default_settings(settings.get());
   settings->max_iter = 2000;
   settings->scaling  = 1;
   settings->verbose  = 1;

--- a/tests/basic_lp/test_basic_lp.cpp
+++ b/tests/basic_lp/test_basic_lp.cpp
@@ -7,13 +7,9 @@
 #include "basic_lp_data.h"
 
 
-TEST_CASE_METHOD(OSQPTestFixture, "Basic LP", "[solve][lp]" )
+TEST_CASE_METHOD(basic_lp_test_fixture, "Basic LP", "[solve][lp]")
 {
   OSQPInt exitflag;
-
-  // Populate data
-  basic_lp_problem_ptr data{generate_problem_basic_lp()};
-  basic_lp_sols_data_ptr sols_data{generate_problem_basic_lp_sols_data()};
 
   /* Test with and without polishing */
   OSQPInt polish;

--- a/tests/basic_qp/test_basic_qp.cpp
+++ b/tests/basic_qp/test_basic_qp.cpp
@@ -720,6 +720,9 @@ TEST_CASE_METHOD(basic_qp_test_fixture, "Basic QP: Update rho", "[update][qp]")
   // rho to use
   OSQPFloat rho;
 
+  /* Test all possible linear system solvers in this test case */
+  osqp_linsys_solver_type linsys = GENERATE(filter(&isLinsysSupported, values({OSQP_DIRECT_SOLVER, OSQP_INDIRECT_SOLVER})));
+
   // Define number of iterations to compare
   OSQPInt n_iter_new_solver;
   OSQPInt n_iter_update_rho;
@@ -732,6 +735,7 @@ TEST_CASE_METHOD(basic_qp_test_fixture, "Basic QP: Update rho", "[update][qp]")
   settings->eps_abs           = 5e-05;
   settings->eps_rel           = 5e-05;
   settings->check_termination = 1;
+  settings->linsys_solver     = linsys;
 
   // Setup solver
   exitflag = osqp_setup(&tmpSolver, data->P, data->q,
@@ -774,6 +778,7 @@ TEST_CASE_METHOD(basic_qp_test_fixture, "Basic QP: Update rho", "[update][qp]")
   settings->check_termination = 1;
   settings->eps_abs           = 5e-05;
   settings->eps_rel           = 5e-05;
+  settings->linsys_solver     = linsys;
 
   // Setup solver
   exitflag = osqp_setup(&tmpSolver, data->P, data->q,
@@ -897,6 +902,9 @@ TEST_CASE_METHOD(basic_qp_test_fixture, "Basic QP: Warm start", "[solve][qp][war
                         data->A, data->l, data->u,
                         data->m, data->n, settings.get());
   solver.reset(tmpSolver);
+
+  // Setup correct
+  mu_assert("Basic QP test warm start: Setup error!", exitflag == 0);
 
   // Solve Problem initially
   osqp_solve(solver.get());

--- a/tests/basic_qp/test_basic_qp.cpp
+++ b/tests/basic_qp/test_basic_qp.cpp
@@ -781,6 +781,7 @@ TEST_CASE_METHOD(basic_qp_test_fixture, "Basic QP: Update rho", "[update][qp]")
   settings->linsys_solver     = linsys;
 
   // Setup solver
+  solver.reset(nullptr);  // TODO (CUDA): Needed until CUDA supports multiple instances
   exitflag = osqp_setup(&tmpSolver, data->P, data->q,
                         data->A, data->l, data->u,
                         data->m, data->n, settings.get());

--- a/tests/basic_qp/test_basic_qp.cpp
+++ b/tests/basic_qp/test_basic_qp.cpp
@@ -659,9 +659,12 @@ TEST_CASE_METHOD(basic_qp_test_fixture, "Basic QP: Termination", "[solve][qp]")
   OSQPInt exitflag;
 
   // Problem-specific settings
+  osqp_set_default_settings(settings.get());
   settings->max_iter          = 200;
+  settings->alpha             = 1.6;
   settings->polishing         = 0;
   settings->scaling           = 0;
+  settings->verbose           = 1;
   settings->check_termination = 0;
   settings->warm_starting     = 0;
 

--- a/tests/basic_qp/test_basic_qp.cpp
+++ b/tests/basic_qp/test_basic_qp.cpp
@@ -7,13 +7,9 @@
 #include "basic_qp_data.h"
 
 
-TEST_CASE_METHOD(OSQPTestFixture, "Basic QP: Solve", "[solve][qp]")
+TEST_CASE_METHOD(basic_qp_test_fixture, "Basic QP: Solve", "[solve][qp]")
 {
   OSQPInt exitflag;
-
-  // Populate data
-  basic_qp_problem_ptr data{generate_problem_basic_qp()};
-  basic_qp_sols_data_ptr sols_data{generate_problem_basic_qp_sols_data()};
 
   // Test-specific options
   settings->polishing     = 1;
@@ -58,7 +54,7 @@ TEST_CASE_METHOD(OSQPTestFixture, "Basic QP: Solve", "[solve][qp]")
       TESTS_TOL);
 }
 
-void test_basic_qp_settings()
+TEST_CASE_METHOD(basic_qp_test_fixture, "Basic QP: Settings", "[solve][qp]")
 {
   OSQPInt        exitflag;
   OSQPInt        tmp_int;
@@ -66,20 +62,7 @@ void test_basic_qp_settings()
   OSQPCscMatrix* tmp_mat;
   OSQPCscMatrix* P_tmp;
 
-  // Problem settings
-  OSQPSettings *settings = (OSQPSettings *)c_malloc(sizeof(OSQPSettings));
-
-  // Structures
-  OSQPSolver   *solver; // Solver
-  OSQPTestData *data;      // Data
-  basic_qp_sols_data *sols_data;
-
-  // Populate data
-  data = generate_problem_basic_qp();
-  sols_data = generate_problem_basic_qp_sols_data();
-
   // Define Solver settings as default
-  osqp_set_default_settings(settings);
   settings->max_iter      = 2000;
   settings->alpha         = 1.6;
   settings->polishing     = 1;
@@ -88,16 +71,17 @@ void test_basic_qp_settings()
   settings->warm_starting = 0;
 
   // Setup solver
-  exitflag = osqp_setup(&solver, data->P, data->q,
+  exitflag = osqp_setup(&tmpSolver, data->P, data->q,
                         data->A, data->l, data->u,
-                        data->m, data->n, settings);
+                        data->m, data->n, settings.get());
+  solver.reset(tmpSolver);
 
   // Setup correct
   mu_assert("Basic QP test solve: Setup error!", exitflag == 0);
 
 
   // Solve Problem
-  osqp_solve(solver);
+  osqp_solve(solver.get());
 
   // Compare solver statuses
   mu_assert("Basic QP test solve: Error in solver status!",
@@ -121,93 +105,94 @@ void test_basic_qp_settings()
 
   // Try to set wrong settings
   mu_assert("Basic QP test solve: Wrong value of rho not caught!",
-	    osqp_update_rho(solver, -0.1) == 1);
+	    osqp_update_rho(solver.get(), -0.1) == 1);
 
   settings->max_iter = -1;
   mu_assert("Basic QP test solve: Wrong value of max_iter not caught!",
-	    osqp_update_settings(solver, settings) > 0);
+	    osqp_update_settings(solver.get(), settings.get()) > 0);
   settings->max_iter = 2000;
 
   settings->eps_abs = -1.;
   mu_assert("Basic QP test solve: Wrong value of eps_abs not caught!",
-	    osqp_update_settings(solver, settings) > 0);
+	    osqp_update_settings(solver.get(), settings.get()) > 0);
   settings->eps_abs = OSQP_EPS_ABS;
 
   settings->eps_rel = -1.;
   mu_assert("Basic QP test solve: Wrong value of eps_rel not caught!",
-	    osqp_update_settings(solver, settings) > 0);
+	    osqp_update_settings(solver.get(), settings.get()) > 0);
   settings->eps_rel = OSQP_EPS_REL;
 
   settings->eps_prim_inf = -0.1;
   mu_assert("Basic QP test solve: Wrong value of eps_prim_inf not caught!",
-	    osqp_update_settings(solver, settings) > 0);
+	    osqp_update_settings(solver.get(), settings.get()) > 0);
   settings->eps_prim_inf = OSQP_EPS_PRIM_INF;
 
   settings->eps_dual_inf = -0.1;
   mu_assert("Basic QP test solve: Wrong value of eps_dual_inf not caught!",
-	    osqp_update_settings(solver, settings) > 0);
+	    osqp_update_settings(solver.get(), settings.get()) > 0);
   settings->eps_dual_inf = OSQP_EPS_DUAL_INF;
 
   settings->alpha = 2.0;
   mu_assert("Basic QP test solve: Wrong value of alpha not caught!",
-	    osqp_update_settings(solver, settings) > 0);
+	    osqp_update_settings(solver.get(), settings.get()) > 0);
   settings->alpha = OSQP_ALPHA;
 
   settings->warm_starting = -1;
   mu_assert("Basic QP test solve: Wrong value of warm_starting not caught!",
-	    osqp_update_settings(solver, settings) > 0);
+	    osqp_update_settings(solver.get(), settings.get()) > 0);
   settings->warm_starting = 0;
 
   settings->scaled_termination = 2;
   mu_assert("Basic QP test solve: Wrong value of scaled_termination not caught!",
-	    osqp_update_settings(solver, settings) > 0);
+	    osqp_update_settings(solver.get(), settings.get()) > 0);
   settings->scaled_termination = OSQP_SCALED_TERMINATION;
 
   settings->check_termination = -1;
   mu_assert("Basic QP test solve: Wrong value of check_termination not caught!",
-	    osqp_update_settings(solver, settings) > 0);
+	    osqp_update_settings(solver.get(), settings.get()) > 0);
   settings->check_termination = OSQP_CHECK_TERMINATION;
 
   settings->delta = 0.0;
   mu_assert("Basic QP test solve: Wrong value of delta not caught!",
-	    osqp_update_settings(solver, settings) > 0);
+	    osqp_update_settings(solver.get(), settings.get()) > 0);
   settings->delta = OSQP_DELTA;
 
   settings->polishing = 2;
   mu_assert("Basic QP test solve: Wrong value of polishing not caught!",
-	    osqp_update_settings(solver, settings) > 0);
+	    osqp_update_settings(solver.get(), settings.get()) > 0);
   settings->polishing = 1;
 
   settings->polish_refine_iter = -1;
   mu_assert("Basic QP test solve: Wrong value of polish_refine_iter not caught!",
-	    osqp_update_settings(solver, settings) > 0);
+	    osqp_update_settings(solver.get(), settings.get()) > 0);
   settings->polish_refine_iter = OSQP_POLISH_REFINE_ITER;
 
   settings->verbose = 2;
   mu_assert("Basic QP test solve: Wrong value of verbose not caught!",
-	    osqp_update_settings(solver, settings) > 0);
+	    osqp_update_settings(solver.get(), settings.get()) > 0);
   settings->verbose = 1;
-
-  // Clean solver
-  osqp_cleanup(solver);
 
   /* =============================
        SETUP WITH WRONG SETTINGS
      ============================= */
+  tmpSolver = nullptr;
 
   // Setup solver with empty settings
-  exitflag = osqp_setup(&solver, data->P, data->q,
+  exitflag = osqp_setup(&tmpSolver, data->P, data->q,
                         data->A, data->l, data->u,
                         data->m, data->n, OSQP_NULL);
+  solver.reset(tmpSolver);
+
   mu_assert("Basic QP test solve: Setup should result in error due to empty settings",
             exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
 
   // Setup solver with a wrong number of scaling iterations
   tmp_int = settings->scaling;
   settings->scaling = -1;
-  exitflag = osqp_setup(&solver, data->P, data->q,
+  exitflag = osqp_setup(&tmpSolver, data->P, data->q,
                         data->A, data->l, data->u,
-                        data->m, data->n, settings);
+                        data->m, data->n, settings.get());
+  solver.reset(tmpSolver);
   mu_assert("Basic QP test solve: Setup should result in error due to a negative number of scaling iterations",
             exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
   settings->scaling = tmp_int;
@@ -215,9 +200,10 @@ void test_basic_qp_settings()
   // Setup solver with wrong settings->adaptive_rho
   tmp_int = settings->adaptive_rho;
   settings->adaptive_rho = 2;
-  exitflag = osqp_setup(&solver, data->P, data->q,
+  exitflag = osqp_setup(&tmpSolver, data->P, data->q,
                         data->A, data->l, data->u,
-                        data->m, data->n, settings);
+                        data->m, data->n, settings.get());
+  solver.reset(tmpSolver);
   mu_assert("Basic QP test solve: Setup should result in error due to non-boolean settings->adaptive_rho",
             exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
   settings->adaptive_rho = tmp_int;
@@ -225,9 +211,10 @@ void test_basic_qp_settings()
   // Setup solver with wrong settings->adaptive_rho_interval
   tmp_int = settings->adaptive_rho_interval;
   settings->adaptive_rho_interval = -1;
-  exitflag = osqp_setup(&solver, data->P, data->q,
+  exitflag = osqp_setup(&tmpSolver, data->P, data->q,
                         data->A, data->l, data->u,
-                        data->m, data->n, settings);
+                        data->m, data->n, settings.get());
+  solver.reset(tmpSolver);
   mu_assert("Basic QP test solve: Setup should result in error due to negative settings->adaptive_rho_interval",
             exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
   settings->adaptive_rho_interval = tmp_int;
@@ -237,9 +224,10 @@ void test_basic_qp_settings()
   tmp_float = settings->adaptive_rho_fraction;
   settings->adaptive_rho_fraction = -1.5;
   // Setup solver
-  exitflag = osqp_setup(&solver, data->P, data->q,
+  exitflag = osqp_setup(&tmpSolver, data->P, data->q,
                         data->A, data->l, data->u,
-                        data->m, data->n, settings);
+                        data->m, data->n, settings.get());
+  solver.reset(tmpSolver);
   mu_assert("Basic QP test solve: Setup should result in error due to non-positive settings->adaptive_rho_fraction",
             exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
   settings->adaptive_rho_fraction = tmp_float;
@@ -248,9 +236,10 @@ void test_basic_qp_settings()
   // Setup solver with wrong settings->adaptive_rho_tolerance
   tmp_float = settings->adaptive_rho_tolerance;
   settings->adaptive_rho_tolerance = 0.5;
-  exitflag = osqp_setup(&solver, data->P, data->q,
+  exitflag = osqp_setup(&tmpSolver, data->P, data->q,
                         data->A, data->l, data->u,
-                        data->m, data->n, settings);
+                        data->m, data->n, settings.get());
+  solver.reset(tmpSolver);
   mu_assert("Basic QP test solve: Setup should result in error due to wrong settings->adaptive_rho_tolerance",
             exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
   settings->adaptive_rho_tolerance = tmp_float;
@@ -258,9 +247,10 @@ void test_basic_qp_settings()
   // Setup solver with wrong settings->polish_refine_iter
   tmp_int = settings->polish_refine_iter;
   settings->polish_refine_iter = -3;
-  exitflag = osqp_setup(&solver, data->P, data->q,
+  exitflag = osqp_setup(&tmpSolver, data->P, data->q,
                         data->A, data->l, data->u,
-                        data->m, data->n, settings);
+                        data->m, data->n, settings.get());
+  solver.reset(tmpSolver);
   mu_assert("Basic QP test solve: Setup should result in error due to negative settings->polish_refine_iter",
             exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
   settings->polish_refine_iter = tmp_int;
@@ -268,9 +258,10 @@ void test_basic_qp_settings()
   // Setup solver with wrong settings->rho
   tmp_float = settings->rho;
   settings->rho = 0.0;
-  exitflag = osqp_setup(&solver, data->P, data->q,
+  exitflag = osqp_setup(&tmpSolver, data->P, data->q,
                         data->A, data->l, data->u,
-                        data->m, data->n, settings);
+                        data->m, data->n, settings.get());
+  solver.reset(tmpSolver);
   mu_assert("Basic QP test solve: Setup should result in error due to non-positive settings->rho",
             exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
   settings->rho = tmp_float;
@@ -278,9 +269,10 @@ void test_basic_qp_settings()
   // Setup solver with wrong settings->sigma
   tmp_float = settings->sigma;
   settings->sigma = -0.1;
-  exitflag = osqp_setup(&solver, data->P, data->q,
+  exitflag = osqp_setup(&tmpSolver, data->P, data->q,
                         data->A, data->l, data->u,
-                        data->m, data->n, settings);
+                        data->m, data->n, settings.get());
+  solver.reset(tmpSolver);
   mu_assert("Basic QP test solve: Setup should result in error due to non-positive settings->sigma",
             exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
   settings->sigma = tmp_float;
@@ -288,9 +280,10 @@ void test_basic_qp_settings()
   // Setup solver with wrong settings->delta
   tmp_float = settings->delta;
   settings->delta = -1.1;
-  exitflag = osqp_setup(&solver, data->P, data->q,
+  exitflag = osqp_setup(&tmpSolver, data->P, data->q,
                         data->A, data->l, data->u,
-                        data->m, data->n, settings);
+                        data->m, data->n, settings.get());
+  solver.reset(tmpSolver);
   mu_assert("Basic QP test solve: Setup should result in error due to non-positive settings->delta",
             exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
   settings->delta = tmp_float;
@@ -298,9 +291,10 @@ void test_basic_qp_settings()
   // Setup solver with wrong settings->max_iter
   tmp_int = settings->max_iter;
   settings->max_iter = 0;
-  exitflag = osqp_setup(&solver, data->P, data->q,
+  exitflag = osqp_setup(&tmpSolver, data->P, data->q,
                         data->A, data->l, data->u,
-                        data->m, data->n, settings);
+                        data->m, data->n, settings.get());
+  solver.reset(tmpSolver);
   mu_assert("Basic QP test solve: Setup should result in error due to non-positive settings->max_iter",
             exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
   settings->max_iter = tmp_int;
@@ -308,9 +302,10 @@ void test_basic_qp_settings()
   // Setup solver with wrong settings->eps_abs
   tmp_float = settings->eps_abs;
   settings->eps_abs = -1.1;
-  exitflag = osqp_setup(&solver, data->P, data->q,
+  exitflag = osqp_setup(&tmpSolver, data->P, data->q,
                         data->A, data->l, data->u,
-                        data->m, data->n, settings);
+                        data->m, data->n, settings.get());
+  solver.reset(tmpSolver);
   mu_assert("Basic QP test solve: Setup should result in error due to negative settings->eps_abs",
             exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
   settings->eps_abs = tmp_float;
@@ -318,9 +313,10 @@ void test_basic_qp_settings()
   // Setup solver with wrong settings->eps_rel
   tmp_float = settings->eps_rel;
   settings->eps_rel = -0.1;
-  exitflag = osqp_setup(&solver, data->P, data->q,
+  exitflag = osqp_setup(&tmpSolver, data->P, data->q,
                         data->A, data->l, data->u,
-                        data->m, data->n, settings);
+                        data->m, data->n, settings.get());
+  solver.reset(tmpSolver);
   mu_assert("Basic QP test solve: Setup should result in error due to negative settings->eps_rel",
             exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
   settings->eps_rel = tmp_float;
@@ -328,9 +324,10 @@ void test_basic_qp_settings()
   // Setup solver with wrong settings->eps_prim_inf
   tmp_float = settings->eps_prim_inf;
   settings->eps_prim_inf = -0.1;
-  exitflag = osqp_setup(&solver, data->P, data->q,
+  exitflag = osqp_setup(&tmpSolver, data->P, data->q,
                         data->A, data->l, data->u,
-                        data->m, data->n, settings);
+                        data->m, data->n, settings.get());
+  solver.reset(tmpSolver);
   mu_assert("Basic QP test solve: Setup should result in error due to non-positive settings->eps_prim_inf",
             exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
   settings->eps_prim_inf = tmp_float;
@@ -338,9 +335,10 @@ void test_basic_qp_settings()
   // Setup solver with wrong settings->eps_dual_inf
   tmp_float = settings->eps_dual_inf;
   settings->eps_dual_inf = 0.0;
-  exitflag = osqp_setup(&solver, data->P, data->q,
+  exitflag = osqp_setup(&tmpSolver, data->P, data->q,
                         data->A, data->l, data->u,
-                        data->m, data->n, settings);
+                        data->m, data->n, settings.get());
+  solver.reset(tmpSolver);
   mu_assert("Basic QP test solve: Setup should result in error due to non-positive settings->eps_dual_inf",
             exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
   settings->eps_dual_inf = tmp_float;
@@ -348,9 +346,10 @@ void test_basic_qp_settings()
   // Setup solver with wrong settings->alpha
   tmp_float = settings->alpha;
   settings->alpha = 2.0;
-  exitflag = osqp_setup(&solver, data->P, data->q,
+  exitflag = osqp_setup(&tmpSolver, data->P, data->q,
                         data->A, data->l, data->u,
-                        data->m, data->n, settings);
+                        data->m, data->n, settings.get());
+  solver.reset(tmpSolver);
   mu_assert("Basic QP test solve: Setup should result in error due to wrong settings->alpha",
             exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
   settings->alpha = tmp_float;
@@ -358,9 +357,10 @@ void test_basic_qp_settings()
   // Setup solver with wrong settings->linsys_solver
   enum osqp_linsys_solver_type tmp_solver_type = settings->linsys_solver;
   settings->linsys_solver = OSQP_UNKNOWN_SOLVER;
-  exitflag = osqp_setup(&solver, data->P, data->q,
+  exitflag = osqp_setup(&tmpSolver, data->P, data->q,
                         data->A, data->l, data->u,
-                        data->m, data->n, settings);
+                        data->m, data->n, settings.get());
+  solver.reset(tmpSolver);
   mu_assert("Basic QP test solve: Setup should result in error due to wrong settings->linsys_solver",
             exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
   settings->linsys_solver = tmp_solver_type;
@@ -368,9 +368,10 @@ void test_basic_qp_settings()
   // Setup solver with wrong settings->verbose
   tmp_int = settings->verbose;
   settings->verbose = 2;
-  exitflag = osqp_setup(&solver, data->P, data->q,
+  exitflag = osqp_setup(&tmpSolver, data->P, data->q,
                         data->A, data->l, data->u,
-                        data->m, data->n, settings);
+                        data->m, data->n, settings.get());
+  solver.reset(tmpSolver);
   mu_assert("Basic QP test solve: Setup should result in error due to non-boolean settings->verbose",
             exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
   settings->verbose = tmp_int;
@@ -378,9 +379,10 @@ void test_basic_qp_settings()
   // Setup solver with wrong settings->scaled_termination
   tmp_int = settings->scaled_termination;
   settings->scaled_termination = 2;
-  exitflag = osqp_setup(&solver, data->P, data->q,
+  exitflag = osqp_setup(&tmpSolver, data->P, data->q,
                         data->A, data->l, data->u,
-                        data->m, data->n, settings);
+                        data->m, data->n, settings.get());
+  solver.reset(tmpSolver);
   mu_assert("Basic QP test solve: Setup should result in error due to non-boolean settings->scaled_termination",
             exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
   settings->scaled_termination = tmp_int;
@@ -388,9 +390,10 @@ void test_basic_qp_settings()
   // Setup solver with wrong settings->check_termination
   tmp_int = settings->check_termination;
   settings->check_termination = -1;
-  exitflag = osqp_setup(&solver, data->P, data->q,
+  exitflag = osqp_setup(&tmpSolver, data->P, data->q,
                         data->A, data->l, data->u,
-                        data->m, data->n, settings);
+                        data->m, data->n, settings.get());
+  solver.reset(tmpSolver);
   mu_assert("Basic QP test solve: Setup should result in error due to non-boolean settings->check_termination",
             exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
   settings->check_termination = tmp_int;
@@ -398,9 +401,10 @@ void test_basic_qp_settings()
   // Setup solver with wrong settings->warm_starting
   tmp_int = settings->warm_starting;
   settings->warm_starting = 5;
-  exitflag = osqp_setup(&solver, data->P, data->q,
+  exitflag = osqp_setup(&tmpSolver, data->P, data->q,
                         data->A, data->l, data->u,
-                        data->m, data->n, settings);
+                        data->m, data->n, settings.get());
+  solver.reset(tmpSolver);
   mu_assert("Basic QP test solve: Setup should result in error due to non-boolean settings->warm_starting",
             exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
   settings->warm_starting = tmp_int;
@@ -409,9 +413,10 @@ void test_basic_qp_settings()
   // Setup solver with wrong settings->time_limit
   tmp_float = settings->time_limit;
   settings->time_limit = -0.2;
-  exitflag = osqp_setup(&solver, data->P, data->q,
+  exitflag = osqp_setup(&tmpSolver, data->P, data->q,
                         data->A, data->l, data->u,
-                        data->m, data->n, settings);
+                        data->m, data->n, settings.get());
+  solver.reset(tmpSolver);
   mu_assert("Basic QP test solve: Setup should result in error due to wrong settings->time_limit",
             exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
   settings->time_limit = tmp_float;
@@ -423,18 +428,20 @@ void test_basic_qp_settings()
      ========================= */
 
   // Setup solver with empty data
-  exitflag = osqp_setup(&solver, OSQP_NULL, OSQP_NULL,
+  exitflag = osqp_setup(&tmpSolver, OSQP_NULL, OSQP_NULL,
                         OSQP_NULL, OSQP_NULL, OSQP_NULL,
-                        data->m, data->n, settings);
+                        data->m, data->n, settings.get());
+  solver.reset(tmpSolver);
   mu_assert("Basic QP test solve: Setup should result in error due to empty data",
             exitflag == OSQP_DATA_VALIDATION_ERROR);
 
   // Setup solver with wrong data->m
   tmp_int = data->m;
   data->m = data->m - 1;
-  exitflag = osqp_setup(&solver, data->P, data->q,
+  exitflag = osqp_setup(&tmpSolver, data->P, data->q,
                         data->A, data->l, data->u,
-                        data->m, data->n, settings);
+                        data->m, data->n, settings.get());
+  solver.reset(tmpSolver);
   mu_assert("Basic QP test solve: Setup should result in error due to wrong data->m",
             exitflag == OSQP_DATA_VALIDATION_ERROR);
   data->m = tmp_int;
@@ -442,17 +449,19 @@ void test_basic_qp_settings()
   // Setup solver with wrong data->n
   tmp_int = data->n;
   data->n = data->n + 1;
-  exitflag = osqp_setup(&solver, data->P, data->q,
+  exitflag = osqp_setup(&tmpSolver, data->P, data->q,
                         data->A, data->l, data->u,
-                        data->m, data->n, settings);
+                        data->m, data->n, settings.get());
+  solver.reset(tmpSolver);
   mu_assert("Basic QP test solve: Setup should result in error due to wrong data->n",
             exitflag == OSQP_DATA_VALIDATION_ERROR);
 
   // Setup solver with zero data->n
   data->n = 0;
-  exitflag = osqp_setup(&solver, data->P, data->q,
+  exitflag = osqp_setup(&tmpSolver, data->P, data->q,
                         data->A, data->l, data->u,
-                        data->m, data->n, settings);
+                        data->m, data->n, settings.get());
+  solver.reset(tmpSolver);
   mu_assert("Basic QP test solve: Setup should result in error due to zero data->n",
             exitflag == OSQP_DATA_VALIDATION_ERROR);
   data->n = tmp_int;
@@ -460,9 +469,10 @@ void test_basic_qp_settings()
   // Setup solver with wrong P->m
   tmp_int = data->P->m;
   data->P->m = data->n + 1;
-  exitflag = osqp_setup(&solver, data->P, data->q,
+  exitflag = osqp_setup(&tmpSolver, data->P, data->q,
                         data->A, data->l, data->u,
-                        data->m, data->n, settings);
+                        data->m, data->n, settings.get());
+  solver.reset(tmpSolver);
   mu_assert("Basic QP test solve: Setup should result in error due to wrong P->m",
             exitflag == OSQP_DATA_VALIDATION_ERROR);
   data->P->m = tmp_int;
@@ -470,17 +480,15 @@ void test_basic_qp_settings()
   // Setup solver with wrong P->n
   tmp_int = data->P->n;
   data->P->n = data->n + 1;
-  exitflag = osqp_setup(&solver, data->P, data->q,
+  exitflag = osqp_setup(&tmpSolver, data->P, data->q,
                         data->A, data->l, data->u,
-                        data->m, data->n, settings);
+                        data->m, data->n, settings.get());
+  solver.reset(tmpSolver);
   mu_assert("Basic QP test solve: Setup should result in error due to wrong P->n",
             exitflag == OSQP_DATA_VALIDATION_ERROR);
   data->P->n = tmp_int;
 
   // Setup solver with non-upper-triangular P
-  tmp_mat = data->P;
-
-  // Construct non-upper-triangular P
   P_tmp = (OSQPCscMatrix*) c_malloc(sizeof(OSQPCscMatrix));
   P_tmp->m = 2;
   P_tmp->n = 2;
@@ -501,48 +509,37 @@ void test_basic_qp_settings()
   P_tmp->p[1] = 2;
   P_tmp->p[2] = 4;
 
-  data->P = P_tmp;
-  exitflag = osqp_setup(&solver, data->P, data->q,
+  exitflag = osqp_setup(&tmpSolver, P_tmp, data->q,
                         data->A, data->l, data->u,
-                        data->m, data->n, settings);
+                        data->m, data->n, settings.get());
+  solver.reset(tmpSolver);
   mu_assert("Basic QP test solve: Setup should result in error due to non-triu structure of P",
             exitflag == OSQP_DATA_VALIDATION_ERROR);
-  data->P = tmp_mat;
 
   // Setup solver with non-consistent bounds
   data->l[0] = data->u[0] + 1.0;
-  exitflag = osqp_setup(&solver, data->P, data->q,
+  exitflag = osqp_setup(&tmpSolver, data->P, data->q,
                         data->A, data->l, data->u,
-                        data->m, data->n, settings);
+                        data->m, data->n, settings.get());
+  solver.reset(tmpSolver);
   mu_assert("Basic QP test solve: Setup should result in error due to non-consistent bounds",
             exitflag == OSQP_DATA_VALIDATION_ERROR);
 
-
-  // Cleanup data
-  clean_problem_basic_qp(data);
-  clean_problem_basic_qp_sols_data(sols_data);
-
   // Cleanup
-  c_free(settings);
   c_free(P_tmp->x);
   c_free(P_tmp->i);
   c_free(P_tmp->p);
   c_free(P_tmp);
 }
 
-TEST_CASE_METHOD(OSQPTestFixture, "Basic QP: Data update", "[solve][qp][data][update]")
+TEST_CASE_METHOD(basic_qp_test_fixture, "Basic QP: Data update", "[solve][qp][data][update]")
 {
   OSQPInt      exitflag;
   OSQPVectorf* q_new;
   OSQPVectorf* l_new;
   OSQPVectorf* u_new;
 
-  // Populate data
-  basic_qp_problem_ptr data{generate_problem_basic_qp()};
-  basic_qp_sols_data_ptr sols_data{generate_problem_basic_qp_sols_data()};
-
   // Define Solver settings as default
-  osqp_set_default_settings(settings.get());
   settings->max_iter      = 200;
   settings->polishing     = 1;
   settings->scaling       = 0;
@@ -657,13 +654,9 @@ TEST_CASE_METHOD(OSQPTestFixture, "Basic QP: Data update", "[solve][qp][data][up
   }
 }
 
-TEST_CASE_METHOD(OSQPTestFixture, "Basic QP: Termination", "[solve][qp]")
+TEST_CASE_METHOD(basic_qp_test_fixture, "Basic QP: Termination", "[solve][qp]")
 {
   OSQPInt exitflag;
-
-  // Populate data
-  basic_qp_problem_ptr data{generate_problem_basic_qp()};
-  basic_qp_sols_data_ptr sols_data{generate_problem_basic_qp_sols_data()};
 
   // Problem-specific settings
   settings->max_iter          = 200;
@@ -716,16 +709,8 @@ TEST_CASE_METHOD(OSQPTestFixture, "Basic QP: Termination", "[solve][qp]")
             TESTS_TOL);
 }
 
-void test_basic_qp_update_rho()
+TEST_CASE_METHOD(basic_qp_test_fixture, "Basic QP: Update rho", "[update][qp]")
 {
-  // Problem settings
-  OSQPSettings *settings = (OSQPSettings *)c_malloc(sizeof(OSQPSettings));
-
-  // Structures
-  OSQPSolver *solver;      // Solver
-  OSQPTestData *data;      // Data
-  basic_qp_sols_data *sols_data;
-
   // Exitflag
   OSQPInt exitflag;
 
@@ -736,14 +721,9 @@ void test_basic_qp_update_rho()
   OSQPInt n_iter_new_solver;
   OSQPInt n_iter_update_rho;
 
-  // Populate data
-  data = generate_problem_basic_qp();
-  sols_data = generate_problem_basic_qp_sols_data();
-
-
   // Define Solver settings as default
   rho = 0.7;
-  osqp_set_default_settings(settings);
+  osqp_set_default_settings(settings.get());
   settings->rho               = rho;
   settings->adaptive_rho      = 0; // Disable adaptive rho for this test
   settings->eps_abs           = 5e-05;
@@ -751,15 +731,16 @@ void test_basic_qp_update_rho()
   settings->check_termination = 1;
 
   // Setup solver
-  exitflag = osqp_setup(&solver, data->P, data->q,
+  exitflag = osqp_setup(&tmpSolver, data->P, data->q,
                         data->A, data->l, data->u,
-                        data->m, data->n, settings);
+                        data->m, data->n, settings.get());
+  solver.reset(tmpSolver);
 
   // Setup correct
   mu_assert("Basic QP test update rho: Setup error!", exitflag == 0);
 
   // Solve Problem
-  osqp_solve(solver);
+  osqp_solve(solver.get());
 
   // Store number of iterations
   n_iter_new_solver = solver->info->iter;
@@ -783,12 +764,8 @@ void test_basic_qp_update_rho()
             c_absval(solver->info->obj_val - sols_data->obj_value_test) <
             TESTS_TOL);
 
-  // Clean solver
-  osqp_cleanup(solver);
-
-
   // Create new problem with different rho and update it
-  osqp_set_default_settings(settings);
+  osqp_set_default_settings(settings.get());
   settings->rho               = 0.1;
   settings->adaptive_rho      = 0;
   settings->check_termination = 1;
@@ -796,19 +773,20 @@ void test_basic_qp_update_rho()
   settings->eps_rel           = 5e-05;
 
   // Setup solver
-  exitflag = osqp_setup(&solver, data->P, data->q,
+  exitflag = osqp_setup(&tmpSolver, data->P, data->q,
                         data->A, data->l, data->u,
-                        data->m, data->n, settings);
+                        data->m, data->n, settings.get());
+  solver.reset(tmpSolver);
 
   // Setup correct
   mu_assert("Basic QP test update rho: Setup error!", exitflag == 0);
 
   // Update rho
-  exitflag = osqp_update_rho(solver, rho);
+  exitflag = osqp_update_rho(solver.get(), rho);
   mu_assert("Basic QP test update rho: Error update rho!", exitflag == 0);
 
   // Solve Problem
-  osqp_solve(solver);
+  osqp_solve(solver.get());
 
   // Compare solver statuses
   mu_assert("Basic QP test update rho: Error in solver status!",
@@ -835,37 +813,15 @@ void test_basic_qp_update_rho()
   // Assert same number of iterations
   mu_assert("Basic QP test update rho: Error in number of iterations!",
             n_iter_new_solver == n_iter_update_rho);
-
-  // Cleanup solver
-  osqp_cleanup(solver);
-
-  // Cleanup data
-  clean_problem_basic_qp(data);
-  clean_problem_basic_qp_sols_data(sols_data);
-
-  // Cleanup
-  c_free(settings);
 }
 
 #ifdef OSQP_ENABLE_PROFILING
-void test_basic_qp_time_limit()
+TEST_CASE_METHOD(basic_qp_test_fixture, "Basic QP: Time limit", "[solve][qp]")
 {
   OSQPInt exitflag;
 
-  // Problem settings
-  OSQPSettings *settings = (OSQPSettings *)c_malloc(sizeof(OSQPSettings));
-
-  // Structures
-  OSQPSolver *solver;      // Solver
-  OSQPTestData *data;      // Data
-  basic_qp_sols_data *sols_data;
-
-  // Populate data
-  data = generate_problem_basic_qp();
-  sols_data = generate_problem_basic_qp_sols_data();
-
   // Define Solver settings as default
-  osqp_set_default_settings(settings);
+  osqp_set_default_settings(settings.get());
   settings->rho = 20;
   settings->adaptive_rho = 0;
 
@@ -874,15 +830,16 @@ void test_basic_qp_time_limit()
             settings->time_limit == OSQP_TIME_LIMIT);
 
   // Setup solver
-  exitflag = osqp_setup(&solver, data->P, data->q,
+  exitflag = osqp_setup(&tmpSolver, data->P, data->q,
                         data->A, data->l, data->u,
-                        data->m, data->n, settings);
+                        data->m, data->n, settings.get());
+  solver.reset(tmpSolver);
 
   // Setup correct
   mu_assert("Basic QP test time limit: Setup error!", exitflag == 0);
 
   // Solve Problem
-  osqp_solve(solver);
+  osqp_solve(solver.get());
 
   // Compare solver statuses
   mu_assert("Basic QP test time limit: Error in no time limit solver status!",
@@ -902,30 +859,20 @@ void test_basic_qp_time_limit()
 # endif
   settings->max_iter = (OSQPInt)2e9;
   settings->check_termination = 0;
-  osqp_update_settings(solver, settings);
+  osqp_update_settings(solver.get(), settings.get());
 
   // Solve Problem
-  osqp_cold_start(solver);
-  osqp_solve(solver);
+  osqp_cold_start(solver.get());
+  osqp_solve(solver.get());
 
   // Compare solver statuses
   mu_assert("Basic QP test time limit: Error in timed out solver status!",
 	    solver->info->status_val == OSQP_TIME_LIMIT_REACHED);
-
-  // Cleanup solver
-  osqp_cleanup(solver);
-
-  // Cleanup data
-  clean_problem_basic_qp(data);
-  clean_problem_basic_qp_sols_data(sols_data);
-
-  // Cleanup
-  c_free(settings);
 }
 #endif // OSQP_ENABLE_PROFILING
 
 
-TEST_CASE_METHOD(OSQPTestFixture, "Basic QP: Warm start", "[solve][qp][warm-start]")
+TEST_CASE_METHOD(basic_qp_test_fixture, "Basic QP: Warm start", "[solve][qp][warm-start]")
 {
   OSQPInt exitflag;
   OSQPInt iter;
@@ -937,10 +884,6 @@ TEST_CASE_METHOD(OSQPTestFixture, "Basic QP: Warm start", "[solve][qp][warm-star
   // Optimal solution
   OSQPFloat xopt[2] = { 0.3, 0.7, };
   OSQPFloat yopt[4] = {-2.9, 0.0, 0.2, 0.0, };
-
-  // Data
-  basic_qp_problem_ptr data{generate_problem_basic_qp()};
-  basic_qp_sols_data_ptr sols_data{generate_problem_basic_qp_sols_data()};
 
   // Setup problem-specific setting
   settings->check_termination = 1;
@@ -974,19 +917,4 @@ TEST_CASE_METHOD(OSQPTestFixture, "Basic QP: Warm start", "[solve][qp][warm-star
     // Check that the number of iterations equals 1
     mu_assert("Basic QP test warm start: Warm start error!", solver->info->iter == 1);
   }
-}
-
-
-TEST_CASE( "Basic QP problem", "[solve][qp]" ) {
-    SECTION( "test_basic_qp_settings" ) {
-        test_basic_qp_settings();
-    }
-    SECTION( "test_basic_qp_update_rho" ) {
-        test_basic_qp_update_rho();
-    }
-#ifdef OSQP_ENABLE_PROFILING
-    SECTION( "test_basic_qp_time_limit" ) {
-        test_basic_qp_time_limit();
-    }
-#endif
 }

--- a/tests/basic_qp2/test_basic_qp2.cpp
+++ b/tests/basic_qp2/test_basic_qp2.cpp
@@ -7,13 +7,9 @@
 #include "basic_qp2_data.h"
 
 
-TEST_CASE_METHOD(OSQPTestFixture, "Basic QP2 solve", "[solve],[qp]")
+TEST_CASE_METHOD(basic_qp2_test_fixture, "Basic QP2 solve", "[solve],[qp]")
 {
   OSQPInt exitflag;
-
-  // Populate data
-  basic_qp2_problem_ptr data{generate_problem_basic_qp2()};
-  basic_qp2_sols_data_ptr sols_data{generate_problem_basic_qp2_sols_data()};
 
   // Need slightly tighter tolerances on this problem to pass the tests
   settings->eps_abs = 1e-6;
@@ -75,13 +71,9 @@ TEST_CASE_METHOD(OSQPTestFixture, "Basic QP2 solve", "[solve],[qp]")
             solver->info->status_polish == expectedPolishStatus);
 }
 
-TEST_CASE_METHOD(OSQPTestFixture, "Basic QP2: Update vectors", "[solve],[qp],[update]")
+TEST_CASE_METHOD(basic_qp2_test_fixture, "Basic QP2: Update vectors", "[solve],[qp],[update]")
 {
   OSQPInt exitflag;
-
-  // Populate data
-  basic_qp2_problem_ptr data{generate_problem_basic_qp2()};
-  basic_qp2_sols_data_ptr sols_data{generate_problem_basic_qp2_sols_data()};
 
   // Define Solver settings as default
   osqp_set_default_settings(settings.get());

--- a/tests/basic_qp2/test_basic_qp2.cpp
+++ b/tests/basic_qp2/test_basic_qp2.cpp
@@ -7,23 +7,15 @@
 #include "basic_qp2_data.h"
 
 
-TEST_CASE("Basic QP2 solve", "[solve],[qp]")
+TEST_CASE_METHOD(OSQPTestFixture, "Basic QP2 solve", "[solve],[qp]")
 {
   OSQPInt exitflag;
-
-  // Problem settings
-  OSQPSettings_ptr settings{(OSQPSettings *)c_malloc(sizeof(OSQPSettings))};
-
-  // Structures
-  OSQPSolver*    tmpSolver = nullptr;
-  OSQPSolver_ptr solver{nullptr};   // Wrap solver inside memory management
 
   // Populate data
   basic_qp2_problem_ptr data{generate_problem_basic_qp2()};
   basic_qp2_sols_data_ptr sols_data{generate_problem_basic_qp2_sols_data()};
 
-  // Define Solver settings as default
-  osqp_set_default_settings(settings.get());
+  // Define Solver settings
   settings->alpha   = 1.6;
   settings->rho     = 0.1;
   settings->verbose = 1;
@@ -86,16 +78,9 @@ TEST_CASE("Basic QP2 solve", "[solve],[qp]")
             solver->info->status_polish == expectedPolishStatus);
 }
 
-TEST_CASE("Basic QP2: Update vectors", "[solve],[qp],[update]")
+TEST_CASE_METHOD(OSQPTestFixture, "Basic QP2: Update vectors", "[solve],[qp],[update]")
 {
   OSQPInt exitflag;
-
-  // Problem settings
-  OSQPSettings_ptr settings{(OSQPSettings *)c_malloc(sizeof(OSQPSettings))};
-
-  // Structures
-  OSQPSolver*    tmpSolver = nullptr;
-  OSQPSolver_ptr solver{nullptr};   // Wrap solver inside memory management
 
   // Populate data
   basic_qp2_problem_ptr data{generate_problem_basic_qp2()};

--- a/tests/basic_qp2/test_basic_qp2.cpp
+++ b/tests/basic_qp2/test_basic_qp2.cpp
@@ -15,12 +15,9 @@ TEST_CASE_METHOD(OSQPTestFixture, "Basic QP2 solve", "[solve],[qp]")
   basic_qp2_problem_ptr data{generate_problem_basic_qp2()};
   basic_qp2_sols_data_ptr sols_data{generate_problem_basic_qp2_sols_data()};
 
-  // Define Solver settings
-  settings->alpha   = 1.6;
-  settings->rho     = 0.1;
-  settings->verbose = 1;
-  settings->eps_abs = 1e-5;
-  settings->eps_rel = 1e-5;
+  // Need slightly tighter tolerances on this problem to pass the tests
+  settings->eps_abs = 1e-6;
+  settings->eps_rel = 1e-6;
 
   /* Test with and without polishing */
   OSQPInt polish;
@@ -88,10 +85,8 @@ TEST_CASE_METHOD(OSQPTestFixture, "Basic QP2: Update vectors", "[solve],[qp],[up
 
   // Define Solver settings as default
   osqp_set_default_settings(settings.get());
-  settings->alpha         = 1.6;
   settings->warm_starting = 1;
   settings->polishing     = 1;
-  settings->verbose       = 1;
 
   /* Test all possible linear system solvers in this test case */
   settings->linsys_solver = GENERATE(filter(&isLinsysSupported, values({OSQP_DIRECT_SOLVER, OSQP_INDIRECT_SOLVER})));

--- a/tests/codegen/test_codegen.cpp
+++ b/tests/codegen/test_codegen.cpp
@@ -10,26 +10,18 @@
 #include "unconstrained_data.h"
 
 #ifdef OSQP_CODEGEN
-TEST_CASE("Basic codegen", "[codegen]")
+TEST_CASE_METHOD(OSQPTestFixture, "Basic codegen", "[codegen]")
 {
   OSQPInt exitflag;
 
-  // Problem settings
-  OSQPSettings_ptr settings{(OSQPSettings *)c_malloc(sizeof(OSQPSettings))};
-
   // Codegen defines
   OSQPCodegenDefines_ptr defines{(OSQPCodegenDefines *)c_malloc(sizeof(OSQPCodegenDefines))};
-
-  // Structures
-  OSQPSolver *tmpSolver = nullptr;
-  OSQPSolver_ptr solver{nullptr};   // Wrap solver inside memory management
 
   // Problem data
   codegen_problem_ptr   data{generate_problem_codegen()};
   codegen_sols_data_ptr sols_data{generate_problem_codegen_sols_data()};
 
-  // Define Solver settings as default
-  osqp_set_default_settings(settings.get());
+  // Define Solver settings
   settings->max_iter      = 2000;
   settings->alpha         = 1.6;
   settings->polishing     = 1;
@@ -68,22 +60,14 @@ TEST_CASE("Basic codegen", "[codegen]")
             exitflag == OSQP_NO_ERROR);
 }
 
-TEST_CASE("Codegen: Data export", "[codegen],[unconstrained],[lp],[qp],[nonconvex]")
+TEST_CASE_METHOD(OSQPTestFixture, "Codegen: Data export", "[codegen],[unconstrained],[lp],[qp],[nonconvex]")
 {
   OSQPInt exitflag;
-
-  // Problem settings
-  OSQPSettings_ptr settings{(OSQPSettings *)c_malloc(sizeof(OSQPSettings))};
 
   // Codegen defines
   OSQPCodegenDefines_ptr defines{(OSQPCodegenDefines *)c_malloc(sizeof(OSQPCodegenDefines))};
 
-  // Structures
-  OSQPSolver *tmpSolver = nullptr;
-  OSQPSolver_ptr solver{nullptr};   // Wrap solver inside memory management
-
-  // Define Solver settings as default
-  osqp_set_default_settings(settings.get());
+  // Define Solver settings
   settings->max_iter      = 2000;
   settings->alpha         = 1.6;
   settings->polishing     = 1;
@@ -220,26 +204,18 @@ TEST_CASE("Codegen: Data export", "[codegen],[unconstrained],[lp],[qp],[nonconve
   }
 }
 
-TEST_CASE("Codegen: defines", "[codegen]")
+TEST_CASE_METHOD(OSQPTestFixture, "Codegen: defines", "[codegen]")
 {
   OSQPInt exitflag;
 
-  // Problem settings
-  OSQPSettings_ptr settings{(OSQPSettings *)c_malloc(sizeof(OSQPSettings))};
-
   // Codegen defines
   OSQPCodegenDefines_ptr defines{(OSQPCodegenDefines *)c_malloc(sizeof(OSQPCodegenDefines))};
-
-  // Structures
-  OSQPSolver *tmpSolver = nullptr;
-  OSQPSolver_ptr solver{nullptr};   // Wrap solver inside memory management
 
   // Problem data
   codegen_problem_ptr   data{generate_problem_codegen()};
   codegen_sols_data_ptr sols_data{generate_problem_codegen_sols_data()};
 
-  // Define Solver settings as default
-  osqp_set_default_settings(settings.get());
+  // Define Solver settings
   settings->max_iter      = 2000;
   settings->alpha         = 1.6;
   settings->polishing     = 1;
@@ -395,26 +371,18 @@ TEST_CASE("Codegen: defines", "[codegen]")
   }
 }
 
-TEST_CASE("Codegen: Error propgatation", "[codegen]")
+TEST_CASE_METHOD(OSQPTestFixture, "Codegen: Error propgatation", "[codegen]")
 {
   OSQPInt exitflag;
 
-  // Problem settings
-  OSQPSettings_ptr settings{(OSQPSettings *)c_malloc(sizeof(OSQPSettings))};
-
   // Codegen defines
   OSQPCodegenDefines_ptr defines{(OSQPCodegenDefines *)c_malloc(sizeof(OSQPCodegenDefines))};
-
-  // Structures
-  OSQPSolver *tmpSolver = nullptr;
-  OSQPSolver_ptr solver{nullptr};   // Wrap solver inside memory management
 
   // Problem data
   codegen_problem_ptr   data{generate_problem_codegen()};
   codegen_sols_data_ptr sols_data{generate_problem_codegen_sols_data()};
 
-  // Define Solver settings as default
-  osqp_set_default_settings(settings.get());
+  // Define Solver settings
   settings->max_iter      = 2000;
   settings->alpha         = 1.6;
   settings->polishing     = 1;
@@ -509,26 +477,18 @@ TEST_CASE("Codegen: Error propgatation", "[codegen]")
   }
 }
 
-TEST_CASE("Codegen: Settings", "[codegen],[settings]")
+TEST_CASE_METHOD(OSQPTestFixture, "Codegen: Settings", "[codegen],[settings]")
 {
   OSQPInt exitflag;
 
-  // Problem settings
-  OSQPSettings_ptr settings{(OSQPSettings *)c_malloc(sizeof(OSQPSettings))};
-
   // Codegen defines
   OSQPCodegenDefines_ptr defines{(OSQPCodegenDefines *)c_malloc(sizeof(OSQPCodegenDefines))};
-
-  // Structures
-  OSQPSolver *tmpSolver = nullptr;
-  OSQPSolver_ptr solver{nullptr};   // Wrap solver inside memory management
 
   // Problem data
   codegen_problem_ptr   data{generate_problem_codegen()};
   codegen_sols_data_ptr sols_data{generate_problem_codegen_sols_data()};
 
-  // Define Solver settings as default
-  osqp_set_default_settings(settings.get());
+  // Define Solver settings
   settings->max_iter      = 2000;
   settings->alpha         = 1.6;
   settings->polishing     = 1;

--- a/tests/codegen/test_codegen.cpp
+++ b/tests/codegen/test_codegen.cpp
@@ -21,12 +21,9 @@ TEST_CASE_METHOD(OSQPTestFixture, "Basic codegen", "[codegen]")
   codegen_problem_ptr   data{generate_problem_codegen()};
   codegen_sols_data_ptr sols_data{generate_problem_codegen_sols_data()};
 
-  // Define Solver settings
-  settings->max_iter      = 2000;
-  settings->alpha         = 1.6;
+  // Test-specific solver settings
   settings->polishing     = 1;
   settings->scaling       = 0;
-  settings->verbose       = 1;
   settings->warm_starting = 0;
 
   // Define codegen settings
@@ -67,12 +64,9 @@ TEST_CASE_METHOD(OSQPTestFixture, "Codegen: Data export", "[codegen],[unconstrai
   // Codegen defines
   OSQPCodegenDefines_ptr defines{(OSQPCodegenDefines *)c_malloc(sizeof(OSQPCodegenDefines))};
 
-  // Define Solver settings
-  settings->max_iter      = 2000;
-  settings->alpha         = 1.6;
+  // Test-specific solver settings
   settings->polishing     = 1;
   settings->scaling       = 0;
-  settings->verbose       = 1;
   settings->warm_starting = 0;
 
   // Define codegen settings
@@ -215,12 +209,9 @@ TEST_CASE_METHOD(OSQPTestFixture, "Codegen: defines", "[codegen]")
   codegen_problem_ptr   data{generate_problem_codegen()};
   codegen_sols_data_ptr sols_data{generate_problem_codegen_sols_data()};
 
-  // Define Solver settings
-  settings->max_iter      = 2000;
-  settings->alpha         = 1.6;
+  // Test-specific solver settings
   settings->polishing     = 1;
   settings->scaling       = 0;
-  settings->verbose       = 1;
   settings->warm_starting = 0;
 
   // Define codegen settings
@@ -382,12 +373,9 @@ TEST_CASE_METHOD(OSQPTestFixture, "Codegen: Error propgatation", "[codegen]")
   codegen_problem_ptr   data{generate_problem_codegen()};
   codegen_sols_data_ptr sols_data{generate_problem_codegen_sols_data()};
 
-  // Define Solver settings
-  settings->max_iter      = 2000;
-  settings->alpha         = 1.6;
+  // Test-specific solver settings
   settings->polishing     = 1;
   settings->scaling       = 0;
-  settings->verbose       = 1;
   settings->warm_starting = 0;
 
   // Define codegen settings
@@ -488,12 +476,9 @@ TEST_CASE_METHOD(OSQPTestFixture, "Codegen: Settings", "[codegen],[settings]")
   codegen_problem_ptr   data{generate_problem_codegen()};
   codegen_sols_data_ptr sols_data{generate_problem_codegen_sols_data()};
 
-  // Define Solver settings
-  settings->max_iter      = 2000;
-  settings->alpha         = 1.6;
+  // Test-specific solver settings
   settings->polishing     = 1;
   settings->scaling       = 0;
-  settings->verbose       = 1;
   settings->warm_starting = 0;
 
   // Define codegen settings

--- a/tests/codegen/test_codegen.cpp
+++ b/tests/codegen/test_codegen.cpp
@@ -10,16 +10,12 @@
 #include "unconstrained_data.h"
 
 #ifdef OSQP_CODEGEN
-TEST_CASE_METHOD(OSQPTestFixture, "Basic codegen", "[codegen]")
+TEST_CASE_METHOD(codegen_test_fixture, "Basic codegen", "[codegen]")
 {
   OSQPInt exitflag;
 
   // Codegen defines
   OSQPCodegenDefines_ptr defines{(OSQPCodegenDefines *)c_malloc(sizeof(OSQPCodegenDefines))};
-
-  // Problem data
-  codegen_problem_ptr   data{generate_problem_codegen()};
-  codegen_sols_data_ptr sols_data{generate_problem_codegen_sols_data()};
 
   // Test-specific solver settings
   settings->polishing     = 1;
@@ -57,7 +53,8 @@ TEST_CASE_METHOD(OSQPTestFixture, "Basic codegen", "[codegen]")
             exitflag == OSQP_NO_ERROR);
 }
 
-TEST_CASE_METHOD(OSQPTestFixture, "Codegen: Data export", "[codegen],[unconstrained],[lp],[qp],[nonconvex]")
+/* We want test data from the unconstrained problem */
+TEST_CASE_METHOD(unconstrained_test_fixture, "Codegen: Unconstrained problem data export", "[codegen],[unconstrained]")
 {
   OSQPInt exitflag;
 
@@ -74,140 +71,156 @@ TEST_CASE_METHOD(OSQPTestFixture, "Codegen: Data export", "[codegen],[unconstrai
   defines->embedded_mode = 1;      // vector update
   defines->float_type    = 1;      // floats
 
-  SECTION( "Unconstrained" ) {
-    OSQPInt embedded;
-    std::string dir;
+  OSQPInt embedded;
+  std::string dir;
 
-    std::tie( embedded, dir ) =
-      GENERATE( table<OSQPInt, std::string>(
-          { /* first is embedded mode, second is output directory */
-            std::make_tuple( 1, CODEGEN1_DIR ),
-            std::make_tuple( 2, CODEGEN2_DIR ) } ) );
+  std::tie( embedded, dir ) =
+    GENERATE( table<OSQPInt, std::string>(
+        { /* first is embedded mode, second is output directory */
+          std::make_tuple( 1, CODEGEN1_DIR ),
+          std::make_tuple( 2, CODEGEN2_DIR ) } ) );
 
-    char name[100];
-    snprintf(name, 100, "data_unconstrained_embedded_%d_", embedded);
+  char name[100];
+  snprintf(name, 100, "data_unconstrained_embedded_%d_", embedded);
 
-    CAPTURE(embedded);
+  CAPTURE(embedded);
 
-    // Problem data
-    unconstrained_problem_ptr   data{generate_problem_unconstrained()};
-    unconstrained_sols_data_ptr sols_data{generate_problem_unconstrained_sols_data()};
+  // Setup solver
+  exitflag = osqp_setup(&tmpSolver, data->P, data->q,
+                        data->A, data->l, data->u,
+                        data->m, data->n, settings.get());
+  solver.reset(tmpSolver);
 
-    // Setup solver
-    exitflag = osqp_setup(&tmpSolver, data->P, data->q,
-                          data->A, data->l, data->u,
-                          data->m, data->n, settings.get());
-    solver.reset(tmpSolver);
+  // Setup correct
+  mu_assert("Setup error!", exitflag == 0);
 
-    // Setup correct
-    mu_assert("Setup error!", exitflag == 0);
+  defines->embedded_mode = embedded;
 
-    defines->embedded_mode = embedded;
+  exitflag = osqp_codegen(solver.get(), dir.c_str(), name, defines.get());
 
-    exitflag = osqp_codegen(solver.get(), dir.c_str(), name, defines.get());
-
-    // Codegen should work or error as appropriate
-    mu_assert("Unconstrained should have worked!",
-              exitflag == OSQP_NO_ERROR);
-  }
-
-  SECTION( "Linear program" ) {
-    OSQPInt embedded;
-    std::string dir;
-
-    std::tie( embedded, dir ) =
-      GENERATE( table<OSQPInt, std::string>(
-          { /* first is embedded mode, second is output directory */
-            std::make_tuple( 1, CODEGEN1_DIR ),
-            std::make_tuple( 2, CODEGEN2_DIR ) } ) );
-
-    char name[100];
-    snprintf(name, 100, "data_lp_embedded_%d_", embedded);
-
-    CAPTURE(embedded);
-
-    // Problem data
-    basic_lp_problem_ptr   data{generate_problem_basic_lp()};
-    basic_lp_sols_data_ptr sols_data{generate_problem_basic_lp_sols_data()};
-
-    // Setup solver
-    exitflag = osqp_setup(&tmpSolver, data->P, data->q,
-                          data->A, data->l, data->u,
-                          data->m, data->n, settings.get());
-    solver.reset(tmpSolver);
-
-    // Setup correct
-    mu_assert("Setup error!", exitflag == 0);
-
-    defines->embedded_mode = embedded;
-
-    exitflag = osqp_codegen(solver.get(), dir.c_str(), name, defines.get());
-
-    // Codegen should work or error as appropriate
-    mu_assert("Linear program should have worked!",
-              exitflag == OSQP_NO_ERROR);
-  }
-
-  SECTION( "Nonconvex" ) {
-    OSQPInt embedded;
-    std::string dir;
-
-    std::tie( embedded, dir ) =
-      GENERATE( table<OSQPInt, std::string>(
-          { /* first is embedded mode, second is output directory */
-            std::make_tuple( 1, CODEGEN1_DIR ),
-            std::make_tuple( 2, CODEGEN2_DIR ) } ) );
-
-    OSQPFloat sigma;
-    OSQPInt   sigma_num;
-    OSQPInt   expected_error;
-
-    std::tie( sigma, sigma_num, expected_error ) =
-      GENERATE( table<OSQPFloat, OSQPInt, OSQPInt>(
-          { /* first is sigma value, second is the filename parameter, third is the expected return value */
-            std::make_tuple( 1e-6, 1, OSQP_NONCVX_ERROR ),
-            std::make_tuple(    5, 2, OSQP_NO_ERROR ) } ) );
-
-    char name[100];
-    snprintf(name, 100, "data_nonconvex_%d_embedded_%d_", sigma_num, embedded);
-
-    CAPTURE(embedded, sigma);
-
-    // Problem data
-    non_cvx_problem_ptr   data{generate_problem_non_cvx()};
-    non_cvx_sols_data_ptr sols_data{generate_problem_non_cvx_sols_data()};
-
-    // Update solver settings
-    settings->sigma = sigma;
-    defines->embedded_mode = embedded;
-
-    // Setup solver
-    exitflag = osqp_setup(&tmpSolver, data->P, data->q,
-                          data->A, data->l, data->u,
-                          data->m, data->n, settings.get());
-    solver.reset(tmpSolver);
-
-    // Setup correct
-    mu_assert("Setup error!", exitflag == expected_error);
-
-    exitflag = osqp_codegen(solver.get(), dir.c_str(), name, defines.get());
-
-    // Codegen should work or error as appropriate
-    mu_assert("Nonconvex codegen error!",
-              exitflag == expected_error);
-  }
+  // Codegen should work or error as appropriate
+  mu_assert("Unconstrained should have worked!",
+            exitflag == OSQP_NO_ERROR);
 }
 
-TEST_CASE_METHOD(OSQPTestFixture, "Codegen: defines", "[codegen]")
+/* We want test data from the LP test case */
+TEST_CASE_METHOD(basic_lp_test_fixture, "Codegen: Linear program data export", "[codegen],[lp]")
 {
   OSQPInt exitflag;
 
   // Codegen defines
   OSQPCodegenDefines_ptr defines{(OSQPCodegenDefines *)c_malloc(sizeof(OSQPCodegenDefines))};
 
-  // Problem data
-  codegen_problem_ptr   data{generate_problem_codegen()};
-  codegen_sols_data_ptr sols_data{generate_problem_codegen_sols_data()};
+  // Test-specific solver settings
+  settings->polishing     = 1;
+  settings->scaling       = 0;
+  settings->warm_starting = 0;
+
+  // Define codegen settings
+  osqp_set_default_codegen_defines(defines.get());
+  defines->embedded_mode = 1;      // vector update
+  defines->float_type    = 1;      // floats
+
+  OSQPInt embedded;
+  std::string dir;
+
+  std::tie( embedded, dir ) =
+    GENERATE( table<OSQPInt, std::string>(
+        { /* first is embedded mode, second is output directory */
+          std::make_tuple( 1, CODEGEN1_DIR ),
+          std::make_tuple( 2, CODEGEN2_DIR ) } ) );
+
+  char name[100];
+  snprintf(name, 100, "data_lp_embedded_%d_", embedded);
+
+  CAPTURE(embedded);
+
+  // Setup solver
+  exitflag = osqp_setup(&tmpSolver, data->P, data->q,
+                        data->A, data->l, data->u,
+                        data->m, data->n, settings.get());
+  solver.reset(tmpSolver);
+
+  // Setup correct
+  mu_assert("Setup error!", exitflag == 0);
+
+  defines->embedded_mode = embedded;
+
+  exitflag = osqp_codegen(solver.get(), dir.c_str(), name, defines.get());
+
+  // Codegen should work or error as appropriate
+  mu_assert("Linear program should have worked!",
+            exitflag == OSQP_NO_ERROR);
+}
+
+/* We want test data from the non convex test case */
+TEST_CASE_METHOD(non_cvx_test_fixture, "Codegen: Data export", "[codegen],[nonconvex]")
+{
+  OSQPInt exitflag;
+
+  // Codegen defines
+  OSQPCodegenDefines_ptr defines{(OSQPCodegenDefines *)c_malloc(sizeof(OSQPCodegenDefines))};
+
+  // Test-specific solver settings
+  settings->polishing     = 1;
+  settings->scaling       = 0;
+  settings->warm_starting = 0;
+
+  // Define codegen settings
+  osqp_set_default_codegen_defines(defines.get());
+  defines->embedded_mode = 1;      // vector update
+  defines->float_type    = 1;      // floats
+
+  OSQPInt embedded;
+  std::string dir;
+
+  std::tie( embedded, dir ) =
+    GENERATE( table<OSQPInt, std::string>(
+        { /* first is embedded mode, second is output directory */
+          std::make_tuple( 1, CODEGEN1_DIR ),
+          std::make_tuple( 2, CODEGEN2_DIR ) } ) );
+
+  OSQPFloat sigma;
+  OSQPInt   sigma_num;
+  OSQPInt   expected_error;
+
+  std::tie( sigma, sigma_num, expected_error ) =
+    GENERATE( table<OSQPFloat, OSQPInt, OSQPInt>(
+        { /* first is sigma value, second is the filename parameter, third is the expected return value */
+          std::make_tuple( 1e-6, 1, OSQP_NONCVX_ERROR ),
+          std::make_tuple(    5, 2, OSQP_NO_ERROR ) } ) );
+
+  char name[100];
+  snprintf(name, 100, "data_nonconvex_%d_embedded_%d_", sigma_num, embedded);
+
+  CAPTURE(embedded, sigma);
+
+  // Update solver settings
+  settings->sigma = sigma;
+  defines->embedded_mode = embedded;
+
+  // Setup solver
+  exitflag = osqp_setup(&tmpSolver, data->P, data->q,
+                        data->A, data->l, data->u,
+                        data->m, data->n, settings.get());
+  solver.reset(tmpSolver);
+
+  // Setup correct
+  mu_assert("Setup error!", exitflag == expected_error);
+
+  exitflag = osqp_codegen(solver.get(), dir.c_str(), name, defines.get());
+
+  // Codegen should work or error as appropriate
+  mu_assert("Nonconvex codegen error!",
+            exitflag == expected_error);
+}
+
+TEST_CASE_METHOD(codegen_test_fixture, "Codegen: defines", "[codegen]")
+{
+  OSQPInt exitflag;
+
+  // Codegen defines
+  OSQPCodegenDefines_ptr defines{(OSQPCodegenDefines *)c_malloc(sizeof(OSQPCodegenDefines))};
 
   // Test-specific solver settings
   settings->polishing     = 1;
@@ -362,16 +375,12 @@ TEST_CASE_METHOD(OSQPTestFixture, "Codegen: defines", "[codegen]")
   }
 }
 
-TEST_CASE_METHOD(OSQPTestFixture, "Codegen: Error propgatation", "[codegen]")
+TEST_CASE_METHOD(codegen_test_fixture, "Codegen: Error propgatation", "[codegen]")
 {
   OSQPInt exitflag;
 
   // Codegen defines
   OSQPCodegenDefines_ptr defines{(OSQPCodegenDefines *)c_malloc(sizeof(OSQPCodegenDefines))};
-
-  // Problem data
-  codegen_problem_ptr   data{generate_problem_codegen()};
-  codegen_sols_data_ptr sols_data{generate_problem_codegen_sols_data()};
 
   // Test-specific solver settings
   settings->polishing     = 1;
@@ -465,16 +474,12 @@ TEST_CASE_METHOD(OSQPTestFixture, "Codegen: Error propgatation", "[codegen]")
   }
 }
 
-TEST_CASE_METHOD(OSQPTestFixture, "Codegen: Settings", "[codegen],[settings]")
+TEST_CASE_METHOD(codegen_test_fixture, "Codegen: Settings", "[codegen],[settings]")
 {
   OSQPInt exitflag;
 
   // Codegen defines
   OSQPCodegenDefines_ptr defines{(OSQPCodegenDefines *)c_malloc(sizeof(OSQPCodegenDefines))};
-
-  // Problem data
-  codegen_problem_ptr   data{generate_problem_codegen()};
-  codegen_sols_data_ptr sols_data{generate_problem_codegen_sols_data()};
 
   // Test-specific solver settings
   settings->polishing     = 1;

--- a/tests/large_qp/test_large_qp.cpp
+++ b/tests/large_qp/test_large_qp.cpp
@@ -11,13 +11,6 @@ TEST_CASE_METHOD(OSQPTestFixture, "Large QP solve", "[solve],[qp]")
 {
   OSQPInt exitflag;
 
-  // Define Solver settings
-  settings->alpha   = 1.6;
-  settings->rho     = 0.1;
-  settings->verbose = 1;
-  settings->eps_abs = 1e-5;
-  settings->eps_rel = 1e-5;
-
   /* Test all possible linear system solvers in this test case */
   settings->linsys_solver = GENERATE(filter(&isLinsysSupported, values({OSQP_DIRECT_SOLVER, OSQP_INDIRECT_SOLVER})));
 

--- a/tests/large_qp/test_large_qp.cpp
+++ b/tests/large_qp/test_large_qp.cpp
@@ -7,19 +7,11 @@
 #include "large_qp_data.h"
 
 
-TEST_CASE("Large QP solve", "[solve],[qp]")
+TEST_CASE_METHOD(OSQPTestFixture, "Large QP solve", "[solve],[qp]")
 {
   OSQPInt exitflag;
 
-  // Problem settings
-  OSQPSettings_ptr settings{(OSQPSettings *)c_malloc(sizeof(OSQPSettings))};
-
-  // Structures
-  OSQPSolver*    tmpSolver = nullptr;
-  OSQPSolver_ptr solver{nullptr};   // Wrap solver inside memory management
-
-  // Define Solver settings as default
-  osqp_set_default_settings(settings.get());
+  // Define Solver settings
   settings->alpha   = 1.6;
   settings->rho     = 0.1;
   settings->verbose = 1;

--- a/tests/no_active_set/test_no_active_set.cpp
+++ b/tests/no_active_set/test_no_active_set.cpp
@@ -7,13 +7,9 @@
 #include "no_active_set_data.h"
 
 
-TEST_CASE_METHOD(OSQPTestFixture, "No active set", "[optimization][no active set]" )
+TEST_CASE_METHOD(no_active_set_test_fixture, "No active set", "[optimization][no active set]" )
 {
   OSQPInt exitflag;
-
-  // Populate data
-  no_active_set_problem_ptr data{generate_problem_no_active_set()};
-  no_active_set_sols_data_ptr sols_data{generate_problem_no_active_set_sols_data()};
 
   /* Test with and without polishing */
   OSQPInt polish;

--- a/tests/no_active_set/test_no_active_set.cpp
+++ b/tests/no_active_set/test_no_active_set.cpp
@@ -7,23 +7,15 @@
 #include "no_active_set_data.h"
 
 
-TEST_CASE( "No active set", "[optimization][no active set]" )
+TEST_CASE_METHOD(OSQPTestFixture, "No active set", "[optimization][no active set]" )
 {
   OSQPInt exitflag;
-
-  // Problem settings
-  OSQPSettings_ptr settings{(OSQPSettings *)c_malloc(sizeof(OSQPSettings))};
-
-  // Structures
-  OSQPSolver     *tmpSolver = nullptr;
-  OSQPSolver_ptr solver{nullptr};   // Wrap solver inside memory management
 
   // Populate data
   no_active_set_problem_ptr data{generate_problem_no_active_set()};
   no_active_set_sols_data_ptr sols_data{generate_problem_no_active_set_sols_data()};
 
-  // Define Solver settings as default
-  osqp_set_default_settings(settings.get());
+  // Define Solver settings
   settings->eps_abs = 1e-05;
   settings->eps_rel = 1e-05;
   settings->verbose = 1;

--- a/tests/no_active_set/test_no_active_set.cpp
+++ b/tests/no_active_set/test_no_active_set.cpp
@@ -15,11 +15,6 @@ TEST_CASE_METHOD(OSQPTestFixture, "No active set", "[optimization][no active set
   no_active_set_problem_ptr data{generate_problem_no_active_set()};
   no_active_set_sols_data_ptr sols_data{generate_problem_no_active_set_sols_data()};
 
-  // Define Solver settings
-  settings->eps_abs = 1e-05;
-  settings->eps_rel = 1e-05;
-  settings->verbose = 1;
-
   /* Test with and without polishing */
   OSQPInt polish;
   OSQPInt expectedPolishStatus;

--- a/tests/non_cvx/test_non_cvx.cpp
+++ b/tests/non_cvx/test_non_cvx.cpp
@@ -15,8 +15,7 @@ TEST_CASE_METHOD(OSQPTestFixture, "Nonconvex: Setup detection", "[nonconvex],[se
   non_cvx_problem_ptr   data{generate_problem_non_cvx()};
   non_cvx_sols_data_ptr sols_data{generate_problem_non_cvx_sols_data()};
 
-  // Define Solver settings
-  settings->verbose = 1;
+  // Test-specific solver settings
   settings->adaptive_rho = 0;
 
   // Direct linear solvers detect the nonconvexity at the setup phase
@@ -60,8 +59,7 @@ TEST_CASE_METHOD(OSQPTestFixture, "Nonconvex: Solve", "[nonconvex],[solve]")
   non_cvx_problem_ptr   data{generate_problem_non_cvx()};
   non_cvx_sols_data_ptr sols_data{generate_problem_non_cvx_sols_data()};
 
-  // Define Solver settings
-  settings->verbose = 1;
+  // Test-specific solver settings
   settings->adaptive_rho = 0;
   settings->sigma = sols_data->sigma_new;
 

--- a/tests/non_cvx/test_non_cvx.cpp
+++ b/tests/non_cvx/test_non_cvx.cpp
@@ -7,13 +7,9 @@
 #include "non_cvx_data.h"
 
 #ifndef OSQP_ALGEBRA_CUDA
-TEST_CASE_METHOD(OSQPTestFixture, "Nonconvex: Setup detection", "[nonconvex],[setup]")
+TEST_CASE_METHOD(non_cvx_test_fixture, "Nonconvex: Setup detection", "[nonconvex],[setup]")
 {
   OSQPInt exitflag;
-
-  // Data
-  non_cvx_problem_ptr   data{generate_problem_non_cvx()};
-  non_cvx_sols_data_ptr sols_data{generate_problem_non_cvx_sols_data()};
 
   // Test-specific solver settings
   settings->adaptive_rho = 0;
@@ -51,13 +47,9 @@ TEST_CASE_METHOD(OSQPTestFixture, "Nonconvex: Setup detection", "[nonconvex],[se
 }
 #endif
 
-TEST_CASE_METHOD(OSQPTestFixture, "Nonconvex: Solve", "[nonconvex],[solve]")
+TEST_CASE_METHOD(non_cvx_test_fixture, "Nonconvex: Solve", "[nonconvex],[solve]")
 {
   OSQPInt exitflag;
-
-  // Data
-  non_cvx_problem_ptr   data{generate_problem_non_cvx()};
-  non_cvx_sols_data_ptr sols_data{generate_problem_non_cvx_sols_data()};
 
   // Test-specific solver settings
   settings->adaptive_rho = 0;

--- a/tests/non_cvx/test_non_cvx.cpp
+++ b/tests/non_cvx/test_non_cvx.cpp
@@ -7,21 +7,15 @@
 #include "non_cvx_data.h"
 
 #ifndef OSQP_ALGEBRA_CUDA
-TEST_CASE("Nonconvex: Setup detection", "[nonconvex],[setup]")
+TEST_CASE_METHOD(OSQPTestFixture, "Nonconvex: Setup detection", "[nonconvex],[setup]")
 {
   OSQPInt exitflag;
-
-  // Solver variables
-  OSQPSolver*      tmpSolver;
-  OSQPSolver_ptr   solver{nullptr};
-  OSQPSettings_ptr settings{(OSQPSettings *)c_malloc(sizeof(OSQPSettings))};
 
   // Data
   non_cvx_problem_ptr   data{generate_problem_non_cvx()};
   non_cvx_sols_data_ptr sols_data{generate_problem_non_cvx_sols_data()};
 
-  // Define Solver settings as default
-  osqp_set_default_settings(settings.get());
+  // Define Solver settings
   settings->verbose = 1;
   settings->adaptive_rho = 0;
 
@@ -58,21 +52,15 @@ TEST_CASE("Nonconvex: Setup detection", "[nonconvex],[setup]")
 }
 #endif
 
-TEST_CASE("Nonconvex: Solve", "[nonconvex],[solve]")
+TEST_CASE_METHOD(OSQPTestFixture, "Nonconvex: Solve", "[nonconvex],[solve]")
 {
   OSQPInt exitflag;
-
-  // Solver variables
-  OSQPSolver*      tmpSolver;
-  OSQPSolver_ptr   solver{nullptr};
-  OSQPSettings_ptr settings{(OSQPSettings *)c_malloc(sizeof(OSQPSettings))};
 
   // Data
   non_cvx_problem_ptr   data{generate_problem_non_cvx()};
   non_cvx_sols_data_ptr sols_data{generate_problem_non_cvx_sols_data()};
 
-  // Define Solver settings as default
-  osqp_set_default_settings(settings.get());
+  // Define Solver settings
   settings->verbose = 1;
   settings->adaptive_rho = 0;
   settings->sigma = sols_data->sigma_new;

--- a/tests/osqp_tester.cpp
+++ b/tests/osqp_tester.cpp
@@ -1,8 +1,52 @@
 /* OSQP TESTER MODULE */
 
-#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_RUNNER
 #include <catch2/catch.hpp>
 
 /* All testcases are in their own cpp file in the subdirectories.
    This file only defines the main function for CATCH to use.
  */
+
+#include <cstdlib>
+#include <iostream>
+
+#include "osqp_tester.h"
+
+int OSQPTestFixture::deviceNumber = 0;
+
+int main( int argc, char* argv[] ) {
+    Catch::Session session;
+
+    int result = 0;
+    int deviceNum = 0;
+
+    /*
+     * Select the device to run the test on.
+     */
+
+    // Start by looking for the environment variable
+    if(const char* deviceEnv = std::getenv("OSQP_TEST_DEVICE_NUM")) {
+        OSQPTestFixture::deviceNumber = std::atoi(deviceEnv);
+    }
+
+    using namespace Catch::clara;
+
+    // Next use a command line option (if it exists)
+    auto cli = session.cli() | Opt(OSQPTestFixture::deviceNumber, "device")
+                                  ["--device"]
+                                  ("Compute device (overrides the OSQP_TEST_DEVICE_NUM environment variable)");
+    session.cli(cli);
+
+    result = session.applyCommandLine( argc, argv );
+
+    if( result != 0 ) {
+        // Indicates a command line error
+        std::cout << "Error configuring command line for test driver" << std::endl;
+        return result;
+    }
+
+    /*
+     * Run the OSQP test suite
+     */
+    return session.run( argc, argv );
+}

--- a/tests/osqp_tester.h
+++ b/tests/osqp_tester.h
@@ -39,6 +39,20 @@ public:
         // Initialize default test settings
         osqp_set_default_settings(settings.get());
         settings->device = deviceNumber;
+
+        /*
+         * Common solver settings
+         */
+        settings->rho   = 0.1;
+        settings->alpha = 1.6;
+
+        settings->max_iter = 2000;
+
+        settings->scaling = 1;
+        settings->verbose = 1;
+
+        settings->eps_abs = 1e-5;
+        settings->eps_rel = 1e-5;
     }
 
     static int deviceNumber;

--- a/tests/osqp_tester.h
+++ b/tests/osqp_tester.h
@@ -4,6 +4,7 @@
 #define OSQP_TESTER_H
 
 #include "osqp.h"
+#include "osqp_api.h"
 
 #define mu_assert(msg, pred) do { INFO(msg); REQUIRE(pred); } while((void)0, 0)
 
@@ -26,5 +27,29 @@ typedef struct {
     OSQPFloat*     l;
     OSQPFloat*     u;
 } OSQPTestData;
+
+/*
+ * Test fixture to hold various types needed for OSQP tests
+ */
+class OSQPTestFixture {
+public:
+    OSQPTestFixture() {
+        settings.reset((OSQPSettings*) c_malloc(sizeof(OSQPSettings)));
+
+        // Initialize default test settings
+        osqp_set_default_settings(settings.get());
+        settings->device = deviceNumber;
+    }
+
+    static int deviceNumber;
+
+protected:
+    // Settings to use for the test
+    OSQPSettings_ptr settings;
+
+    // OSQP Solver itself
+    OSQPSolver*    tmpSolver = nullptr;
+    OSQPSolver_ptr solver{nullptr};   // Wrap solver inside memory management
+};
 
 #endif /* ifndef OSQP_TESTER_H */

--- a/tests/osqp_tester.h
+++ b/tests/osqp_tester.h
@@ -15,10 +15,28 @@
 #define TESTS_TOL 1e-3      // Slightly larger tolerance for floats
 #endif
 
-/* create structure to hold problem data */
-/* similar to OSQP internal container, but */
-/* holding only bare array types and csc */
-typedef struct {
+/* QP problem data */
+class OSQPTestData {
+public:
+    OSQPTestData() {};
+
+    virtual ~OSQPTestData() {
+        // Clean vectors
+        c_free(l);
+        c_free(u);
+        c_free(q);
+
+        //Clean Matrices
+        c_free(A->x);
+        c_free(A->i);
+        c_free(A->p);
+        c_free(A);
+        c_free(P->x);
+        c_free(P->i);
+        c_free(P->p);
+        c_free(P);
+    };
+
     OSQPInt        n;
     OSQPInt        m;
     OSQPCscMatrix* P;
@@ -26,14 +44,23 @@ typedef struct {
     OSQPCscMatrix* A;
     OSQPFloat*     l;
     OSQPFloat*     u;
-} OSQPTestData;
+};
+
+#include <memory>
+
+class OSQPBaseFixture {
+public:
+    OSQPBaseFixture() {}
+    virtual ~OSQPBaseFixture() {}
+};
 
 /*
  * Test fixture to hold various types needed for OSQP tests
  */
-class OSQPTestFixture {
+class OSQPTestFixture{
 public:
-    OSQPTestFixture() {
+    OSQPTestFixture()
+    {
         settings.reset((OSQPSettings*) c_malloc(sizeof(OSQPSettings)));
 
         // Initialize default test settings
@@ -55,6 +82,9 @@ public:
         settings->eps_rel = 1e-5;
     }
 
+    virtual ~OSQPTestFixture() {}
+
+    /* Device number to use in the test suite */
     static int deviceNumber;
 
 protected:
@@ -64,6 +94,9 @@ protected:
     // OSQP Solver itself
     OSQPSolver*    tmpSolver = nullptr;
     OSQPSolver_ptr solver{nullptr};   // Wrap solver inside memory management
+
+    // Test data
+    std::unique_ptr<OSQPTestData> data;
 };
 
 #endif /* ifndef OSQP_TESTER_H */

--- a/tests/primal_dual_infeasibility/test_primal_dual_infeasibility.cpp
+++ b/tests/primal_dual_infeasibility/test_primal_dual_infeasibility.cpp
@@ -14,12 +14,9 @@ TEST_CASE_METHOD(OSQPTestFixture, "Feasible problem", "[solve]")
 
   primal_dual_infeasibility_sols_data_ptr data{generate_problem_primal_dual_infeasibility_sols_data()};
 
-  // Define Solver settings
-  settings->max_iter  = 2000;
-  settings->alpha     = 1.6;
+  // Test-specific solver settings
   settings->polishing = 1;
   settings->scaling   = 0;
-  settings->verbose   = 1;
 
   // Setup workspace
   exitflag = osqp_setup(&tmpSolver,   data->P,    data->q,
@@ -59,12 +56,9 @@ TEST_CASE_METHOD(OSQPTestFixture, "Primal infeasible problem", "[solve],[infeasi
 
   primal_dual_infeasibility_sols_data_ptr data{generate_problem_primal_dual_infeasibility_sols_data()};
 
-  // Define Solver settings
-  settings->max_iter  = 2000;
-  settings->alpha     = 1.6;
+  // Test-specific solver settings
   settings->polishing = 0;
   settings->scaling   = 0;
-  settings->verbose   = 1;
 
   // Setup workspace
   exitflag = osqp_setup(&tmpSolver,   data->P,    data->q,
@@ -90,12 +84,9 @@ TEST_CASE_METHOD(OSQPTestFixture, "Dual infeasible problem", "[solve],[infeasibl
 
   primal_dual_infeasibility_sols_data_ptr data{generate_problem_primal_dual_infeasibility_sols_data()};
 
-  // Define Solver settings
-  settings->max_iter  = 2000;
-  settings->alpha     = 1.6;
+  // Test-specific solver settings
   settings->polishing = 0;
   settings->scaling   = 0;
-  settings->verbose   = 1;
 
   // Setup solver
   exitflag = osqp_setup(&tmpSolver,   data->P,    data->q,
@@ -121,12 +112,9 @@ TEST_CASE_METHOD(OSQPTestFixture, "Primal and dual infeasible problem", "[solve]
 
   primal_dual_infeasibility_sols_data_ptr data{generate_problem_primal_dual_infeasibility_sols_data()};
 
-  // Define Solver settings
-  settings->max_iter  = 2000;
-  settings->alpha     = 1.6;
+  // Test-specific solver settings
   settings->polishing = 0;
   settings->scaling   = 0;
-  settings->verbose   = 1;
 
   // Setup Solver
   exitflag = osqp_setup(&tmpSolver,   data->P,    data->q,

--- a/tests/primal_dual_infeasibility/test_primal_dual_infeasibility.cpp
+++ b/tests/primal_dual_infeasibility/test_primal_dual_infeasibility.cpp
@@ -8,19 +8,13 @@
 #include "primal_dual_infeasibility_data.h"
 
 
-TEST_CASE("Feasible problem", "[solve]")
+TEST_CASE_METHOD(OSQPTestFixture, "Feasible problem", "[solve]")
 {
   OSQPInt exitflag;
 
-  // Structures
-  OSQPSolver*      tmpSolver;   // Solver
-  OSQPSolver_ptr   solver{};
-  OSQPSettings_ptr settings{(OSQPSettings *)c_malloc(sizeof(OSQPSettings))};
-
   primal_dual_infeasibility_sols_data_ptr data{generate_problem_primal_dual_infeasibility_sols_data()};
 
-  // Define Solver settings as default
-  osqp_set_default_settings(settings.get());
+  // Define Solver settings
   settings->max_iter  = 2000;
   settings->alpha     = 1.6;
   settings->polishing = 1;
@@ -59,19 +53,13 @@ TEST_CASE("Feasible problem", "[solve]")
             c_absval(solver->info->obj_val - data->obj_value1) < TESTS_TOL);
 }
 
-TEST_CASE("Primal infeasible problem", "[solve],[infeasible]")
+TEST_CASE_METHOD(OSQPTestFixture, "Primal infeasible problem", "[solve],[infeasible]")
 {
   OSQPInt exitflag;
 
-// Structures
-  OSQPSolver*      tmpSolver;   // Solver
-  OSQPSolver_ptr   solver{};
-  OSQPSettings_ptr settings{(OSQPSettings *)c_malloc(sizeof(OSQPSettings))};
-
   primal_dual_infeasibility_sols_data_ptr data{generate_problem_primal_dual_infeasibility_sols_data()};
 
-  // Define Solver settings as default
-  osqp_set_default_settings(settings.get());
+  // Define Solver settings
   settings->max_iter  = 2000;
   settings->alpha     = 1.6;
   settings->polishing = 0;
@@ -96,19 +84,13 @@ TEST_CASE("Primal infeasible problem", "[solve],[infeasible]")
             solver->info->status_val == OSQP_PRIMAL_INFEASIBLE);
 }
 
-TEST_CASE("Dual infeasible problem", "[solve],[infeasible]")
+TEST_CASE_METHOD(OSQPTestFixture, "Dual infeasible problem", "[solve],[infeasible]")
 {
   OSQPInt exitflag;
 
-  // Structures
-  OSQPSolver*      tmpSolver;   // Solver
-  OSQPSolver_ptr   solver{};
-  OSQPSettings_ptr settings{(OSQPSettings *)c_malloc(sizeof(OSQPSettings))};
-
   primal_dual_infeasibility_sols_data_ptr data{generate_problem_primal_dual_infeasibility_sols_data()};
 
-  // Define Solver settings as default
-  osqp_set_default_settings(settings.get());
+  // Define Solver settings
   settings->max_iter  = 2000;
   settings->alpha     = 1.6;
   settings->polishing = 0;
@@ -133,19 +115,13 @@ TEST_CASE("Dual infeasible problem", "[solve],[infeasible]")
             solver->info->status_val == OSQP_DUAL_INFEASIBLE);
 }
 
-TEST_CASE("Primal and dual infeasible problem", "[solve],[infeasible]")
+TEST_CASE_METHOD(OSQPTestFixture, "Primal and dual infeasible problem", "[solve],[infeasible]")
 {
   OSQPInt exitflag;
 
-// Structures
-  OSQPSolver*      tmpSolver;   // Solver
-  OSQPSolver_ptr   solver{};
-  OSQPSettings_ptr settings{(OSQPSettings *)c_malloc(sizeof(OSQPSettings))};
-
   primal_dual_infeasibility_sols_data_ptr data{generate_problem_primal_dual_infeasibility_sols_data()};
 
-  // Define Solver settings as default
-  osqp_set_default_settings(settings.get());
+  // Define Solver settings
   settings->max_iter  = 2000;
   settings->alpha     = 1.6;
   settings->polishing = 0;

--- a/tests/primal_infeasibility/test_primal_infeasibility.cpp
+++ b/tests/primal_infeasibility/test_primal_infeasibility.cpp
@@ -16,12 +16,9 @@ TEST_CASE_METHOD(OSQPTestFixture, "Primal infeasibility", "[solve],[infeasible]"
   primal_infeasibility_problem_ptr   data{generate_problem_primal_infeasibility()};
   primal_infeasibility_sols_data_ptr sols_data{generate_problem_primal_infeasibility_sols_data()};
 
-  // Define Solver settings
-  settings->max_iter      = 10000;
-  settings->alpha         = 1.6;
+  // Test-specific solver settings
   settings->polishing     = 1;
   settings->scaling       = 0;
-  settings->verbose       = 1;
   settings->warm_starting = 0;
 
   /* Test all possible linear system solvers in this test case */

--- a/tests/primal_infeasibility/test_primal_infeasibility.cpp
+++ b/tests/primal_infeasibility/test_primal_infeasibility.cpp
@@ -8,21 +8,15 @@
 #include "primal_infeasibility_data.h"
 
 
-TEST_CASE("Primal infeasibility", "[solve],[infeasible]")
+TEST_CASE_METHOD(OSQPTestFixture, "Primal infeasibility", "[solve],[infeasible]")
 {
   OSQPInt exitflag;
-
-  // Solver
-  OSQPSolver*    tmpSolver; // Workspace
-  OSQPSolver_ptr solver;
-  OSQPSettings_ptr settings{(OSQPSettings *)c_malloc(sizeof(OSQPSettings))};
 
   // Problem data
   primal_infeasibility_problem_ptr   data{generate_problem_primal_infeasibility()};
   primal_infeasibility_sols_data_ptr sols_data{generate_problem_primal_infeasibility_sols_data()};
 
-  // Define Solver settings as default
-  osqp_set_default_settings(settings.get());
+  // Define Solver settings
   settings->max_iter      = 10000;
   settings->alpha         = 1.6;
   settings->polishing     = 1;

--- a/tests/primal_infeasibility/test_primal_infeasibility.cpp
+++ b/tests/primal_infeasibility/test_primal_infeasibility.cpp
@@ -8,13 +8,9 @@
 #include "primal_infeasibility_data.h"
 
 
-TEST_CASE_METHOD(OSQPTestFixture, "Primal infeasibility", "[solve],[infeasible]")
+TEST_CASE_METHOD(primal_infeasibility_test_fixture, "Primal infeasibility", "[solve],[infeasible]")
 {
   OSQPInt exitflag;
-
-  // Problem data
-  primal_infeasibility_problem_ptr   data{generate_problem_primal_infeasibility()};
-  primal_infeasibility_sols_data_ptr sols_data{generate_problem_primal_infeasibility_sols_data()};
 
   // Test-specific solver settings
   settings->polishing     = 1;

--- a/tests/unconstrained/test_unconstrained.cpp
+++ b/tests/unconstrained/test_unconstrained.cpp
@@ -15,11 +15,6 @@ TEST_CASE_METHOD(OSQPTestFixture, "Unconstrained solve", "[unconstrained],[solve
   unconstrained_problem_ptr   data{generate_problem_unconstrained()};
   unconstrained_sols_data_ptr sols_data{generate_problem_unconstrained_sols_data()};
 
-  // Define Solver settings
-  settings->eps_abs = 1e-05;
-  settings->eps_rel = 1e-05;
-  settings->verbose = 1;
-
   /* Test with and without polishing */
   OSQPInt polish;
   OSQPInt expectedPolishStatus;

--- a/tests/unconstrained/test_unconstrained.cpp
+++ b/tests/unconstrained/test_unconstrained.cpp
@@ -7,23 +7,15 @@
 #include "unconstrained_data.h"
 
 
-TEST_CASE("Unconstrained solve", "[unconstrained],[solve]")
+TEST_CASE_METHOD(OSQPTestFixture, "Unconstrained solve", "[unconstrained],[solve]")
 {
   OSQPInt exitflag;
-
-  // Problem settings
-  OSQPSettings_ptr settings{(OSQPSettings *)c_malloc(sizeof(OSQPSettings))};
-
-  // Structures
-  OSQPSolver*    tmpSolver = nullptr;
-  OSQPSolver_ptr solver{nullptr};   // Wrap solver inside memory management
 
   // Populate data
   unconstrained_problem_ptr   data{generate_problem_unconstrained()};
   unconstrained_sols_data_ptr sols_data{generate_problem_unconstrained_sols_data()};
 
-  // Define Solver settings as default
-  osqp_set_default_settings(settings.get());
+  // Define Solver settings
   settings->eps_abs = 1e-05;
   settings->eps_rel = 1e-05;
   settings->verbose = 1;

--- a/tests/unconstrained/test_unconstrained.cpp
+++ b/tests/unconstrained/test_unconstrained.cpp
@@ -7,13 +7,9 @@
 #include "unconstrained_data.h"
 
 
-TEST_CASE_METHOD(OSQPTestFixture, "Unconstrained solve", "[unconstrained],[solve]")
+TEST_CASE_METHOD(unconstrained_test_fixture, "Unconstrained solve", "[unconstrained],[solve]")
 {
   OSQPInt exitflag;
-
-  // Populate data
-  unconstrained_problem_ptr   data{generate_problem_unconstrained()};
-  unconstrained_sols_data_ptr sols_data{generate_problem_unconstrained_sols_data()};
 
   /* Test with and without polishing */
   OSQPInt polish;

--- a/tests/update_matrices/test_update_matrices.cpp
+++ b/tests/update_matrices/test_update_matrices.cpp
@@ -93,16 +93,9 @@ TEST_CASE("Test updating KKT matrix", "[kkt],[update]")
 #endif /* ifndef OSQP_ALGEBRA_CUDA */
 
 
-TEST_CASE("Test updating P and A", "[update]")
+TEST_CASE_METHOD(OSQPTestFixture, "Test updating P and A", "[update]")
 {
   OSQPInt exitflag;
-
-  // Problem settings
-  OSQPSettings_ptr settings{(OSQPSettings *)c_malloc(sizeof(OSQPSettings))};
-
-  // Structures
-  OSQPSolver*    tmpSolver = nullptr;
-  OSQPSolver_ptr solver{nullptr};   // Wrap solver inside memory management
 
   // Populate data
   update_matrices_sols_data_ptr data{generate_problem_update_matrices_sols_data()};
@@ -110,9 +103,7 @@ TEST_CASE("Test updating P and A", "[update]")
   OSQPInt nnzP = data->test_solve_Pu_new->p[data->test_solve_Pu->n];
   OSQPInt nnzA = data->test_solve_A->p[data->test_solve_A->n];
 
-  // Define Solver settings as default
-  // Problem settings
-  osqp_set_default_settings(settings.get());
+  // Define Solver settings
   settings->max_iter = 1000;
   settings->alpha    = 1.6;
   settings->verbose  = 1;

--- a/tests/update_matrices/test_update_matrices.cpp
+++ b/tests/update_matrices/test_update_matrices.cpp
@@ -105,10 +105,6 @@ TEST_CASE_METHOD(OSQPTestFixture, "Test updating P and A", "[update]")
 
   // Define Solver settings
   settings->max_iter = 1000;
-  settings->alpha    = 1.6;
-  settings->verbose  = 1;
-  settings->eps_abs  = 1e-05;
-  settings->eps_rel  = 1e-05;
 
   /* Test all possible linear system solvers in this test case */
   settings->linsys_solver = GENERATE(filter(&isLinsysSupported, values({OSQP_DIRECT_SOLVER, OSQP_INDIRECT_SOLVER})));

--- a/tests/utils/test_utils.cpp
+++ b/tests/utils/test_utils.cpp
@@ -1,4 +1,5 @@
 #include "osqp.h"
+#include "osqp_tester.h"
 
 // Needed for the c_absval define
 extern "C" {


### PR DESCRIPTION
This PR adds an option for the test cases to run on a specified compute device number (specified through either a command line option or environment variable). It also implements a test fixture for the majority of test cases that contains all the data structures used, ensuring they are created and destroyed properly.