### PR TITLE
colcon metadata

### DIFF
--- a/.github/workflows/colcon.yml
+++ b/.github/workflows/colcon.yml
@@ -1,0 +1,42 @@
+name: colcon
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: "${{ matrix.image }}"
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        include:
+            - {image: "ubuntu:22.04"}
+            - {image: "ubuntu:24.04"}
+            - {image: "ubuntu:26.04"}
+
+    container:
+      image: ${{ matrix.image }}
+      env:
+        DEBIAN_FRONTEND: noninteractive
+        PIP_BREAK_SYSTEM_PACKAGES: 1
+
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install tooling
+        run: |
+          apt update
+          apt install -y python3-pip
+          pip install colcon-common-extensions rosdep
+
+      - name: Initialize rosdep
+        run: |
+          rosdep init || true
+          rosdep update
+
+      - name: Install package dependencies
+        run: |
+          rosdep install -y --from-paths . --ignore-src --rosdistro rolling
+
+      - name: Build with colcon
+        run: colcon build --event-handlers console_direct+

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>osqp</name>
+
+  <version>1.0.0</version>
+
+  <description>The Operator Splitting QP Solver</description>
+
+  <maintainer email="Rauch.Christian@gmx.de">Christian Rauch</maintainer>
+
+  <license>Apache-2.0</license>
+
+  <url>https://osqp.org</url>
+
+  <author email="bartolomeo.stellato@gmail.com">Bartolomeo Stellato</author>
+
+  <buildtool_depend>cmake</buildtool_depend>
+  <buildtool_depend>git</buildtool_depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
I would like to add colcon metadata in form of a `package.xml` to this repo. This is an XML file defining the package build dependencies, contact information, etc. I also added a new workflow to build the package using this metadata to verify that all build decencies are properly defined.

I add Bartolomeo Stellato as author and me as maintainer. If this information is outdated and someone else wants to be mentioned as maintainer, let me know. There can be multiple `maintainer` and `author` tags in the `package.xml`.