### PR TITLE
[CI] Add additional dependency to the Windows CI to get OpenMP import library

### DIFF
--- a/.github/workflows/mkl.yaml
+++ b/.github/workflows/mkl.yaml
@@ -97,6 +97,12 @@ jobs:
             conda info
             conda list
 
+        - name: Install additional dependencies (Windows)
+          if: runner.os == 'Windows'
+          run: |
+            # Needed to get import library for the Intel OpenMP library to be found
+            conda install -c intel dpcpp_impl_win-64
+
         - name: Build
           run: |
             cmake -G "${{ matrix.cmake_generator }}" \


### PR DESCRIPTION
The Windows Intel OpenMP import library is contained inside a different Conda package than the OpenMP runtime library, so we need to install the other package to get CMake to properly find and link against OpenMP.