### PR TITLE
docs: update setting interfaces name for examples

### DIFF
--- a/docs/examples/lasso.rst
+++ b/docs/examples/lasso.rst
@@ -64,7 +64,7 @@ Python
     prob = osqp.OSQP()
 
     # Setup workspace
-    prob.setup(P, q, A, l, u, warm_starting=True)
+    prob.setup(P, q, A, l, u, warm_start=True)
 
     # Solve problem for different values of gamma parameter
     for gamma in gammas:
@@ -103,7 +103,7 @@ Matlab
     prob = osqp;
 
     % Setup workspace
-    prob.setup(P, q, A, l, u, 'warm_starting', true);
+    prob.setup(P, q, A, l, u, 'warm_start', true);
 
     % Solve problem for different values of gamma parameter
     for i = 1 : length(gammas)
@@ -146,7 +146,7 @@ CVXPY
     # Solve problem for different values of gamma parameter
     for gamma_val in gammas:
         gamma.value = gamma_val
-        prob.solve(solver=OSQP, warm_starting=True)
+        prob.solve(solver=OSQP, warm_start=True)
 
 
 YALMIP

--- a/docs/examples/mpc.rst
+++ b/docs/examples/mpc.rst
@@ -103,7 +103,7 @@ Python
     prob = osqp.OSQP()
 
     # Setup workspace
-    prob.setup(P, q, A, l, u, warm_starting=True)
+    prob.setup(P, q, A, l, u, warm_start=True)
 
     # Simulate in closed loop
     nsim = 15
@@ -201,7 +201,7 @@ Matlab
     prob = osqp;
 
     % Setup workspace
-    prob.setup(P, q, A, l, u, 'warm_starting', true);
+    prob.setup(P, q, A, l, u, 'warm_start', true);
 
     % Simulate in closed loop
     nsim = 15;
@@ -305,7 +305,7 @@ CVXPY
     nsim = 15
     for i in range(nsim):
         x_init.value = x0
-        prob.solve(solver=OSQP, warm_starting=True)
+        prob.solve(solver=OSQP, warm_start=True)
         x0 = Ad@x0 + Bd@u[:,0].value
 
 
@@ -465,7 +465,7 @@ Julia
     m = OSQP.Model()
 
     # Setup workspace
-    OSQP.setup!(m; P=P, q=q, A=A, l=l, u=u, warm_starting=true)
+    OSQP.setup!(m; P=P, q=q, A=A, l=l, u=u, warm_start=true)
 
     # Simulate in closed loop
     nsim = 15;


### PR DESCRIPTION
I cross-checked and found that the naming for [`warm_starting`](https://osqp.org/docs/interfaces/solver_settings.html) is different in other interfaces, including Python, Julia, and MATLAB. Instead, it is referred to `warm_start`

I have updated the docs examples in this PR to incorporate this issue.