### PR TITLE
Fixed broken link in documentation

### DIFF
--- a/docs/interfaces/status_values.rst
+++ b/docs/interfaces/status_values.rst
@@ -8,7 +8,7 @@ Status values and errors
 Status values
 -------------
 
-These are the exit statuses, their respective constants and values returned by the solver as defined in `constants.h <https://github.com/osqp/osqp/blob/master/include/constants.h>`_.
+These are the exit statuses, their respective constants and values returned by the solver as defined in `osqp_api_constants.h <https://github.com/osqp/osqp/blob/master/include/public/osqp_api_constants.h>`_.
 The *inaccurate* statuses define when the optimality, primal infeasibility or dual infeasibility conditions are satisfied with tolerances 10 times larger than the ones set.
 
 +------------------------------+-----------------------------------+-------+


### PR DESCRIPTION
The existing link to the file where constants were defined was broken. Previously it pointed to `include/constants.h` but it should be pointing to `include/public/osqp_api_constants.h`.