### PR TITLE
Fix memory leaks and error handling in QDLDL adjoint linear solver

### DIFF
--- a/algebra/_common/csc_utils.c
+++ b/algebra/_common/csc_utils.c
@@ -167,7 +167,11 @@ OSQPCscMatrix* csc_submatrix_byrows(const OSQPCscMatrix* A,
 
   // Form R = A(rows,:), where nrows = sum(rows != 0)
   R = csc_spalloc(Rm, An, nzR, 1, 0);
-  if (!R) return OSQP_NULL;
+  if (!R) {
+    // Free work index and return on error
+    c_free(rridx);
+    return OSQP_NULL;
+  }
 
   // no active constraints
   if (Rm == 0) {

--- a/algebra/_common/lin_sys/qdldl/qdldl_interface.c
+++ b/algebra/_common/lin_sys/qdldl/qdldl_interface.c
@@ -2,6 +2,7 @@
 #include "algebra_impl.h"
 #include "printing.h"
 
+#include "error.h"
 #include "qdldl.h"
 #include "qdldl_interface.h"
 #include "util.h"
@@ -684,6 +685,8 @@ OSQPInt adjoint_derivative_qdldl(qdldl_solver**     s,
     /* We don't currently reuse the solver for the adjoint computations */
     OSQP_UnusedVar(s);
 
+    OSQPInt retval = 0;
+
     OSQPInt n = OSQPMatrix_get_m(P_full);
     OSQPInt n_ineq = OSQPMatrix_get_m(G);
     OSQPInt n_eq = OSQPMatrix_get_m(A_eq);
@@ -704,10 +707,16 @@ OSQPInt adjoint_derivative_qdldl(qdldl_solver**     s,
 
     OSQPInt dim = 2 * (n + n_ineq + n_eq);
     OSQPCscMatrix* adj = csc_spalloc(dim, dim, nnzKKT, 1, 0);
-    if (!adj) return OSQP_NULL;
+    if (!adj) return osqp_error(OSQP_MEM_ALLOC_ERROR);
+
     _adj_assemble_csc(adj, P_full, G, A_eq, GDiagLambda, slacks);
 
     OSQPMatrix *adj_matrix = OSQPMatrix_new_from_csc(adj, 1);
+
+    if (!adj_matrix) {
+        retval = OSQP_MEM_ALLOC_ERROR;
+        goto adj_alloc_fail;
+    }
 
     _adj_perturb(adj, 1e-6);
 
@@ -719,43 +728,36 @@ OSQPInt adjoint_derivative_qdldl(qdldl_solver**     s,
 
     //data for L and D factors
     QDLDL_int Ln = An;
-    QDLDL_int *Lp;
-    QDLDL_int *Li;
-    QDLDL_float *Lx;
-    QDLDL_float *D;
-    QDLDL_float *Dinv;
+
+    QDLDL_float *Lx = OSQP_NULL;
+    QDLDL_int   *Li = OSQP_NULL;
+
+    QDLDL_int   *Lp   = (QDLDL_int*)malloc(sizeof(QDLDL_int)*(An+1));
+    QDLDL_float *D    = (QDLDL_float*)malloc(sizeof(QDLDL_float)*An);
+    QDLDL_float *Dinv = (QDLDL_float*)malloc(sizeof(QDLDL_float)*An);
 
     //permutation
-    QDLDL_int   *P;
-    QDLDL_int   *Pinv;
+    QDLDL_int   *P    = (QDLDL_int*)malloc(sizeof(QDLDL_int)*(An));
+    QDLDL_int   *Pinv = OSQP_NULL;
 
     //data for elim tree calculation
-    QDLDL_int *etree;
-    QDLDL_int *Lnz;
+    QDLDL_int *etree = (QDLDL_int*)malloc(sizeof(QDLDL_int)*An);
+    QDLDL_int *Lnz   = (QDLDL_int*)malloc(sizeof(QDLDL_int)*An);
     QDLDL_int  sumLnz;
 
     //working data for factorisation
-    QDLDL_int   *iwork;
-    QDLDL_bool  *bwork;
-    QDLDL_float *fwork;
+    QDLDL_int   *iwork = (QDLDL_int*)malloc(sizeof(QDLDL_int)*(3*An));
+    QDLDL_bool  *bwork = (QDLDL_bool*)malloc(sizeof(QDLDL_bool)*An);
+    QDLDL_float *fwork = (QDLDL_float*)malloc(sizeof(QDLDL_float)*An);
 
     //Data for results of A\b
-    QDLDL_float *x;
-    QDLDL_float *x_work;
+    QDLDL_float *x = OSQP_NULL;
+    QDLDL_float *x_work = OSQP_NULL;
 
-    etree = (QDLDL_int*)malloc(sizeof(QDLDL_int)*An);
-    Lnz   = (QDLDL_int*)malloc(sizeof(QDLDL_int)*An);
-
-    Lp    = (QDLDL_int*)malloc(sizeof(QDLDL_int)*(An+1));
-    D     = (QDLDL_float*)malloc(sizeof(QDLDL_float)*An);
-    Dinv  = (QDLDL_float*)malloc(sizeof(QDLDL_float)*An);
-
-    iwork = (QDLDL_int*)malloc(sizeof(QDLDL_int)*(3*An));
-    bwork = (QDLDL_bool*)malloc(sizeof(QDLDL_bool)*An);
-    fwork = (QDLDL_float*)malloc(sizeof(QDLDL_float)*An);
-
-    P = (QDLDL_int*)malloc(sizeof(QDLDL_int)*(An));
-    Pinv = (QDLDL_int*)malloc(sizeof(QDLDL_int)*(An));
+    if (!Lp || !D || !Dinv || !P || !etree || !Lnz || !iwork || !bwork || !fwork) {
+        retval = OSQP_MEM_ALLOC_ERROR;
+        goto mat_comp_alloc_error;
+    }
 
     OSQPInt amd_status;
 #ifdef OSQP_USE_LONG
@@ -764,24 +766,43 @@ OSQPInt adjoint_derivative_qdldl(qdldl_solver**     s,
     amd_status = amd_order(An, adj->p, adj->i, P, (OSQPFloat *)OSQP_NULL, (OSQPFloat *)OSQP_NULL);
 #endif
     if (amd_status < 0) {
-        return amd_status;
+        retval = amd_status;
+        goto mat_comp_alloc_error;
     }
 
     // Inverse of the permutation vector
     Pinv = csc_pinv(P, An);
+    if (!Pinv) {
+        retval = OSQP_MEM_ALLOC_ERROR;
+        goto inv_perm_fail;
+    }
 
-    OSQPCscMatrix* adj_permuted;
+    OSQPCscMatrix* adj_permuted = OSQP_NULL;
     adj_permuted = csc_symperm(adj, Pinv, OSQP_NULL, 1);
+    if (!adj_permuted) {
+        retval = OSQP_MEM_ALLOC_ERROR;
+        goto sym_perm_fail;
+    }
 
     sumLnz = QDLDL_etree(An, adj_permuted->p, adj_permuted->i, iwork, Lnz, etree);
 
     Li    = (QDLDL_int*)malloc(sizeof(QDLDL_int)*sumLnz);
     Lx    = (QDLDL_float*)malloc(sizeof(QDLDL_float)*sumLnz);
 
+    if (!Li || !Lx) {
+        retval = OSQP_MEM_ALLOC_ERROR;
+        goto csc_alloc_fail;
+    }
+
     QDLDL_factor(An, adj_permuted->p, adj_permuted->i, adj_permuted->x, Lp, Li, Lx, D, Dinv, Lnz, etree, bwork, iwork, fwork);
 
     x = (QDLDL_float*)malloc(sizeof(QDLDL_float)*An);
     x_work = (QDLDL_float*)malloc(sizeof(QDLDL_float)*An);
+
+    if (!x || !x_work) {
+        retval = OSQP_MEM_ALLOC_ERROR;
+        goto x_alloc_fail;
+    }
 
     //when solving A\b, start with x = b
     for (i = 0 ; i < An ; i++) x_work[i] = rhs->values[P[i]];
@@ -790,6 +811,11 @@ OSQPInt adjoint_derivative_qdldl(qdldl_solver**     s,
 
     OSQPVectorf *sol = OSQPVectorf_new(x, An);
     OSQPVectorf *residual = OSQPVectorf_malloc(An);
+
+    if (!sol || !residual) {
+        retval = OSQP_MEM_ALLOC_ERROR;
+        goto vec_alloc_fail;
+    }
 
     OSQPInt k;
     for (k=0; k<200; k++) {
@@ -806,29 +832,41 @@ OSQPInt adjoint_derivative_qdldl(qdldl_solver**     s,
 
     OSQPVectorf_copy(rhs, sol);
 
-    c_free(Lp);
+/* Free data based on what failed */
+vec_alloc_fail:
+    OSQPVectorf_free(sol);
+    OSQPVectorf_free(residual);
+
+x_alloc_fail:
+    c_free(x);
+    c_free(x_work);
+
+csc_alloc_fail:
     c_free(Li);
     c_free(Lx);
+
+sym_perm_fail:
+    csc_spfree(adj_permuted);
+
+inv_perm_fail:
+    c_free(Pinv);
+
+mat_comp_alloc_error:
+    c_free(Lp);
     c_free(D);
     c_free(Dinv);
     c_free(P);
-    c_free(Pinv);
     c_free(etree);
     c_free(Lnz);
     c_free(iwork);
     c_free(bwork);
     c_free(fwork);
-    c_free(x);
-    c_free(x_work);
 
-    csc_spfree(adj_permuted);
+adj_alloc_fail:
     OSQPMatrix_free(adj_matrix);
     csc_spfree(adj);
 
-    OSQPVectorf_free(sol);
-    OSQPVectorf_free(residual);
-
-    return 0;
+    return retval;
 }
 
 #endif

--- a/algebra/mkl/lin_sys/indirect/mkl-cg_interface.c
+++ b/algebra/mkl/lin_sys/indirect/mkl-cg_interface.c
@@ -109,7 +109,7 @@ OSQPInt init_linsys_mklcg(mklcg_solver**     sp,
   //Otherwise, use rho_vec = ones.*(1/sigma)
   s->rho_vec = OSQPVectorf_malloc(m);
   if (!polish) {
-      s->rho_vec = OSQPVectorf_copy_new(rho_vec);
+      OSQPVectorf_copy(s->rho_vec, rho_vec);
   } else {
       OSQPVectorf_set_scalar(s->rho_vec, 1/settings->sigma);
   }


### PR DESCRIPTION
This fixes several potential memory leaks, and also cleans up the memory handling inside the QDLDL adjoint solver routine to ensure all allocations are checked and the allocations are unwound in reverse order if any errors occur.