### PR TITLE
Switch to using a dedicated conda test environment for ghactions

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -41,11 +41,14 @@ jobs:
             lfs: false
             submodules: recursive
 
-        - name: Set up conda
+        - name: Set up conda environment for testing
           uses: conda-incubator/setup-miniconda@v2
           with:
             auto-update-conda: true
             python-version: ${{ matrix.python-version }}
+            activate-environment: osqp-test
+            environment-file: tests/testenv.yml
+            auto-activate-base: false
 
         # -----------------
         # OS-specific setup
@@ -54,13 +57,6 @@ jobs:
           if: runner.os == 'Linux'
           run: |
             echo "LD_LIBRARY_PATH=$CONDA_PREFIX/lib" >> $GITHUB_ENV
-
-
-        - name: Install unit testing python dependencies
-          run: |
-            conda install numpy scipy
-            conda info
-            conda list
 
         - name: Install MKL
           run: |

--- a/.github/workflows/main-cuda.yml
+++ b/.github/workflows/main-cuda.yml
@@ -39,19 +39,18 @@ jobs:
             lfs: false
             submodules: recursive
 
+        - name: Set up conda environment for testing
+          uses: conda-incubator/setup-miniconda@v2
+          with:
+            auto-update-conda: true
+            python-version: ${{ matrix.python-version }}
+            activate-environment: osqp-test
+            environment-file: tests/testenv.yml
+            auto-activate-base: false
+
         - name: Setup (Linux)
           run: |
             echo "LD_LIBRARY_PATH=$CONDA_PREFIX/lib" >> $GITHUB_ENV
-
-        # Fetching mkl from the anaconda channel instead of defaults gives us the MKL runtime dynamic libraries
-        # as well (mkl_rt.<dll/so>), required during the runtime testing steps.
-        # MKL on Anaconda 2021.* seems to have inexplicably renamed mkl_rt.dll to mkl_rt.1.dll, so we insist on
-        # a version earlier than 2021
-        - name: Install python dependencies
-          run: |
-            conda install -c anaconda "mkl<2021" numpy scipy
-            conda info
-            conda list
 
         - name: Build
           run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,11 +54,14 @@ jobs:
             lfs: false
             submodules: recursive
 
-        - name: Set up conda
+        - name: Set up conda environment for testing
           uses: conda-incubator/setup-miniconda@v2
           with:
             auto-update-conda: true
             python-version: ${{ matrix.python-version }}
+            activate-environment: osqp-test
+            environment-file: tests/testenv.yml
+            auto-activate-base: false
 
         # -----------------
         # OS-specific setup
@@ -84,12 +87,6 @@ jobs:
           run: |
             echo "$CONDA_PREFIX/Library/bin" >> $GITHUB_PATH
         # -----------------
-
-        - name: Install unit testing python dependencies
-          run: |
-            conda install numpy scipy
-            conda info
-            conda list
 
         - name: Build
           run: |

--- a/.github/workflows/mkl.yaml
+++ b/.github/workflows/mkl.yaml
@@ -53,11 +53,14 @@ jobs:
             lfs: false
             submodules: recursive
 
-        - name: Set up conda
+        - name: Set up conda environment for testing
           uses: conda-incubator/setup-miniconda@v2
           with:
             auto-update-conda: true
             python-version: ${{ matrix.python-version }}
+            activate-environment: osqp-test
+            environment-file: tests/testenv.yml
+            auto-activate-base: false
 
         # -----------------
         # OS-specific setup
@@ -83,12 +86,6 @@ jobs:
           run: |
             echo "$CONDA_PREFIX/Library/bin" >> $GITHUB_PATH
         # -----------------
-
-        - name: Install unit testing python dependencies
-          run: |
-            conda install numpy scipy
-            conda info
-            conda list
 
         - name: Install MKL
           run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,11 +37,14 @@ jobs:
           lfs: false
           submodules: recursive
 
-      - name: Set up conda
+      - name: Set up conda environment for testing
         uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
+          activate-environment: osqp-test
+          environment-file: tests/testenv.yml
+          auto-activate-base: false
 
       - name: Setup Envvars
         run: |
@@ -78,7 +81,7 @@ jobs:
       # a version earlier than 2021
       - name: Install python dependencies
         run: |
-          conda install -c anaconda "mkl<2021" numpy scipy
+          conda install -c anaconda "mkl<2021"
           conda info
           conda list
 

--- a/tests/testenv.yml
+++ b/tests/testenv.yml
@@ -1,0 +1,10 @@
+name: osqp-test
+channels:
+  - conda-forge
+dependencies:
+  - numpy
+  # 0.17.0 was when sparse.random was added, which we need.
+  # Exclude scipy 1.12 because the random sparse array function started returning
+  # the transpose of the original, breaking the unit tests.
+  # ref: https://github.com/scipy/scipy/issues/20027
+  - scipy>=0.17.0,<1.12.0


### PR DESCRIPTION
This unifies all our testing dependencies into a single environment definition that we can then include in every workflow that needs it, making pinning versions and keeping the workflows updated easier.