### PR TITLE
Update to QDLDL 0.1.8 and update how we include it

### DIFF
--- a/algebra/_common/lin_sys/qdldl/qdldl.cmake
+++ b/algebra/_common/lin_sys/qdldl/qdldl.cmake
@@ -3,28 +3,22 @@ include(FetchContent)
 message(STATUS "Fetching/configuring QDLDL solver")
 list(APPEND CMAKE_MESSAGE_INDENT "  ")
 
-# Corresponds to 0.1.6 release of QDLDL
 FetchContent_Declare(
   qdldl
   GIT_REPOSITORY https://github.com/osqp/qdldl.git
-  GIT_TAG 29d140419a3bec20d860052d73ba2be927faf5a1
-  SOURCE_DIR ${OSQP_ALGEBRA_ROOT}/_common/lin_sys/qdldl/qdldl_sources)
+  GIT_TAG v0.1.8
+  )
+
+# Make QDLDL use the same types as OSQP
+set(QDLDL_FLOAT ${OSQP_USE_FLOAT} CACHE BOOL "QDLDL Float type")
+set(QDLDL_LONG ${OSQP_USE_LONG} CACHE BOOL "QDLDL Integer type")
+
+# We only want the object library, so turn off the other library products
+set(QDLDL_BUILD_STATIC_LIB OFF CACHE BOOL "Build QDLDL static library")
+set(QDLDL_BUILD_SHARED_LIB OFF CACHE BOOL "Build QDLDL shared library")
+
+FetchContent_MakeAvailable(qdldl)
 FetchContent_GetProperties(qdldl)
-
-if(NOT qdldl_POPULATED)
-  FetchContent_Populate(qdldl)
-
-  # Make QDLDL use the same types as OSQP
-  set(QDLDL_FLOAT ${OSQP_USE_FLOAT} CACHE BOOL "QDLDL Float type")
-  set(QDLDL_LONG ${OSQP_USE_LONG} CACHE BOOL "QDLDL Integer type")
-
-  # We only want the object library, so turn off the other library products
-  set(QDLDL_BUILD_STATIC_LIB OFF CACHE BOOL "Build QDLDL static library")
-  set(QDLDL_BUILD_SHARED_LIB OFF CACHE BOOL "Build QDLDL shared library")
-
-  # We don't actually want to build anything from here by default
-  add_subdirectory(${qdldl_SOURCE_DIR} ${qdldl_BINARY_DIR} EXCLUDE_FROM_ALL)
-endif()
 
 list(POP_BACK CMAKE_MESSAGE_INDENT)
 
@@ -59,5 +53,6 @@ set( LIN_SYS_QDLDL_INC_PATHS
      ${OSQP_ALGEBRA_ROOT}/_common/
      ${OSQP_ALGEBRA_ROOT}/_common/lin_sys/qdldl/
      ${OSQP_ALGEBRA_ROOT}/_common/lin_sys/qdldl/amd/include
-     ${OSQP_ALGEBRA_ROOT}/_common/lin_sys/qdldl/qdldl_sources/include
+     ${qdldl_SOURCE_DIR}/include
+     ${qdldl_BINARY_DIR}/include
      )

--- a/algebra/builtin/CMakeLists.txt
+++ b/algebra/builtin/CMakeLists.txt
@@ -44,7 +44,7 @@ if( OSQP_CODEGEN )
        ${OSQP_ALGEBRA_ROOT}/_common/lin_sys/qdldl/qdldl_interface.c
        ${qdldl_SOURCE_DIR}/src/qdldl.c
        ${qdldl_SOURCE_DIR}/include/qdldl.h
-       ${qdldl_SOURCE_DIR}/include/qdldl_version.h )
+       ${qdldl_BINARY_DIR}/include/qdldl_version.h )
 
   foreach( f ${EMBEDDED_LINALG} )
     get_filename_component( fname ${f} NAME )


### PR DESCRIPTION
The FetchContent_Populate method was deprecated, so modify to use the MakeAvailable method, which requires a slightly different method of working (it automatically adds the subdirectory if it has the CMakeLists.txt present).

Also change QDLDL to be placed into the build directory, letting each build have an isolated copy of it.