### PR TITLE
Allow newer SciPy versions

### DIFF
--- a/tests/testenv.yml
+++ b/tests/testenv.yml
@@ -5,6 +5,6 @@ dependencies:
   - numpy
   # 0.17.0 was when sparse.random was added, which we need.
   # Exclude scipy 1.12 because the random sparse array function started returning
-  # the transpose of the original, breaking the unit tests.
+  # the transpose of the original, breaking the unit tests. This was fixed in 1.13.0.
   # ref: https://github.com/scipy/scipy/issues/20027
-  - scipy>=0.17.0,<1.12.0
+  - scipy>=0.17.0,!=1.12


### PR DESCRIPTION
SciPy 1.13.0 fixed the transposed sparse matrix generation in https://github.com/scipy/scipy/pull/20314, so we can just exclude the 1.12 version to let newer SciPy versions be used as well.