### PR TITLE
Run more CodeQL checks to test code quality

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -60,7 +60,7 @@ jobs:
         # Prefix the list here with "+" to use these queries and those in the config file.
 
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+        queries: security-extended,security-and-quality
 
 
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).


### PR DESCRIPTION
The default CodeQL configuration is more conservative checks that only focus on security. There are also checks that can test for code quality, so lets enable those and see how it works.