### PR TITLE
Enable dependabot on GitHub actions workflows

### DIFF
--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -1,0 +1,7 @@
+# Check the GitHub actions for updates
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"


### PR DESCRIPTION
Lets try this to keep on top of the GitHub actions versions, since we are having some deprecation warnings for actions in pipelines right now.