### PR TITLE
Add list of community-developed implementations of our ADMM algorithm

### DIFF
--- a/docs/interfaces/index.rst
+++ b/docs/interfaces/index.rst
@@ -1,3 +1,5 @@
+.. _interfaces:
+
 Interfaces
 ============
 

--- a/docs/solver/index.rst
+++ b/docs/solver/index.rst
@@ -175,3 +175,21 @@ The chances to have a successful polishing increase if the tolerances :code:`eps
 However, low tolerances might require a very large number of iterations.
 
 
+Implementations
+---------------
+
+The OSQP library provides a :ref:`C language implementation<c_interface>` of the above ADMM algorithm, and also
+:ref:`interfaces to several high level languages<interfaces>` to enable those languages to solve QPs using OSQP.
+
+There are also several community-developed implementations of this ADMM algorithm.
+
++----------------+----------+------------------------------------------------------------------------------------------------------------------------------+
+| Implementation | Language | Link                                                                                                                         |
++================+==========+==============================================================================================================================+
+| jaxopt.OSQP    | JAX      | `jaxopt.github.io/stable/quadratic_programming.html#osqp <https://jaxopt.github.io/stable/quadratic_programming.html#osqp>`_ |
++----------------+----------+------------------------------------------------------------------------------------------------------------------------------+
+| jOSQP          | Java     | `github.com/quantego/josqp <https://github.com/quantego/josqp>`_                                                             |
++----------------+----------+------------------------------------------------------------------------------------------------------------------------------+
+
+Note that these implementations may not have the same API or features as the OSQP library, and any questions or support requests
+should be directed to the authors of the implementations.


### PR DESCRIPTION
There are now a few community-developed implementations of the ADMM algorithm used by OSQP, so lets add a small table on the algorithm description page listing them and providing links to them.

What is written:
![image](https://github.com/osqp/osqp/assets/2262453/611c059e-973e-46c0-9f01-6e9dbc9e6f58)


cc @loehndorf, this adds the jOSQP implementation into our documentation website.