### PR TITLE
Allow user to override choice of MKL linkage

### DIFF
--- a/algebra/mkl/CMakeLists.txt
+++ b/algebra/mkl/CMakeLists.txt
@@ -4,8 +4,13 @@ else()
   set(MKL_INTERFACE "lp64")
 endif()
 
-# Link against the single dynamic library version of the MKL library
-set(MKL_LINK "sdl")
+# Select the MKL library to link against.
+# Link against the single dynamic library version of the MKL library by default.
+set(MKL_LINK "sdl" CACHE STRING "MKL linkage")
+
+if(${MKL_LINK} STREQUAL "sdl")
+  target_compile_definitions(OSQPLIB PUBLIC MKL_LINK_SDL=1)
+endif()
 
 find_package(MKL CONFIG REQUIRED)
 

--- a/algebra/mkl/algebra_libs.c
+++ b/algebra/mkl/algebra_libs.c
@@ -22,10 +22,14 @@ enum osqp_linsys_solver_type osqp_algebra_default_linsys(void) {
 OSQPInt osqp_algebra_init_libs(OSQPInt device) {
     OSQPInt retval = 0;
 
+/* Only select the interface when linking against the single dynamic library version
+   of MKL */
+#ifdef MKL_LINK_SDL
 #ifdef OSQP_USE_LONG
     retval = mkl_set_interface_layer(MKL_INTERFACE_ILP64);
 #else
     retval = mkl_set_interface_layer(MKL_INTERFACE_LP64);
+#endif
 #endif
 
     // Positive value is the interface chosen, so -1 is the error condition


### PR DESCRIPTION
Turn the MKL linkage choice into a cache variable so that the user can specify it using a CMake command should they choose, but default to the single dynamic library version if nothing is given.

Fixes #296.