### PR TITLE
minor changes in cuda runner workflow

### DIFF
--- a/.github/workflows/algebra-cuda.yml
+++ b/.github/workflows/algebra-cuda.yml
@@ -16,8 +16,8 @@ jobs:
       strategy:
         matrix:
           os: [ubuntu-latest]
-          python-version: [3.9]
-          cmake_flags: ['-DOSQP_BUILD_UNITTESTS=ON -DOSQP_ALGEBRA_BACKEND=cuda -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DCMAKE_CUDA_HOST_COMPILER=g++-10']
+          python-version: [3.12]
+          cmake_flags: ['-DOSQP_BUILD_UNITTESTS=ON -DOSQP_ALGEBRA_BACKEND=cuda -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc']
 
           include:
             - os: ubuntu-latest
@@ -42,15 +42,11 @@ jobs:
         - name: Set up conda environment for testing
           uses: conda-incubator/setup-miniconda@v3
           with:
-            auto-update-conda: true
+            auto-update-conda: false
             python-version: ${{ matrix.python-version }}
             activate-environment: osqp-test
             environment-file: tests/testenv.yml
             auto-activate-base: false
-
-        - name: Setup (Linux)
-          run: |
-            echo "LD_LIBRARY_PATH=$CONDA_PREFIX/lib" >> $GITHUB_ENV
 
         - name: Build
           run: |


### PR DESCRIPTION
Removed stuff in cuda runner workflow that was specific to the runner machine (my laptop). Setting `auto_update` of `conda` to `false` to hopefully have fewer issues going forward.

This setup worked on a brand new head node at Princeton, so hopefully its generic enough now.