### PR TITLE
Fixed hyperlink on home page and python build instructions

### DIFF
--- a/docs/get_started/python.rst
+++ b/docs/get_started/python.rst
@@ -41,4 +41,4 @@ Now you are ready to build OSQP python interface from sources. Run the following
 
    git clone --recurse-submodules https://github.com/osqp/osqp-python
    cd osqp-python
-   python setup.py install
+   pip install .

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 OSQP solver documentation
 ==========================
 
-[**Visit our GitHub Discussions page**](https://github.com/orgs/osqp/discussions)
+`Visit our GitHub Discussions page <https://github.com/orgs/osqp/discussions>`_
 for any questions related to the solver!
 
 The OSQP (Operator Splitting Quadratic Program) solver is a numerical


### PR DESCRIPTION
Previously the python build instructions did not work. I assume the build process for the python wrapper changed at some point, but the documentation was not updated.