### PR TITLE
Replace references to discourse with GitHub discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ![PyPI - downloads](https://img.shields.io/pypi/dm/osqp.svg?label=Pypi%20downloads)
 ![Conda - downloads](https://img.shields.io/conda/dn/conda-forge/osqp.svg?label=Conda%20downloads)
 
-[**Join our forum on Discourse**](https://osqp.discourse.group) for any questions related to the solver!
+[**Visit our GitHub Discussions page**](https://github.com/orgs/osqp/discussions) for any questions related to the solver!
 
 **The documentation** is available at [**osqp.org**](https://osqp.org/)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,8 +1,8 @@
 OSQP solver documentation
 ==========================
 
-**Join our** `forum <https://osqp.discourse.group/>`_ **for any
-questions related to the solver!**
+[**Visit our GitHub Discussions page**](https://github.com/orgs/osqp/discussions)
+for any questions related to the solver!
 
 The OSQP (Operator Splitting Quadratic Program) solver is a numerical
 optimization package for solving convex quadratic programs in the form

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -26,7 +26,7 @@ url: "https://osqp.org" # the base hostname & protocol for your site, e.g. http:
 # facebook_link: https://www.facebook.com/groups/331532750262318/
 github_link: https://github.com/osqp/osqp
 google_analytics: UA-56714542-3
-discourse_link: https://osqp.discourse.group/
+forum_link: https://github.com/orgs/osqp/discussions
 
 # Which folders to include?
 # gh pages does not currently support a source directive,

--- a/site/_includes/navbar.html
+++ b/site/_includes/navbar.html
@@ -20,7 +20,7 @@
 				{% assign pages_list = site.pages | sort:"order" %}
 				{% assign group = 'navigation' %}
 				{% include pages_list %}
-				<li class="nav-item"><a class="nav-link" href="{{ site.discourse_link }}">Forum</a></li>
+				<li class="nav-item"><a class="nav-link" href="{{ site.forum_link }}">Forum</a></li>
 				<li class="nav-item"><a class="nav-link" href="{{ site.github_link }}">GitHub</a></li>
 			</ul>
 			<ul class="navbar-nav">


### PR DESCRIPTION
We have now switched to GitHub discussions as the primary Q&A forum, so direct users there in the documentation.