### PR TITLE
Release 0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+Version 0.6.3 (25 May 2023)
+------------------------------
+* Fix MKL function prototypes (required for CRAN compilation) (PR [#487](https://github.com/osqp/osqp/pull/487))
+* Use a constant interval for adaptive rho when in embedded=2 mode (PR [#347](https://github.com/osqp/osqp/pull/347))
+* Include version.h in the OSQP installed headers (Fixes [#323](https://github.com/osqp/osqp/issues/323))
+* Switch unit testing to use Catch2
+* Switch to GitHub actions CI system
+* Switched binary distribution from bintray to GitHub releases
+* Various documentation fixes and improvements
+
+
 Version 0.6.2 (6 January 2021)
 ------------------------------
 * Fix segfault python multithreading

--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ subject to      l <= A x <= u
 where `x in R^n` is the optimization variable. The objective function is defined by a positive semidefinite matrix `P in S^n_+` and vector `q in R^n`. The linear constraints are defined by matrix `A in R^{m x n}` and vectors `l` and `u` so that `l_i in R U {-inf}` and `u_i in R U {+inf}` for all `i in 1,...,m`.
 
 
-The latest version is `0.6.2`.
-
 ## Citing OSQP
 
 If you are using OSQP for your work, we encourage you to

--- a/include/version.h
+++ b/include/version.h
@@ -5,5 +5,5 @@ to cmake
 */
 
 #ifndef OSQP_VERSION
-#define OSQP_VERSION "0.0.0"
+#define OSQP_VERSION "0.6.3"
 #endif


### PR DESCRIPTION
Release version 0.6.3 - the last version tagged before develop-1.0 is merged in to make the 1.0.0.beta release.

Once merged, I'll create the tag.