### PR TITLE
Null checks for allocations in MKL backend to prevent crashes under memory pressure

### DIFF
--- a/algebra/mkl/lin_sys/direct/pardiso_interface.c
+++ b/algebra/mkl/lin_sys/direct/pardiso_interface.c
@@ -37,13 +37,15 @@ void free_linsys_solver_pardiso(pardiso_solver* s) {
   if (s) {
 
     // Free pardiso solver using internal function
-    s->phase = PARDISO_CLEANUP;
-    PARDISO (s->pt, &(s->maxfct), &(s->mnum), &(s->mtype), &(s->phase),
-             &(s->nKKT), &(s->fdum), s->KKT_p, s->KKT_i, &(s->idum), &(s->nrhs),
-             s->iparm, &(s->msglvl), &(s->fdum), &(s->fdum), &(s->error));
+    if (s->KKT_p && s->KKT_i) {
+      s->phase = PARDISO_CLEANUP;
+      PARDISO (s->pt, &(s->maxfct), &(s->mnum), &(s->mtype), &(s->phase),
+               &(s->nKKT), &(s->fdum), s->KKT_p, s->KKT_i, &(s->idum), &(s->nrhs),
+               s->iparm, &(s->msglvl), &(s->fdum), &(s->fdum), &(s->error));
 
-    if ( s->error != 0 ){
-      c_eprint("Error during MKL Pardiso cleanup: %d", (int)s->error);
+      if ( s->error != 0 ){
+        c_eprint("Error during MKL Pardiso cleanup: %d", (int)s->error);
+      }
     }
     // Check each attribute of the structure and free it if it exists
     if (s->KKT)         csc_spfree(s->KKT);
@@ -81,7 +83,9 @@ OSQPInt init_linsys_solver_pardiso(pardiso_solver**    sp,
 
   // Allocate private structure to store KKT factorization
   pardiso_solver *s = c_calloc(1, sizeof(pardiso_solver));
-  *sp = s;
+  *sp = OSQP_NULL;
+
+  if (!s) return OSQP_LINSYS_SOLVER_INIT_ERROR;
 
   // Size of KKT
   n = P->csc->n;
@@ -121,6 +125,11 @@ OSQPInt init_linsys_solver_pardiso(pardiso_solver**    sp,
   }
   // else it is NULL
 
+  if (!s->bp || !s->sol || (rho_vec && !s->rho_inv_vec)) {
+    free_linsys_solver_pardiso(s);
+    return OSQP_LINSYS_SOLVER_INIT_ERROR;
+  }
+
   // Form KKT matrix
   if (polishing){ // Called from polish()
     s->KKT = form_KKT(P->csc,A->csc,
@@ -134,6 +143,11 @@ OSQPInt init_linsys_solver_pardiso(pardiso_solver**    sp,
     s->PtoKKT   = c_malloc(P->csc->p[n] * sizeof(OSQPInt));
     s->AtoKKT   = c_malloc(A->csc->p[n] * sizeof(OSQPInt));
     s->rhotoKKT = c_malloc(m * sizeof(OSQPInt));
+
+    if (!s->PtoKKT || !s->AtoKKT || !s->rhotoKKT) {
+      free_linsys_solver_pardiso(s);
+      return OSQP_LINSYS_SOLVER_INIT_ERROR;
+    }
 
     // Use s->rho_inv_vec for storing param2 = rho_inv_vec
     if (rho_vec) {
@@ -154,7 +168,7 @@ OSQPInt init_linsys_solver_pardiso(pardiso_solver**    sp,
 
   // Check if matrix has been created
   if (!(s->KKT)) {
-	  c_eprint("Error in forming KKT matrix");
+    c_eprint("Error in forming KKT matrix");
     free_linsys_solver_pardiso(s);
     return OSQP_LINSYS_SOLVER_INIT_ERROR;
   } else {
@@ -162,6 +176,11 @@ OSQPInt init_linsys_solver_pardiso(pardiso_solver**    sp,
     nnzKKT = s->KKT->p[n_plus_m];
     s->KKT_i = c_malloc((nnzKKT) * sizeof(OSQPInt));
     s->KKT_p = c_malloc((n_plus_m + 1) * sizeof(OSQPInt));
+
+    if (!s->KKT_i || !s->KKT_p) {
+      free_linsys_solver_pardiso(s);
+      return OSQP_LINSYS_SOLVER_INIT_ERROR;
+    }
 
     for(i = 0; i < nnzKKT; i++){
       s->KKT_i[i] = s->KKT->i[i] + 1;
@@ -215,7 +234,6 @@ OSQPInt init_linsys_solver_pardiso(pardiso_solver**    sp,
   if ( s->error != 0 ){
     c_eprint("Error during symbolic factorization: %d", (int)s->error);
     free_linsys_solver_pardiso(s);
-    *sp = OSQP_NULL;
     return OSQP_LINSYS_SOLVER_INIT_ERROR;
   }
 
@@ -230,15 +248,16 @@ OSQPInt init_linsys_solver_pardiso(pardiso_solver**    sp,
   if ( s->error ){
     c_eprint("Error during numerical factorization: %d", (int)s->error);
     free_linsys_solver_pardiso(s);
-    *sp = OSQP_NULL;
     return OSQP_LINSYS_SOLVER_INIT_ERROR;
   }
   if ( s->iparm[21] < n ) {
     // Error: Number of positive eigenvalues of KKT should be the same as dimension of P
     c_eprint("KKT matrix has fewer positive eigenvalues than it should. The problem seems to be non-convex.");
+    free_linsys_solver_pardiso(s);
     return OSQP_NONCVX_ERROR;
   }
 
+  *sp = s;
   return 0;
 }
 

--- a/algebra/mkl/lin_sys/indirect/mkl-cg_interface.c
+++ b/algebra/mkl/lin_sys/indirect/mkl-cg_interface.c
@@ -154,6 +154,12 @@ OSQPInt init_linsys_mklcg(mklcg_solver**     sp,
   //cold start condition for the CG inner solver
   s->x = OSQPVectorf_calloc(n);
   s->ywork = OSQPVectorf_malloc(m);
+
+  //Allocate a 4*n vector for the MKL workspace
+  // 1:n     = Vector to multiply by the matrix
+  // n+1:2n  = Vector after multiplying by the matrix
+  // 2n+1:3n = Vector to apply the preconditioner to
+  // 3n+1:4n = Vector after application of the preconditioner
   s->tmp = OSQPVectorf_malloc(4*n);
   s->precond     = OSQPVectorf_malloc(n);
   s->precond_inv = OSQPVectorf_malloc(n);

--- a/algebra/mkl/lin_sys/indirect/mkl-cg_interface.c
+++ b/algebra/mkl/lin_sys/indirect/mkl-cg_interface.c
@@ -92,8 +92,10 @@ OSQPInt init_linsys_mklcg(mklcg_solver**     sp,
   OSQPInt m = A->csc->m;
   OSQPInt n = P->csc->n;
   MKL_INT status;
-  mklcg_solver* s = (mklcg_solver *)c_malloc(sizeof(mklcg_solver));
-  *sp = s;
+  mklcg_solver* s = (mklcg_solver *)c_calloc(1, sizeof(mklcg_solver));
+  *sp = OSQP_NULL;
+
+  if (!s) return OSQP_LINSYS_SOLVER_INIT_ERROR;
 
   //Just hold on to pointers to the problem
   //data, no copies or processing required
@@ -110,6 +112,10 @@ OSQPInt init_linsys_mklcg(mklcg_solver**     sp,
   //if polish is false, use the rho_vec we get.
   //Otherwise, use rho_vec = ones.*(1/sigma)
   s->rho_vec = OSQPVectorf_malloc(m);
+  if (!s->rho_vec) {
+    free_linsys_mklcg(s);
+    return OSQP_LINSYS_SOLVER_INIT_ERROR;
+  }
   if (!polish) {
       OSQPVectorf_copy(s->rho_vec, rho_vec);
   } else {
@@ -147,9 +153,15 @@ OSQPInt init_linsys_mklcg(mklcg_solver**     sp,
   //Initialise solver state to zero since it provides
   //cold start condition for the CG inner solver
   s->x = OSQPVectorf_calloc(n);
-
-  //Workspace for CG products and polishing
   s->ywork = OSQPVectorf_malloc(m);
+  s->tmp = OSQPVectorf_malloc(4*n);
+  s->precond     = OSQPVectorf_malloc(n);
+  s->precond_inv = OSQPVectorf_malloc(n);
+
+  if (!s->x || !s->ywork || !s->tmp || !s->precond || !s->precond_inv) {
+    free_linsys_mklcg(s);
+    return OSQP_LINSYS_SOLVER_INIT_ERROR;
+  }
 
   //make subviews for the rhs.   OSQP passes
   //a different RHS pointer at every iteration,
@@ -157,13 +169,6 @@ OSQPInt init_linsys_mklcg(mklcg_solver**     sp,
   //time we solve. Just point them at x for now.
   s->r1 = OSQPVectorf_view(s->x, 0, 0);
   s->r2 = OSQPVectorf_view(s->x, 0, 0);
-
-  //Allocate a 4*n vector for the MKL workspace
-  // 1:n     = Vector to multiply by the matrix
-  // n+1:2n  = Vector after multiplying by the matrix
-  // 2n+1:3n = Vector to apply the preconditioner to
-  // 3n+1:4n = Vector after application of the preconditioner
-  s->tmp = OSQPVectorf_malloc(4*n);
 
   // Create subviews to tmp to aid the matrix-vector multiplication
   s->mvm_pre  = OSQPVectorf_view(s->tmp, 0, n);
@@ -173,14 +178,21 @@ OSQPInt init_linsys_mklcg(mklcg_solver**     sp,
   s->precond_pre  = OSQPVectorf_view(s->tmp, 2*n, n);
   s->precond_post = OSQPVectorf_view(s->tmp, 3*n, n);
 
-  status = cg_solver_init(s);
+  if (!s->r1 || !s->r2 || !s->mvm_pre || !s->mvm_post ||
+      !s->precond_pre  || !s->precond_post) {
+    free_linsys_mklcg(s);
+    return OSQP_LINSYS_SOLVER_INIT_ERROR;
+  }
 
-  // Compute the preconditioner
-  s->precond     = OSQPVectorf_malloc(n);
-  s->precond_inv = OSQPVectorf_malloc(n);
+  status = cg_solver_init(s);
+  if (status != 0) {
+    free_linsys_mklcg(s);
+    return OSQP_LINSYS_SOLVER_INIT_ERROR;
+  }
   cg_update_precond(s);
 
-  return status;
+  *sp = s;
+  return 0;
 }
 
 
@@ -375,7 +387,7 @@ OSQPInt update_rho_linsys_mklcg(mklcg_solver*    s,
 
 void free_linsys_mklcg(mklcg_solver* s) {
 
-  if (s->tmp) {
+  if (s) {
     OSQPVectorf_free(s->tmp);
     OSQPVectorf_free(s->rho_vec);
     OSQPVectorf_free(s->x);
@@ -388,6 +400,6 @@ void free_linsys_mklcg(mklcg_solver* s) {
     OSQPVectorf_view_free(s->mvm_post);
     OSQPVectorf_view_free(s->precond_pre);
     OSQPVectorf_view_free(s->precond_post);
+    c_free(s);
   }
-  c_free(s);
 }

--- a/algebra/mkl/matrix.c
+++ b/algebra/mkl/matrix.c
@@ -19,6 +19,7 @@ OSQPInt OSQPMatrix_is_eq(const OSQPMatrix* A,
 
 /* Special routine to allocate a OSQPCscMatrix using the MKL memory routines
    instead of the normal memory routines */
+static void mkl_csc_spfree(OSQPCscMatrix* M);
 static OSQPCscMatrix* mkl_csc_spalloc(OSQPInt m, OSQPInt n, OSQPInt nzmax, OSQPInt hasData) {
   OSQPCscMatrix* csc = c_calloc(1, sizeof(OSQPCscMatrix));
 
@@ -33,6 +34,11 @@ static OSQPCscMatrix* mkl_csc_spalloc(OSQPInt m, OSQPInt n, OSQPInt nzmax, OSQPI
   csc->p     = blas_malloc((n + 1) * sizeof(OSQPInt));
   csc->i     = hasData ? blas_malloc(nzmax * sizeof(OSQPInt)) : OSQP_NULL;
   csc->x     = hasData ? blas_malloc(nzmax * sizeof(OSQPFloat)) : OSQP_NULL;
+
+  if (!csc->p || (hasData && (!csc->i || !csc->x))) {
+    mkl_csc_spfree(csc);
+    return OSQP_NULL;
+  }
 
   return csc;
 }
@@ -152,6 +158,8 @@ OSQPCscMatrix* OSQPMatrix_get_csc(const OSQPMatrix* M) {
   /* Create the CSC using the returned data */
   nnz = p_end[numcols-1]+1;
   B = csc_spalloc(numcols, numrows, nnz, 1, 0);
+
+  if (!B) return OSQP_NULL;
 
   /* MKL doesn't give back the actual p we need, we need to take the last value from p_end and concatenate
      it onto the array returned in p_start */
@@ -328,7 +336,10 @@ static OSQPCscMatrix* mkl_submatrix_byrows(const OSQPCscMatrix* A,
 
   // Form R = A(rows,:), where nrows = sum(rows != 0)
   R = mkl_csc_spalloc(Rm, An, nzR, 1);
-  if (!R) return OSQP_NULL;
+  if (!R) {
+    c_free(rridx);
+    return OSQP_NULL;
+  }
 
   // no active constraints
   if (Rm == 0) {


### PR DESCRIPTION
https://github.com/osqp/osqp/issues/779

I've observed segfaults when running (python) OSQP in a memory constrained production environment. It appears that when the system is under memory pressure, and allocations fail, there are a few areas in the code where the failures go unchecked and cause serious issues.

This PR attempts to address them. To contain the scope, I've only tried to fix the MKL backend here. If this approach seems reasonable I can try to fix the builtin backend as well.

Claude (with Opus 4.6) wrote most of this under my direction.