### PR TITLE
Fix several issues that block building Julia wrappers

### DIFF
--- a/algebra/_common/lin_sys/qdldl/qdldl_interface.c
+++ b/algebra/_common/lin_sys/qdldl/qdldl_interface.c
@@ -663,7 +663,7 @@ static void _adj_assemble_csc(OSQPCscMatrix*     D,
 
 }
 
-OSQPInt adjoint_derivative_qdldl(qdldl_solver*      s,
+OSQPInt adjoint_derivative_qdldl(qdldl_solver**     s,
                                  const OSQPMatrix*  P_full,
                                  const OSQPMatrix*  G,
                                  const OSQPMatrix*  A_eq,

--- a/algebra/_common/lin_sys/qdldl/qdldl_interface.h
+++ b/algebra/_common/lin_sys/qdldl/qdldl_interface.h
@@ -184,7 +184,7 @@ OSQPInt update_linsys_solver_rho_vec_qdldl(qdldl_solver*      s,
  */
 void free_linsys_solver_qdldl(qdldl_solver* s);
 
-OSQPInt adjoint_derivative_qdldl(qdldl_solver*      s,
+OSQPInt adjoint_derivative_qdldl(qdldl_solver**     s,
                                  const OSQPMatrix*  P,
                                  const OSQPMatrix*  G,
                                  const OSQPMatrix*  A_eq,

--- a/algebra/cuda/include/cuda_wrapper.h
+++ b/algebra/cuda/include/cuda_wrapper.h
@@ -26,6 +26,7 @@
 # define CUDA_WRAPPER_H
 
 #include <cublas_v2.h>
+#include <cusparse_v2.h>
 
 #include "osqp_api_types.h"
 
@@ -116,6 +117,18 @@ static cublasStatus_t cublasTnrm2(cublasHandle_t   handle,
   return cublasDnrm2(handle, n, x, incx, result);
 #endif
 }
+
+/*
+ * CUSparse 12.0 removed the CUSPARSE_MV_ALG_DEFAULT enumeration for the algorithm
+ * selection and replaced it with the CUSPARSE_SPMV_ALG_DEFAULT enumeration.
+ */
+#ifndef CUSPARSE_VERSION
+#error "Unable to find CUSparse version"
+#elif (CUSPARSE_VERSION >= 12000)
+#define CUSPARSE_SPMV_ALGORITHM_DEFAULT CUSPARSE_SPMV_ALG_DEFAULT
+#else
+#define CUSPARSE_SPMV_ALGORITHM_DEFAULT CUSPARSE_MV_ALG_DEFAULT
+#endif
 
 
 #endif /* ifndef CUDA_WRAPPER */

--- a/algebra/cuda/lin_sys/indirect/cuda_pcg.cu
+++ b/algebra/cuda/lin_sys/indirect/cuda_pcg.cu
@@ -74,7 +74,7 @@ static void mat_vec_prod(cudapcg_solver*             s,
   checkCudaErrors(cusparseSpMV(
     CUDA_handle->cusparseHandle, CUSPARSE_OPERATION_NON_TRANSPOSE,
     &H_ONE, P->SpMatDescr, vecx, &H_ONE, vecy,
-    CUDA_FLOAT, CUSPARSE_SPMV_ALG_DEFAULT, P->SpMatBuffer));
+    CUDA_FLOAT, CUSPARSE_SPMV_ALGORITHM_DEFAULT, P->SpMatBuffer));
 
   if (m == 0) return;
 
@@ -83,14 +83,14 @@ static void mat_vec_prod(cudapcg_solver*             s,
     checkCudaErrors(cusparseSpMV(
       CUDA_handle->cusparseHandle, CUSPARSE_OPERATION_NON_TRANSPOSE,
       &s->h_rho, A->SpMatDescr, vecx, &H_ZERO, s->vecz,
-      CUDA_FLOAT, CUSPARSE_SPMV_ALG_DEFAULT, A->SpMatBuffer));
+      CUDA_FLOAT, CUSPARSE_SPMV_ALGORITHM_DEFAULT, A->SpMatBuffer));
   }
   else {
     /* z = A * x */
     checkCudaErrors(cusparseSpMV(
       CUDA_handle->cusparseHandle, CUSPARSE_OPERATION_NON_TRANSPOSE,
       &H_ONE, A->SpMatDescr, vecx, &H_ZERO, s->vecz,
-      CUDA_FLOAT, CUSPARSE_SPMV_ALG_DEFAULT, A->SpMatBuffer));
+      CUDA_FLOAT, CUSPARSE_SPMV_ALGORITHM_DEFAULT, A->SpMatBuffer));
 
     /* z = diag(rho_vec) * z */
     cuda_vec_ew_prod(s->d_z, s->d_z, s->d_rho_vec, m);
@@ -100,7 +100,7 @@ static void mat_vec_prod(cudapcg_solver*             s,
   checkCudaErrors(cusparseSpMV(
     CUDA_handle->cusparseHandle, CUSPARSE_OPERATION_NON_TRANSPOSE,
     &H_ONE, At->SpMatDescr, s->vecz, &H_ONE, vecy,
-    CUDA_FLOAT, CUSPARSE_SPMV_ALG_DEFAULT, At->SpMatBuffer));
+    CUDA_FLOAT, CUSPARSE_SPMV_ALGORITHM_DEFAULT, At->SpMatBuffer));
 }
 
 

