### PR TITLE
Ensure shared library uses the suffix on all platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -467,7 +467,7 @@ if(OSQP_BUILD_SHARED_LIB)
 
   # Modify the soname of the library to include the algebra if desired
   if(OSQP_LIB_SUFFIX)
-    set_target_properties(osqp PROPERTIES LIBRARY_OUTPUT_NAME "osqp_${OSQP_LIB_SUFFIX}")
+    set_target_properties(osqp PROPERTIES OUTPUT_NAME "osqp_${OSQP_LIB_SUFFIX}")
   endif()
 endif()
 


### PR DESCRIPTION
On Windows, the LIBRARY_OUTPUT_NAME is not actually used for the DLL, since it is stored into the runtime location, so just make the basename for all items have the proper suffix.

This was found when doing a build of OSQP for the Julia JLL library.