### PR TITLE
Fix build warnings

### DIFF
--- a/algebra/_common/kkt.c
+++ b/algebra/_common/kkt.c
@@ -303,11 +303,6 @@ OSQPCscMatrix* form_KKT(OSQPCscMatrix* P,
   OSQPInt   m,n;            //number of variables, constraints
   OSQPInt  nKKT, nnzKKT;    // Size, number of nonzeros in KKT
   OSQPInt  ndiagP;          // entries on diagonal of P
-  OSQPInt  ptr, i, j;       // Counters for elements (i,j) and index pointer
-  OSQPInt  zKKT = 0;        // Counter for total number of elements in P and in
-                            // KKT
-  OSQPInt* KKT_TtoC;        // Pointer to vector mapping from KKT in triplet form
-                            // to CSC
 
   OSQPCscMatrix* KKT;     // KKT matrix in CSC (or CSR) format
 
@@ -388,7 +383,7 @@ void update_KKT_A(OSQPCscMatrix* KKT,
                   OSQPInt        A_new_n,
                   OSQPInt*       AtoKKT) {
 
-  OSQPInt j, nnzA, Aidx, Kidx, doall;
+  OSQPInt j, Aidx, Kidx, doall;
 
   if(A_new_n <= 0){return;}
 
@@ -397,7 +392,6 @@ void update_KKT_A(OSQPCscMatrix* KKT,
   doall  = Ax_new_idx == OSQP_NULL ? 1 : 0;
 
   // Update elements of KKT using A
-  nnzA = A->p[A->n];
   for (j = 0; j < A_new_n; j++) {
     Aidx = doall ? j : Ax_new_idx[j];
     Kidx = AtoKKT[Aidx];

--- a/algebra/_common/lin_sys/qdldl/qdldl_interface.c
+++ b/algebra/_common/lin_sys/qdldl/qdldl_interface.c
@@ -4,6 +4,7 @@
 
 #include "qdldl.h"
 #include "qdldl_interface.h"
+#include "util.h"
 
 #ifndef OSQP_EMBEDDED_MODE
 #include "amd.h"
@@ -19,13 +20,18 @@
 
 void update_settings_linsys_solver_qdldl(qdldl_solver*       s,
                                          const OSQPSettings* settings) {
-  return;
+    /* No settings to update */
+    OSQP_UnusedVar(s);
+    OSQP_UnusedVar(settings);
+    return;
 }
 
-// Warm starting not used by direct solvers
 void warm_start_linsys_solver_qdldl(qdldl_solver*      s,
                                     const OSQPVectorf* x) {
-  return;
+    /* Warm starting not used by direct solvers */
+    OSQP_UnusedVar(s);
+    OSQP_UnusedVar(x);
+    return;
 }
 
 #ifndef OSQP_EMBEDDED_MODE
@@ -372,7 +378,9 @@ OSQPInt init_linsys_solver_qdldl(qdldl_solver**      sp,
 #endif  // OSQP_EMBEDDED_MODE
 
 const char* name_qdldl(qdldl_solver* s) {
-  return "QDLDL v" STRINGIZE(QDLDL_VERSION_MAJOR) "." STRINGIZE(QDLDL_VERSION_MINOR) "." STRINGIZE(QDLDL_VERSION_PATCH);
+    OSQP_UnusedVar(s);
+
+    return "QDLDL v" STRINGIZE(QDLDL_VERSION_MAJOR) "." STRINGIZE(QDLDL_VERSION_MINOR) "." STRINGIZE(QDLDL_VERSION_PATCH);
 }
 
 
@@ -405,6 +413,9 @@ OSQPInt solve_linsys_qdldl(qdldl_solver* s,
   OSQPInt    n = s->n;
   OSQPInt    m = s->m;
   OSQPFloat* bv = b->values;
+
+  // Direct solver doesn't care about the ADMM iteration
+  OSQP_UnusedVar(admm_iter);
 
 #ifndef OSQP_EMBEDDED_MODE
   if (s->polishing) {
@@ -670,6 +681,8 @@ OSQPInt adjoint_derivative_qdldl(qdldl_solver**     s,
                                  const OSQPMatrix*  GDiagLambda,
                                  const OSQPVectorf* slacks,
                                        OSQPVectorf* rhs) {
+    /* We don't currently reuse the solver for the adjoint computations */
+    OSQP_UnusedVar(s);
 
     OSQPInt n = OSQPMatrix_get_m(P_full);
     OSQPInt n_ineq = OSQPMatrix_get_m(G);

--- a/algebra/_common/lin_sys/qdldl/qdldl_interface.c
+++ b/algebra/_common/lin_sys/qdldl/qdldl_interface.c
@@ -669,7 +669,7 @@ OSQPInt adjoint_derivative_qdldl(qdldl_solver**     s,
                                  const OSQPMatrix*  A_eq,
                                  const OSQPMatrix*  GDiagLambda,
                                  const OSQPVectorf* slacks,
-                                 const OSQPVectorf* rhs) {
+                                       OSQPVectorf* rhs) {
 
     OSQPInt n = OSQPMatrix_get_m(P_full);
     OSQPInt n_ineq = OSQPMatrix_get_m(G);

--- a/algebra/_common/lin_sys/qdldl/qdldl_interface.h
+++ b/algebra/_common/lin_sys/qdldl/qdldl_interface.h
@@ -35,7 +35,13 @@ struct qdldl {
                        const  OSQPVectorf* x);
 
 #ifndef OSQP_EMBEDDED_MODE
-    OSQPInt (*adjoint_derivative)(struct qdldl* self);
+    OSQPInt (*adjoint_derivative)(qdldl_solver**     s,
+                                  const OSQPMatrix*  P,
+                                  const OSQPMatrix*  G,
+                                  const OSQPMatrix*  A_eq,
+                                  const OSQPMatrix*  GDiagLambda,
+                                  const OSQPVectorf* slacks,
+                                        OSQPVectorf* rhs);
 
     void (*free)(struct qdldl* self); ///< Free workspace (only if desktop)
 #endif
@@ -190,7 +196,7 @@ OSQPInt adjoint_derivative_qdldl(qdldl_solver**     s,
                                  const OSQPMatrix*  A_eq,
                                  const OSQPMatrix*  GDiagLambda,
                                  const OSQPVectorf* slacks,
-                                 const OSQPVectorf* rhs);
+                                       OSQPVectorf* rhs);
 
 #endif
 

--- a/algebra/builtin/algebra_libs.c
+++ b/algebra/builtin/algebra_libs.c
@@ -1,6 +1,7 @@
 #include "osqp_api_constants.h"
 #include "osqp_api_types.h"
 #include "qdldl_interface.h"
+#include "util.h"
 
 OSQPInt osqp_algebra_linsys_supported(void) {
   /* Only has QDLDL (direct solver) */
@@ -12,11 +13,17 @@ enum osqp_linsys_solver_type osqp_algebra_default_linsys(void) {
   return OSQP_DIRECT_SOLVER;
 }
 
-OSQPInt osqp_algebra_init_libs(OSQPInt device) {return 0;}
+OSQPInt osqp_algebra_init_libs(OSQPInt device)
+{
+  OSQP_UnusedVar(device);
+  return 0;
+}
 
 void osqp_algebra_free_libs(void) {return;}
 
 OSQPInt osqp_algebra_name(char* name, OSQPInt nameLen) {
+  OSQP_UnusedVar(nameLen);
+
   // Manually assign into the buffer to avoid using strcpy
   name[0] = 'B';
   name[1] = 'u';
@@ -32,6 +39,8 @@ OSQPInt osqp_algebra_name(char* name, OSQPInt nameLen) {
 }
 
 OSQPInt osqp_algebra_device_name(char* name, OSQPInt nameLen) {
+  OSQP_UnusedVar(nameLen);
+
   /* No device name for built-in algebra */
   name[0] = 0;
   return 0;
@@ -50,6 +59,10 @@ OSQPInt osqp_algebra_init_linsys_solver(LinSysSolver**      s,
                                         OSQPFloat*          scaled_dual_res,
                                         OSQPInt             polishing) {
 
+  // Don't use the scaled residuals right now
+  OSQP_UnusedVar(scaled_prim_res);
+  OSQP_UnusedVar(scaled_dual_res);
+
   switch (settings->linsys_solver) {
   default:
   case OSQP_DIRECT_SOLVER:
@@ -66,7 +79,9 @@ OSQPInt adjoint_derivative_linsys_solver(LinSysSolver**      s,
                                          OSQPVectorf*        slacks,
                                          OSQPVectorf*        rhs) {
 
-return adjoint_derivative_qdldl((qdldl_solver **)s, P, G, A_eq, GDiagLambda, slacks, rhs);
+  OSQP_UnusedVar(settings);
+
+  return adjoint_derivative_qdldl((qdldl_solver **)s, P, G, A_eq, GDiagLambda, slacks, rhs);
 }
 
 #endif

--- a/algebra/mkl/algebra_libs.c
+++ b/algebra/mkl/algebra_libs.c
@@ -4,6 +4,7 @@
 
 #include "pardiso_interface.h"
 #include "mkl-cg_interface.h"
+#include "util.h"
 
 #include <mkl.h>
 
@@ -21,6 +22,8 @@ enum osqp_linsys_solver_type osqp_algebra_default_linsys(void) {
 
 OSQPInt osqp_algebra_init_libs(OSQPInt device) {
     OSQPInt retval = 0;
+
+    OSQP_UnusedVar(device);
 
 /* Only select the interface when linking against the single dynamic library version
    of MKL */

--- a/algebra/mkl/lin_sys/direct/pardiso_interface.c
+++ b/algebra/mkl/lin_sys/direct/pardiso_interface.c
@@ -1,6 +1,7 @@
 #include "pardiso_interface.h"
 #include "algebra_impl.h"
 #include "printing.h"
+#include "util.h"
 
 #if OSQP_EMBEDDED_MODE != 1
 #include "kkt.h"
@@ -17,12 +18,16 @@
 
 void update_settings_linsys_solver_pardiso(pardiso_solver*     s,
                                            const OSQPSettings* settings) {
+  OSQP_UnusedVar(s);
+  OSQP_UnusedVar(settings);
   return;
 }
 
-// Warm starting not used by direct solvers
 void warm_start_linsys_solver_pardiso(pardiso_solver*    s,
                                       const OSQPVectorf* x) {
+  // Warm starting not used by direct solvers
+  OSQP_UnusedVar(s);
+  OSQP_UnusedVar(x);
   return;
 }
 
@@ -231,6 +236,8 @@ OSQPInt init_linsys_solver_pardiso(pardiso_solver**    sp,
 }
 
 const char* name_pardiso(pardiso_solver* s) {
+  OSQP_UnusedVar(s);
+
   return "Pardiso";
 }
 
@@ -238,6 +245,8 @@ const char* name_pardiso(pardiso_solver* s) {
 OSQPInt solve_linsys_pardiso(pardiso_solver* s,
                              OSQPVectorf*    b,
                              OSQPInt         admm_iter) {
+  // Direct solver doesn't care about the ADMM iteration
+  OSQP_UnusedVar(admm_iter);
 
   OSQPInt    j;
   OSQPInt    n  = s->n;

--- a/algebra/mkl/lin_sys/indirect/mkl-cg_interface.c
+++ b/algebra/mkl/lin_sys/indirect/mkl-cg_interface.c
@@ -336,8 +336,15 @@ OSQPInt update_matrices_linsys_mklcg(mklcg_solver*     s,
                                      const OSQPMatrix* A,
                                      const OSQPInt*    Ax_new_idx,
                                      OSQPInt           A_new_n) {
-  s->P = *(OSQPMatrix**)(&P);
-  s->A = *(OSQPMatrix**)(&A);
+  /* The MKL solver holds pointers to the matrices A and P, so it already has
+     access to the updated matrices at this point. The only task remaining is to
+     recompute the preconditioner */
+  OSQP_UnusedVar(P);
+  OSQP_UnusedVar(Px_new_idx);
+  OSQP_UnusedVar(P_new_n);
+  OSQP_UnusedVar(A);
+  OSQP_UnusedVar(Ax_new_idx);
+  OSQP_UnusedVar(A_new_n);
 
   // Update the preconditioner (matrix-only update)
   cg_update_precond(s);

--- a/algebra/mkl/lin_sys/indirect/mkl-cg_interface.c
+++ b/algebra/mkl/lin_sys/indirect/mkl-cg_interface.c
@@ -2,6 +2,7 @@
 #include "algebra_vector.h"
 #include "reduced_kkt.h"
 #include "mkl-cg_interface.h"
+#include "util.h"
 #include <mkl_rci.h>
 
 OSQPFloat cg_compute_tolerance(OSQPInt    admm_iter,
@@ -322,6 +323,8 @@ void update_settings_linsys_solver_mklcg(struct mklcg_solver_* s,
 void warm_start_linys_mklcg(struct mklcg_solver_* self,
                             const OSQPVectorf*    x) {
   // TODO: Warm starting!
+  OSQP_UnusedVar(self);
+  OSQP_UnusedVar(x);
   return;
 }
 

--- a/algebra/mkl/lin_sys/indirect/mkl-cg_interface.c
+++ b/algebra/mkl/lin_sys/indirect/mkl-cg_interface.c
@@ -88,7 +88,6 @@ OSQPInt init_linsys_mklcg(mklcg_solver**     sp,
 
   OSQPInt m = A->csc->m;
   OSQPInt n = P->csc->n;
-  MKL_INT mkln = n;
   MKL_INT status;
   mklcg_solver* s = (mklcg_solver *)c_malloc(sizeof(mklcg_solver));
   *sp = s;

--- a/examples/osqp_codegen_demo.c
+++ b/examples/osqp_codegen_demo.c
@@ -11,6 +11,7 @@ int main(int argc, char *argv[]) {
     case 3:
       sprintf(matDirPath, "%s", argv[2]);
       /* Fall through to set the vector path */
+      /* FALLTHROUGH */
 
     case 2:
       sprintf(vecDirPath, "%s", argv[1]) ;

--- a/examples/osqp_codegen_demo.c
+++ b/examples/osqp_codegen_demo.c
@@ -17,8 +17,9 @@ int main(int argc, char *argv[]) {
       break;
 
     default:
-      sprintf(vecDirPath, "");
-      sprintf(matDirPath, "");
+      /* Empty string */
+      vecDirPath[0] = '\0';
+      matDirPath[0] = '\0';
   }
 
   printf("OSQP code generation demo program.\n\n");

--- a/include/private/codegen.h
+++ b/include/private/codegen.h
@@ -7,13 +7,12 @@
 extern "C" {
 #endif
 
-OSQPInt codegen_inc(OSQPSolver* solver,
-                    const char* output_dir,
+OSQPInt codegen_inc(const char* output_dir,
                     const char* file_prefix);
 
-OSQPInt codegen_src(OSQPSolver* solver,
-                    const char* output_dir,
+OSQPInt codegen_src(const char* output_dir,
                     const char* file_prefix,
+                    OSQPSolver* solver,
                     OSQPInt     embedded);
 
 OSQPInt codegen_defines(const char*         output_dir,

--- a/include/private/printing.h
+++ b/include/private/printing.h
@@ -9,6 +9,13 @@
 extern "C" {
 #endif
 
+/* Format specifier to use for the OSQP integers */
+# ifdef OSQP_USE_LONG            /* Long integers */
+#define OSQP_INT_FMT "lld"
+# else                           /* Standard integers */
+#define OSQP_INT_FMT "d"
+# endif
+
 /* Error printing function */
 /* Always define this, and let implementations undefine if they want to change it */
 # if __STDC_VERSION__ >= 199901L

--- a/include/private/util.h
+++ b/include/private/util.h
@@ -5,6 +5,12 @@
 # include "osqp.h"
 # include "types.h"
 
+/**********************
+ * Helper macros     *
+ *********************/
+/* Identify unused variables */
+#define OSQP_UnusedVar(x)  (void)(x)
+
 
 /**********************
 * Utility Functions  *

--- a/src/auxil.c
+++ b/src/auxil.c
@@ -13,7 +13,6 @@
 
 OSQPFloat compute_rho_estimate(const OSQPSolver* solver) {
 
-  OSQPInt   n, m;                         // Dimensions
   OSQPFloat prim_res, dual_res;           // Primal and dual residuals
   OSQPFloat prim_res_norm, dual_res_norm; // Normalization for the residuals
   OSQPFloat temp_res_norm;                // Temporary residual norm
@@ -21,10 +20,6 @@ OSQPFloat compute_rho_estimate(const OSQPSolver* solver) {
 
   OSQPSettings*  settings = solver->settings;
   OSQPWorkspace* work     = solver->work;
-
-  // Get problem dimensions
-  n = work->data->n;
-  m = work->data->m;
 
   // Get primal and dual residuals
   prim_res = work->scaled_prim_res;

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -633,8 +633,7 @@ static OSQPInt write_solver(FILE*             f,
 * Codegen API
 **************/
 
-OSQPInt codegen_inc(OSQPSolver* solver,
-                    const char* output_dir,
+OSQPInt codegen_inc(const char* output_dir,
                     const char* file_prefix) {
 
   char fname[FILE_LENGTH], hfname[PATH_LENGTH], incGuard[FILE_LENGTH+2];
@@ -691,9 +690,9 @@ OSQPInt codegen_inc(OSQPSolver* solver,
 }
 
 
-OSQPInt codegen_src(OSQPSolver* solver,
-                    const char* output_dir,
+OSQPInt codegen_src(const char* output_dir,
                     const char* file_prefix,
+                    OSQPSolver* solver,
                     OSQPInt     embedded) {
 
   OSQPInt exitflag = OSQP_NO_ERROR;

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -801,7 +801,7 @@ OSQPInt codegen_defines(const char*         output_dir,
 OSQPInt codegen_example(const char* output_dir,
                         const char* file_prefix){
 
-  char fname[PATH_LENGTH], cfname[PATH_LENGTH];
+  char cfname[PATH_LENGTH];
   FILE *srcFile;
   time_t now;
 

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -5,6 +5,7 @@
 #include "error.h"
 #include "osqp_api_constants.h"
 #include "types.h"
+#include "printing.h"
 #include "algebra_impl.h"
 #include "qdldl_interface.h"
 
@@ -37,7 +38,7 @@ static OSQPInt write_vecf(FILE*            f,
   OSQPInt i;
 
   if (n && vecf) {
-    fprintf(f, "OSQPFloat %s[%d] = {\n", name, n);
+    fprintf(f, "OSQPFloat %s[%" OSQP_INT_FMT "] = {\n", name, n);
     for (i = 0; i < n; i++) {
       fprintf(f, "  (OSQPFloat)%.20f,\n", vecf[i]);
     }
@@ -58,9 +59,9 @@ static OSQPInt write_veci(FILE*          f,
   OSQPInt i;
 
   if (n && veci) {
-    fprintf(f, "OSQPInt %s[%d] = {\n", name, n);
+    fprintf(f, "OSQPInt %s[%" OSQP_INT_FMT "] = {\n", name, n);
     for (i = 0; i < n; i++) {
-      fprintf(f, "  %i,\n", veci[i]);
+      fprintf(f, "  %" OSQP_INT_FMT ",\n", veci[i]);
     }
     fprintf(f, "};\n");
   }
@@ -82,7 +83,7 @@ static OSQPInt write_OSQPVectorf(FILE*              f,
 
   sprintf(vecf_name, "%s_val", name);
   PROPAGATE_ERROR(write_vecf(f, vec->values, vec->length, vecf_name))
-  fprintf(f, "OSQPVectorf %s = {\n  %s,\n  %d\n};\n", name, vecf_name, vec->length);
+  fprintf(f, "OSQPVectorf %s = {\n  %s,\n  %" OSQP_INT_FMT "\n};\n", name, vecf_name, vec->length);
 
   return exitflag;
 }
@@ -92,13 +93,13 @@ static OSQPInt write_OSQPVectori(FILE*              f,
                                  const char*        name) {
   
   OSQPInt exitflag = OSQP_NO_ERROR;
-  char veci_name[MAX_VAR_LENGTH];
+  char veci_name[MAX_VAR_LENGTH+4];
 
   if (!vec) return OSQP_DATA_NOT_INITIALIZED;
 
   sprintf(veci_name, "%s_val", name);
   PROPAGATE_ERROR(write_veci(f, vec->values, vec->length, veci_name))
-  fprintf(f, "OSQPVectori %s = {\n  %s,\n  %d\n};\n", name, veci_name, vec->length);
+  fprintf(f, "OSQPVectori %s = {\n  %s,\n  %" OSQP_INT_FMT "\n};\n", name, veci_name, vec->length);
 
   return exitflag;
 }
@@ -124,13 +125,13 @@ static OSQPInt write_csc(FILE*                f,
   sprintf(vec_name, "%s_x", name);
   PROPAGATE_ERROR(write_vecf(f, M->x, M->nzmax, vec_name))
   fprintf(f, "OSQPCscMatrix %s = {\n", name);
-  fprintf(f, "  %d,\n", M->m);
-  fprintf(f, "  %d,\n", M->n);
+  fprintf(f, "  %" OSQP_INT_FMT ",\n", M->m);
+  fprintf(f, "  %" OSQP_INT_FMT ",\n", M->n);
   fprintf(f, "  %s_p,\n", name);
   fprintf(f, "  %s_i,\n", name);
   fprintf(f, "  %s_x,\n", name);
-  fprintf(f, "  %d,\n", M->nzmax);
-  fprintf(f, "  %d,\n", M->nz);
+  fprintf(f, "  %" OSQP_INT_FMT ",\n", M->nzmax);
+  fprintf(f, "  %" OSQP_INT_FMT ",\n", M->nz);
   fprintf(f, "};\n");
 
   return exitflag;
@@ -141,7 +142,7 @@ static OSQPInt write_OSQPMatrix(FILE*             f,
                                 const char*       name) {
 
   OSQPInt exitflag = OSQP_NO_ERROR;
-  char csc_name[MAX_VAR_LENGTH];
+  char csc_name[MAX_VAR_LENGTH+4];
 
   if (!mat) return OSQP_DATA_NOT_INITIALIZED;
 
@@ -171,31 +172,31 @@ static OSQPInt write_settings(FILE*               f,
   fprintf(f, "  0,\n"); // device
   fprintf(f, "  OSQP_DIRECT_SOLVER,\n");
   fprintf(f, "  0,\n"); // verbose
-  fprintf(f, "  %d,\n", settings->warm_starting);
-  fprintf(f, "  %d,\n", settings->scaling);
+  fprintf(f, "  %" OSQP_INT_FMT ",\n", settings->warm_starting);
+  fprintf(f, "  %" OSQP_INT_FMT ",\n", settings->scaling);
   fprintf(f, "  0,\n"); // polishing
   fprintf(f, "  (OSQPFloat)%.20f,\n", settings->rho);
-  fprintf(f, "  %d,\n", settings->rho_is_vec);
+  fprintf(f, "  %" OSQP_INT_FMT ",\n", settings->rho_is_vec);
   fprintf(f, "  (OSQPFloat)%.20f,\n", settings->sigma);
   fprintf(f, "  (OSQPFloat)%.20f,\n", settings->alpha);
-  fprintf(f, "  %d,\n", settings->cg_max_iter);
-  fprintf(f, "  %d,\n", settings->cg_tol_reduction);
+  fprintf(f, "  %" OSQP_INT_FMT ",\n", settings->cg_max_iter);
+  fprintf(f, "  %" OSQP_INT_FMT ",\n", settings->cg_tol_reduction);
   fprintf(f, "  (OSQPFloat)%.20f,\n", settings->cg_tol_fraction);
-  fprintf(f, "  %d,\n", settings->cg_precond);
-  fprintf(f, "  %d,\n", settings->adaptive_rho);
-  fprintf(f, "  %d,\n", settings->adaptive_rho_interval);
+  fprintf(f, "  %u,\n", settings->cg_precond);
+  fprintf(f, "  %" OSQP_INT_FMT ",\n", settings->adaptive_rho);
+  fprintf(f, "  %" OSQP_INT_FMT ",\n", settings->adaptive_rho_interval);
   fprintf(f, "  (OSQPFloat)%.20f,\n", settings->adaptive_rho_fraction);
   fprintf(f, "  (OSQPFloat)%.20f,\n", settings->adaptive_rho_tolerance);
-  fprintf(f, "  %d,\n", settings->max_iter);
+  fprintf(f, "  %" OSQP_INT_FMT ",\n", settings->max_iter);
   fprintf(f, "  (OSQPFloat)%.20f,\n", settings->eps_abs);
   fprintf(f, "  (OSQPFloat)%.20f,\n", settings->eps_rel);
   fprintf(f, "  (OSQPFloat)%.20f,\n", settings->eps_prim_inf);
   fprintf(f, "  (OSQPFloat)%.20f,\n", settings->eps_dual_inf);
-  fprintf(f, "  %d,\n", settings->scaled_termination);
-  fprintf(f, "  %d,\n", settings->check_termination);
+  fprintf(f, "  %" OSQP_INT_FMT ",\n", settings->scaled_termination);
+  fprintf(f, "  %" OSQP_INT_FMT ",\n", settings->check_termination);
   fprintf(f, "  (OSQPFloat)%.20f,\n", settings->time_limit);
   fprintf(f, "  (OSQPFloat)%.20f,\n", settings->delta);
-  fprintf(f, "  %d,\n", settings->polish_refine_iter);
+  fprintf(f, "  %" OSQP_INT_FMT ",\n", settings->polish_refine_iter);
   fprintf(f, "};\n\n");
 
   return OSQP_NO_ERROR;
@@ -246,12 +247,12 @@ static OSQPInt write_solution(FILE*       f,
   /* No need to actually test anything here */
 
   fprintf(f, "/* Define the solution structure */\n");
-  fprintf(f, "OSQPFloat %ssol_x[%d];\n", prefix, n);
-  if (m > 0) fprintf(f, "OSQPFloat %ssol_y[%d];\n", prefix, m);
+  fprintf(f, "OSQPFloat %ssol_x[%" OSQP_INT_FMT "];\n", prefix, n);
+  if (m > 0) fprintf(f, "OSQPFloat %ssol_y[%" OSQP_INT_FMT "];\n", prefix, m);
   else       fprintf(f, "#define %ssol_y (OSQP_NULL)\n", prefix);
-  if (m > 0) fprintf(f, "OSQPFloat %ssol_prim_inf_cert[%d];\n", prefix, m);
+  if (m > 0) fprintf(f, "OSQPFloat %ssol_prim_inf_cert[%" OSQP_INT_FMT "];\n", prefix, m);
   else       fprintf(f, "#define %ssol_prim_inf_cert (OSQP_NULL)\n", prefix);
-  fprintf(f, "OSQPFloat %ssol_dual_inf_cert[%d];\n", prefix, n);
+  fprintf(f, "OSQPFloat %ssol_dual_inf_cert[%" OSQP_INT_FMT "];\n", prefix, n);
   fprintf(f, "OSQPSolution %ssol = {\n", prefix);
   fprintf(f, "  %ssol_x,\n", prefix);
   fprintf(f, "  %ssol_y,\n", prefix);
@@ -323,8 +324,8 @@ static OSQPInt write_data(FILE*           f,
   sprintf(name, "%sdata_u", prefix);
   GENERATE_ERROR(write_OSQPVectorf(f, data->u, name))
   fprintf(f, "OSQPData %sdata = {\n", prefix);
-  fprintf(f, "  %d,\n", data->n);
-  fprintf(f, "  %d,\n", data->m);
+  fprintf(f, "  %" OSQP_INT_FMT ",\n", data->n);
+  fprintf(f, "  %" OSQP_INT_FMT ",\n", data->m);
   fprintf(f, "  &%sdata_P,\n", prefix);
   fprintf(f, "  &%sdata_A,\n", prefix);
   fprintf(f, "  &%sdata_q,\n", prefix);
@@ -361,8 +362,8 @@ static OSQPInt write_linsys(FILE*               f,
   GENERATE_ERROR(write_vecf(f, linsys->Dinv, n+m, name))
   sprintf(name, "%slinsys_P", prefix);
   GENERATE_ERROR(write_veci(f, linsys->P, n+m, name))
-  fprintf(f, "OSQPFloat %slinsys_bp[%d];\n",  prefix, n+m);
-  fprintf(f, "OSQPFloat %slinsys_sol[%d];\n", prefix, n+m);
+  fprintf(f, "OSQPFloat %slinsys_bp[%" OSQP_INT_FMT "];\n",  prefix, n+m);
+  fprintf(f, "OSQPFloat %slinsys_sol[%" OSQP_INT_FMT "];\n", prefix, n+m);
 
   if (linsys->rho_inv_vec) {
     sprintf(name, "%slinsys_rho_inv_vec", prefix);
@@ -384,9 +385,9 @@ static OSQPInt write_linsys(FILE*               f,
     GENERATE_ERROR(write_veci(f, linsys->etree, n+m, name))
     sprintf(name, "%slinsys_Lnz", prefix);
     GENERATE_ERROR(write_veci(f, linsys->Lnz, n+m, name))
-    fprintf(f, "QDLDL_int   %slinsys_iwork[%d];\n", prefix, 3*(n+m));
-    fprintf(f, "QDLDL_bool  %slinsys_bwork[%d];\n", prefix, n+m);
-    fprintf(f, "QDLDL_float %slinsys_fwork[%d];\n", prefix, n+m);
+    fprintf(f, "QDLDL_int   %slinsys_iwork[%" OSQP_INT_FMT "];\n", prefix, 3*(n+m));
+    fprintf(f, "QDLDL_bool  %slinsys_bwork[%" OSQP_INT_FMT "];\n", prefix, n+m);
+    fprintf(f, "QDLDL_float %slinsys_fwork[%" OSQP_INT_FMT "];\n", prefix, n+m);
   }
 
   fprintf(f, "qdldl_solver %slinsys = {\n", prefix);
@@ -399,7 +400,7 @@ static OSQPInt write_linsys(FILE*               f,
     fprintf(f, "  &update_linsys_solver_matrices_qdldl,\n");
     fprintf(f, "  &update_linsys_solver_rho_vec_qdldl,\n");
   }
-  fprintf(f, "  %d,\n", linsys->nthreads);
+  fprintf(f, "  %" OSQP_INT_FMT ",\n", linsys->nthreads);
   fprintf(f, "  &%slinsys_L,\n", prefix);
   fprintf(f, "  %slinsys_Dinv,\n", prefix);
   fprintf(f, "  %slinsys_P,\n", prefix);
@@ -415,8 +416,8 @@ static OSQPInt write_linsys(FILE*               f,
 
   fprintf(f, "  (OSQPFloat)%.20f,\n", linsys->sigma);
   fprintf(f, "  (OSQPFloat)%.20f,\n", linsys->rho_inv);
-  fprintf(f, "  %d,\n", n);
-  fprintf(f, "  %d,\n", m);
+  fprintf(f, "  %" OSQP_INT_FMT ",\n", n);
+  fprintf(f, "  %" OSQP_INT_FMT ",\n", m);
   if (embedded > 1) {
     fprintf(f, "  &%slinsys_KKT,\n", prefix);
     fprintf(f, "  %slinsys_PtoKKT,\n", prefix);
@@ -475,54 +476,54 @@ static OSQPInt write_workspace(FILE*             f,
   sprintf(name, "%swork_z", prefix);
   GENERATE_ERROR(write_OSQPVectorf(f, work->z, name))
 
-  fprintf(f, "OSQPFloat   %swork_xz_tilde_val[%d];\n", prefix, n+m);
-  fprintf(f, "OSQPVectorf %swork_xz_tilde = {\n  %swork_xz_tilde_val,\n  %d\n};\n", prefix, prefix, n+m);
-  fprintf(f, "OSQPVectorf %swork_xtilde_view = {\n  %swork_xz_tilde_val,\n  %d\n};\n", prefix, prefix, n);
-  fprintf(f, "OSQPVectorf %swork_ztilde_view = {\n  %swork_xz_tilde_val+%d,\n  %d\n};\n", prefix, prefix, n, m);
-  fprintf(f, "OSQPFloat   %swork_x_prev_val[%d];\n", prefix, n);
-  fprintf(f, "OSQPVectorf %swork_x_prev = {\n  %swork_x_prev_val,\n  %d\n};\n", prefix, prefix, n);
+  fprintf(f, "OSQPFloat   %swork_xz_tilde_val[%" OSQP_INT_FMT "];\n", prefix, n+m);
+  fprintf(f, "OSQPVectorf %swork_xz_tilde = {\n  %swork_xz_tilde_val,\n  %" OSQP_INT_FMT "\n};\n", prefix, prefix, n+m);
+  fprintf(f, "OSQPVectorf %swork_xtilde_view = {\n  %swork_xz_tilde_val,\n  %" OSQP_INT_FMT "\n};\n", prefix, prefix, n);
+  fprintf(f, "OSQPVectorf %swork_ztilde_view = {\n  %swork_xz_tilde_val+%" OSQP_INT_FMT ",\n  %" OSQP_INT_FMT "\n};\n", prefix, prefix, n, m);
+  fprintf(f, "OSQPFloat   %swork_x_prev_val[%" OSQP_INT_FMT "];\n", prefix, n);
+  fprintf(f, "OSQPVectorf %swork_x_prev = {\n  %swork_x_prev_val,\n  %" OSQP_INT_FMT "\n};\n", prefix, prefix, n);
   if (m > 0) {
-    fprintf(f, "OSQPFloat   %swork_z_prev_val[%d];\n", prefix, m);
-    fprintf(f, "OSQPVectorf %swork_z_prev = {\n  %swork_z_prev_val,\n  %d\n};\n", prefix, prefix, m);
-    fprintf(f, "OSQPFloat   %swork_Ax_val[%d];\n", prefix, m);
-    fprintf(f, "OSQPVectorf %swork_Ax = {\n  %swork_Ax_val,\n  %d\n};\n", prefix, prefix, m);
+    fprintf(f, "OSQPFloat   %swork_z_prev_val[%" OSQP_INT_FMT "];\n", prefix, m);
+    fprintf(f, "OSQPVectorf %swork_z_prev = {\n  %swork_z_prev_val,\n  %" OSQP_INT_FMT "\n};\n", prefix, prefix, m);
+    fprintf(f, "OSQPFloat   %swork_Ax_val[%" OSQP_INT_FMT "];\n", prefix, m);
+    fprintf(f, "OSQPVectorf %swork_Ax = {\n  %swork_Ax_val,\n  %" OSQP_INT_FMT "\n};\n", prefix, prefix, m);
   }
   else {
     fprintf(f, "OSQPVectorf %swork_z_prev = { OSQP_NULL, 0 };\n", prefix);
     fprintf(f, "OSQPVectorf %swork_Ax = { OSQP_NULL, 0 };\n", prefix);
   }
-  fprintf(f, "OSQPFloat   %swork_Px_val[%d];\n", prefix, n);
-  fprintf(f, "OSQPVectorf %swork_Px = {\n  %swork_Px_val,\n  %d\n};\n", prefix, prefix, n);
-  fprintf(f, "OSQPFloat   %swork_Aty_val[%d];\n", prefix, n);
-  fprintf(f, "OSQPVectorf %swork_Aty = {\n  %swork_Aty_val,\n  %d\n};\n", prefix, prefix, n);
+  fprintf(f, "OSQPFloat   %swork_Px_val[%" OSQP_INT_FMT "];\n", prefix, n);
+  fprintf(f, "OSQPVectorf %swork_Px = {\n  %swork_Px_val,\n  %" OSQP_INT_FMT "\n};\n", prefix, prefix, n);
+  fprintf(f, "OSQPFloat   %swork_Aty_val[%" OSQP_INT_FMT "];\n", prefix, n);
+  fprintf(f, "OSQPVectorf %swork_Aty = {\n  %swork_Aty_val,\n  %" OSQP_INT_FMT "\n};\n", prefix, prefix, n);
   if (m > 0) {
-    fprintf(f, "OSQPFloat   %swork_delta_y_val[%d];\n", prefix, m);
-    fprintf(f, "OSQPVectorf %swork_delta_y = {\n  %swork_delta_y_val,\n  %d\n};\n", prefix, prefix, m);
+    fprintf(f, "OSQPFloat   %swork_delta_y_val[%" OSQP_INT_FMT "];\n", prefix, m);
+    fprintf(f, "OSQPVectorf %swork_delta_y = {\n  %swork_delta_y_val,\n  %" OSQP_INT_FMT "\n};\n", prefix, prefix, m);
   }
   else {
     fprintf(f, "OSQPVectorf %swork_delta_y = { OSQP_NULL, 0 };\n", prefix);
   }
-  fprintf(f, "OSQPFloat   %swork_Atdelta_y_val[%d];\n", prefix, n);
-  fprintf(f, "OSQPVectorf %swork_Atdelta_y = {\n  %swork_Atdelta_y_val,\n  %d\n};\n", prefix, prefix, n);
-  fprintf(f, "OSQPFloat   %swork_delta_x_val[%d];\n", prefix, n);
-  fprintf(f, "OSQPVectorf %swork_delta_x = {\n  %swork_delta_x_val,\n  %d\n};\n", prefix, prefix, n);
-  fprintf(f, "OSQPFloat   %swork_Pdelta_x_val[%d];\n", prefix, n);
-  fprintf(f, "OSQPVectorf %swork_Pdelta_x = {\n  %swork_Pdelta_x_val,\n  %d\n};\n", prefix, prefix, n);
+  fprintf(f, "OSQPFloat   %swork_Atdelta_y_val[%" OSQP_INT_FMT "];\n", prefix, n);
+  fprintf(f, "OSQPVectorf %swork_Atdelta_y = {\n  %swork_Atdelta_y_val,\n  %" OSQP_INT_FMT "\n};\n", prefix, prefix, n);
+  fprintf(f, "OSQPFloat   %swork_delta_x_val[%" OSQP_INT_FMT "];\n", prefix, n);
+  fprintf(f, "OSQPVectorf %swork_delta_x = {\n  %swork_delta_x_val,\n  %" OSQP_INT_FMT "\n};\n", prefix, prefix, n);
+  fprintf(f, "OSQPFloat   %swork_Pdelta_x_val[%" OSQP_INT_FMT "];\n", prefix, n);
+  fprintf(f, "OSQPVectorf %swork_Pdelta_x = {\n  %swork_Pdelta_x_val,\n  %" OSQP_INT_FMT "\n};\n", prefix, prefix, n);
   if (m > 0) {
-    fprintf(f, "OSQPFloat   %swork_Adelta_x_val[%d];\n", prefix, m);
-    fprintf(f, "OSQPVectorf %swork_Adelta_x = {\n  %swork_Adelta_x_val,\n  %d\n};\n", prefix, prefix, m);
+    fprintf(f, "OSQPFloat   %swork_Adelta_x_val[%" OSQP_INT_FMT "];\n", prefix, m);
+    fprintf(f, "OSQPVectorf %swork_Adelta_x = {\n  %swork_Adelta_x_val,\n  %" OSQP_INT_FMT "\n};\n", prefix, prefix, m);
   }
   else {
     fprintf(f, "OSQPVectorf %swork_Adelta_x = { OSQP_NULL, 0 };\n", prefix);
   }
   if (embedded > 1) {
-    fprintf(f, "OSQPFloat   %swork_D_temp_val[%d];\n", prefix, n);
-    fprintf(f, "OSQPVectorf %swork_D_temp = {\n  %swork_D_temp_val,\n  %d\n};\n", prefix, prefix, n);
-    fprintf(f, "OSQPFloat   %swork_D_temp_A_val[%d];\n", prefix, n);
-    fprintf(f, "OSQPVectorf %swork_D_temp_A = {\n  %swork_D_temp_A_val,\n  %d\n};\n", prefix, prefix, n);
+    fprintf(f, "OSQPFloat   %swork_D_temp_val[%" OSQP_INT_FMT "];\n", prefix, n);
+    fprintf(f, "OSQPVectorf %swork_D_temp = {\n  %swork_D_temp_val,\n  %" OSQP_INT_FMT "\n};\n", prefix, prefix, n);
+    fprintf(f, "OSQPFloat   %swork_D_temp_A_val[%" OSQP_INT_FMT "];\n", prefix, n);
+    fprintf(f, "OSQPVectorf %swork_D_temp_A = {\n  %swork_D_temp_A_val,\n  %" OSQP_INT_FMT "\n};\n", prefix, prefix, n);
     if (m > 0) {
-      fprintf(f, "OSQPFloat   %swork_E_temp_val[%d];\n", prefix, m);
-      fprintf(f, "OSQPVectorf %swork_E_temp = {\n  %swork_E_temp_val,\n  %d\n};\n", prefix, prefix, m);
+      fprintf(f, "OSQPFloat   %swork_E_temp_val[%" OSQP_INT_FMT "];\n", prefix, m);
+      fprintf(f, "OSQPVectorf %swork_E_temp = {\n  %swork_E_temp_val,\n  %" OSQP_INT_FMT "\n};\n", prefix, prefix, m);
     }
     else {
       fprintf(f, "OSQPVectorf %swork_E_temp = { OSQP_NULL, 0 };\n", prefix);
@@ -636,7 +637,7 @@ OSQPInt codegen_inc(OSQPSolver* solver,
                     const char* output_dir,
                     const char* file_prefix) {
 
-  char fname[FILE_LENGTH], hfname[PATH_LENGTH], incGuard[FILE_LENGTH];
+  char fname[FILE_LENGTH], hfname[PATH_LENGTH], incGuard[FILE_LENGTH+2];
   FILE *incFile;
   time_t now;
   OSQPInt i = 0;
@@ -696,7 +697,7 @@ OSQPInt codegen_src(OSQPSolver* solver,
                     OSQPInt     embedded) {
 
   OSQPInt exitflag = OSQP_NO_ERROR;
-  char fname[PATH_LENGTH], cfname[PATH_LENGTH];
+  char fname[PATH_LENGTH], cfname[PATH_LENGTH+2];
   FILE *srcFile;
   time_t now;
 
@@ -760,7 +761,7 @@ OSQPInt codegen_defines(const char*         output_dir,
   fprintf(incFile, "#define OSQP_ALGEBRA_BUILTIN\n");
 
   /* Write out the embedded mode in use */
-  fprintf(incFile, "#define OSQP_EMBEDDED_MODE %d\n\n", defines->embedded_mode);
+  fprintf(incFile, "#define OSQP_EMBEDDED_MODE %" OSQP_INT_FMT "\n\n", defines->embedded_mode);
 
   /* Write out if derivatives are enabled */
   if (defines->printing_enable == 1) {

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -411,7 +411,7 @@ static OSQPInt write_linsys(FILE*               f,
     fprintf(f, "  %slinsys_rho_inv_vec,\n", prefix);
   }
   else {
-    fprintf(f, "  OSQP_NULL,\n", prefix);
+    fprintf(f, "  OSQP_NULL,\n");
   }
 
   fprintf(f, "  (OSQPFloat)%.20f,\n", linsys->sigma);
@@ -546,10 +546,10 @@ static OSQPInt write_workspace(FILE*             f,
       fprintf(f, "  &%swork_constr_type,\n", prefix);
     }
   } else {
-    fprintf(f, "  OSQP_NULL,\n", prefix);    /* work_rho_vec */
-    fprintf(f, "  OSQP_NULL,\n", prefix);    /* work_rho_inv_vec */
+    fprintf(f, "  OSQP_NULL,\n");    /* work_rho_vec */
+    fprintf(f, "  OSQP_NULL,\n");    /* work_rho_inv_vec */
     if (embedded > 1) {
-      fprintf(f, "  OSQP_NULL,\n", prefix);  /* work_constr_type */
+      fprintf(f, "  OSQP_NULL,\n");  /* work_constr_type */
     }
   }
 

--- a/src/error.c
+++ b/src/error.c
@@ -39,7 +39,7 @@ OSQPInt _osqp_error_line(enum osqp_error_type error_code,
 
   /* Don't print anything if there was no error */
   if (error_code != OSQP_NO_ERROR)
-    c_print("ERROR in %s (%s:%d): %s\n", function_name, filename, line_number, OSQP_ERROR_MESSAGE[error_code-1]);
+    c_print("ERROR in %s (%s:%" OSQP_INT_FMT "): %s\n", function_name, filename, line_number, OSQP_ERROR_MESSAGE[error_code-1]);
 
   return (OSQPInt)error_code;
 }

--- a/src/osqp_api.c
+++ b/src/osqp_api.c
@@ -1265,8 +1265,8 @@ OSQPInt osqp_codegen(OSQPSolver*         solver,
     return osqp_error(OSQP_CODEGEN_DEFINES_ERROR);
   }
 
-  exitflag = codegen_inc(solver, output_dir, file_prefix);
-  if (!exitflag) exitflag = codegen_src(solver, output_dir, file_prefix, defines->embedded_mode);
+  exitflag = codegen_inc(output_dir, file_prefix);
+  if (!exitflag) exitflag = codegen_src(output_dir, file_prefix, solver, defines->embedded_mode);
   if (!exitflag) exitflag = codegen_example(output_dir, file_prefix);
   if (!exitflag) exitflag = codegen_defines(output_dir, defines);
 #else

--- a/src/osqp_api.c
+++ b/src/osqp_api.c
@@ -1270,6 +1270,10 @@ OSQPInt osqp_codegen(OSQPSolver*         solver,
   if (!exitflag) exitflag = codegen_example(output_dir, file_prefix);
   if (!exitflag) exitflag = codegen_defines(output_dir, defines);
 #else
+  OSQP_UnusedVar(solver);
+  OSQP_UnusedVar(output_dir);
+  OSQP_UnusedVar(file_prefix);
+  OSQP_UnusedVar(defines);
   exitflag = OSQP_FUNC_NOT_IMPLEMENTED;
 #endif /* ifdef OSQP_CODEGEN */
 
@@ -1310,6 +1314,10 @@ OSQPInt osqp_adjoint_derivative_compute(OSQPSolver* solver,
 #ifdef OSQP_ENABLE_DERIVATIVES
   status = adjoint_derivative_compute(solver, dx, dy_l, dy_u);
 #else
+  OSQP_UnusedVar(solver);
+  OSQP_UnusedVar(dx);
+  OSQP_UnusedVar(dy_l);
+  OSQP_UnusedVar(dy_u);
   status = OSQP_FUNC_NOT_IMPLEMENTED;
 #endif
 
@@ -1324,6 +1332,9 @@ OSQPInt osqp_adjoint_derivative_get_mat(OSQPSolver*    solver,
 #ifdef OSQP_ENABLE_DERIVATIVES
   status = adjoint_derivative_get_mat(solver, dP, dA);
 #else
+  OSQP_UnusedVar(solver);
+  OSQP_UnusedVar(dP);
+  OSQP_UnusedVar(dA);
   status = OSQP_FUNC_NOT_IMPLEMENTED;
 #endif
 
@@ -1339,6 +1350,10 @@ OSQPInt osqp_adjoint_derivative_get_vec(OSQPSolver* solver,
 #ifdef OSQP_ENABLE_DERIVATIVES
   status = adjoint_derivative_get_vec(solver, dq, dl, du);
 #else
+  OSQP_UnusedVar(solver);
+  OSQP_UnusedVar(dq);
+  OSQP_UnusedVar(dl);
+  OSQP_UnusedVar(du);
   status = OSQP_FUNC_NOT_IMPLEMENTED;
 #endif
 

--- a/src/scaling.c
+++ b/src/scaling.c
@@ -59,7 +59,7 @@ OSQPInt scale_data(OSQPSolver* solver) {
   //
 
   OSQPInt   i;          // Iterations index
-  OSQPInt   n, m;       // Number of constraints and variables
+  OSQPInt   n;          // Number of variables
   OSQPFloat c_temp;     // Objective function scaling
   OSQPFloat inf_norm_q; // Infinity norm of q
 
@@ -67,7 +67,6 @@ OSQPInt scale_data(OSQPSolver* solver) {
   OSQPWorkspace* work     = solver->work;
 
   n = work->data->n;
-  m = work->data->m;
 
   // Initialize scaling to 1
   work->scaling->c = 1.0;


### PR DESCRIPTION
Fix various warnings found when building with GCC `-Wall` flag.

Main changes are:
* Removing unused variables
* Modifying the format string used to write the integer based on the current `OSQPInt` type to make sure values are always representable