### PR TITLE
Improve error handling in polishing routines

### DIFF
--- a/include/private/polish.h
+++ b/include/private/polish.h
@@ -14,8 +14,7 @@ extern "C" {
  * Solution polish: Solve equality constrained QP with assumed active
  *constraints
  * @param  solver OSQP solver
- * @return        Exitflag:  0: Factorization successful
- *                           1: Factorization unsuccessful
+ * @return        Exitflag
  */
 OSQPInt polish(OSQPSolver* solver);
 

--- a/src/osqp_api.c
+++ b/src/osqp_api.c
@@ -721,8 +721,14 @@ OSQPInt osqp_solve(OSQPSolver *solver) {
 
 #ifndef OSQP_EMBEDDED_MODE
   // Polish the obtained solution
-  if (solver->settings->polishing && (solver->info->status_val == OSQP_SOLVED))
-    polish(solver);
+  if (solver->settings->polishing && (solver->info->status_val == OSQP_SOLVED)) {
+    exitflag = polish(solver);
+
+    if (exitflag > 0) {
+      c_eprint("Failed polishing");
+      goto exit;
+    }
+  }
 #endif /* ifndef OSQP_EMBEDDED_MODE */
 
 #ifdef OSQP_ENABLE_PROFILING


### PR DESCRIPTION
The polishing routines were allocating memory for vector and matrices and then never checking that the allocation succeeded. This PR fixes the polishing code to always check for successful memory allocation, and report the errors to the main polish routine if any occur.

(Memory use errors were flagged by running PVS-Studio on the code).