--- a/algebra/cuda/src/cuda_csr.cu
+++ b/algebra/cuda/src/cuda_csr.cu
@@ -20,6 +20,7 @@
 #include "cuda_handler.h"
 #include "cuda_lin_alg.h"   /* --> cuda_vec_gather */
 #include "cuda_malloc.h"
+#include "cuda_wrapper.h"
 #include "helper_cuda.h"    /* --> checkCudaErrors */
 
 #include "csr_type.h"
@@ -303,7 +304,7 @@ static void init_SpMV_interface(csr *M) {
       checkCudaErrors(cusparseSpMV_bufferSize(
         CUDA_handle->cusparseHandle, CUSPARSE_OPERATION_NON_TRANSPOSE,
         &alpha, M->SpMatDescr, vecx, &alpha, vecy,
-        CUDA_FLOAT, CUSPARSE_SPMV_ALG_DEFAULT, &M->SpMatBufferSize));
+        CUDA_FLOAT, CUSPARSE_SPMV_ALGORITHM_DEFAULT, &M->SpMatBufferSize));
 
       if (M->SpMatBufferSize)
         cuda_malloc((void **) &M->SpMatBuffer, M->SpMatBufferSize);

--- a/algebra/cuda/src/cuda_lin_alg.cu
+++ b/algebra/cuda/src/cuda_lin_alg.cu
@@ -992,7 +992,7 @@ void cuda_mat_Axpy(const csr*                 A,
   checkCudaErrors(cusparseSpMV(
     CUDA_handle->cusparseHandle, CUSPARSE_OPERATION_NON_TRANSPOSE,
     &alpha, A->SpMatDescr, vecx, &beta, vecy,
-    CUDA_FLOAT, CUSPARSE_SPMV_ALG_DEFAULT, A->SpMatBuffer));
+    CUDA_FLOAT, CUSPARSE_SPMV_ALGORITHM_DEFAULT, A->SpMatBuffer));
 }
 
 void cuda_mat_row_norm_inf(const csr*       S,

--- a/src/derivative.c
+++ b/src/derivative.c
@@ -74,6 +74,8 @@ OSQPInt adjoint_derivative_get_vec(OSQPSolver *solver,
                                         OSQPFloat*     dl,
                                         OSQPFloat*     du) {
 
+    OSQPInt i;
+
     // Check if solver has been initialized
     if (!solver || !solver->work || !solver->work->derivative_data)
       return osqp_error(OSQP_WORKSPACE_NOT_INIT_ERROR);
@@ -88,7 +90,7 @@ OSQPInt adjoint_derivative_get_vec(OSQPSolver *solver,
     OSQPVectorf_to_raw(dq, rx);
     OSQPVectorf_to_raw(dl, derivative_data->ryl);
     OSQPVectorf_to_raw(du, derivative_data->ryu);
-    for (OSQPInt i=0; i<OSQPVectorf_length(derivative_data->ryu); i++) {
+    for (i=0; i<OSQPVectorf_length(derivative_data->ryu); i++) {
         du[i] = -du[i];
     }
 

--- a/src/derivative.c
+++ b/src/derivative.c
@@ -277,7 +277,8 @@ OSQPInt adjoint_derivative_compute(OSQPSolver *solver,
 
     OSQPMatrix* P_full = OSQPMatrix_triu_to_symm(P);
     OSQPMatrix_free(P);
-    adjoint_derivative_linsys_solver(solver, solver->settings, P_full, G, A_eq, GDiagLambda, slacks, rhs);
+    adjoint_derivative_linsys_solver(NULL /* No solver object is allocated for this solver yet */,
+                                     solver->settings, P_full, G, A_eq, GDiagLambda, slacks, rhs);
     OSQPMatrix_free(P_full);
     OSQPMatrix_free(G);
     OSQPMatrix_free(A_eq);


### PR DESCRIPTION
There were several issues in the code that caused errors when building the code in the Julia BinaryBuilder environment. The fixes are:

* Fix C90 compatibility: Don't define variables in for loop statements
* Fix compatibility with CUDA <11.2 (the name of the SPMV operation changed, and the one used in the code was only introduced in 11.2, so to allow building on 11.0 select the operation name based on the library version).

This also contains two minor fixes to the definition and calling of the adjoint derivative linear solver function.