### PR TITLE
ospq/timing: fix build warning if enable -Wstrict-prototypes

### DIFF
--- a/include/private/timing.h
+++ b/include/private/timing.h
@@ -18,7 +18,7 @@ extern "C" {
  * Create a new timer.
  * @return the timer
  */
-OSQPTimer* OSQPTimer_new();
+OSQPTimer* OSQPTimer_new(void);
 
 /**
  * Free an existing timer.

--- a/src/timing_linux.c
+++ b/src/timing_linux.c
@@ -16,7 +16,7 @@ struct OSQPTimer_ {
 
 
 /* Create the timer */
-OSQPTimer* OSQPTimer_new() {
+OSQPTimer* OSQPTimer_new(void) {
     return c_malloc(sizeof(struct OSQPTimer_));
 }
 

--- a/src/timing_macos.c
+++ b/src/timing_macos.c
@@ -16,7 +16,7 @@ struct OSQPTimer_ {
 
 
 /* Create the timer */
-OSQPTimer* OSQPTimer_new() {
+OSQPTimer* OSQPTimer_new(void) {
     return c_malloc(sizeof(struct OSQPTimer_));
 }
 

--- a/src/timing_windows.c
+++ b/src/timing_windows.c
@@ -19,7 +19,7 @@ struct OSQPTimer_ {
 
 
 /* Create the timer */
-OSQPTimer* OSQPTimer_new() {
+OSQPTimer* OSQPTimer_new(void) {
     return c_malloc(sizeof(struct OSQPTimer_));
 }
 


### PR DESCRIPTION
ospq/timing: fix build warning if enable -Wstrict-prototypes

```
osqp/include/private/timing.h:21:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
   21 | OSQPTimer* OSQPTimer_new();
      | ^~~~~~~~~
```

Signed-off-by: chao an <anchao@lixiang.com>
