### PR TITLE
Fix the CI involving MKL

### DIFF
--- a/.github/workflows/algebra-mkl.yaml
+++ b/.github/workflows/algebra-mkl.yaml
@@ -94,7 +94,7 @@ jobs:
         - name: Install MKL
           run: |
             conda install -c conda-forge llvm-openmp
-            conda install -c intel mkl-devel
+            conda install -c https://software.repos.intel.com/python/conda/ mkl-devel
             conda info
             conda list
 
@@ -102,7 +102,7 @@ jobs:
           if: runner.os == 'Windows'
           run: |
             # Needed to get import library for the Intel OpenMP library to be found
-            conda install -c intel dpcpp_impl_win-64
+            conda install -c https://software.repos.intel.com/python/conda/ dpcpp_impl_win-64
 
         - name: Build
           run: |

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -61,6 +61,7 @@ jobs:
             echo "LD_LIBRARY_PATH=$CONDA_PREFIX/lib" >> $GITHUB_ENV
 
         - name: Install MKL
+          if: matrix.algebra == 'mkl'
           run: |
             conda install -c intel mkl-devel
             conda info

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -63,7 +63,7 @@ jobs:
         - name: Install MKL
           if: matrix.algebra == 'mkl'
           run: |
-            conda install -c intel mkl-devel
+            conda install -c https://software.repos.intel.com/python/conda/ mkl-devel
             conda info
             conda list
 


### PR DESCRIPTION
The Intel conda repos changed locations, so now we must install using the full Intel URL instead of a specific anaconda channel. Additionally, we only need MKL when doing MKL tests in coverage, it is extraneous for the other backends and doesn't need to be installed.