### PR TITLE
Preallocate polish workspace at setup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -432,6 +432,12 @@ if (UNITTESTS)
                 CXX_EXTENSIONS NO
             )
     target_link_libraries (osqp_tester osqpstatic ${CMAKE_DL_LIBS})
+    if(OSQP_CUSTOM_MEMORY)
+        target_sources(osqp_tester PRIVATE
+                ${PROJECT_SOURCE_DIR}/tests/custom_memory/custom_memory.c
+                ${PROJECT_SOURCE_DIR}/tests/custom_memory/custom_memory.h
+                )
+    endif()
 
     # Add custom memory target
     add_executable(osqp_tester_custom_memory
@@ -444,6 +450,7 @@ if (UNITTESTS)
 		   ${PROJECT_SOURCE_DIR}/tests/custom_memory/custom_memory.h
 		)
     target_link_libraries (osqp_tester_custom_memory osqpstatic ${CMAKE_DL_LIBS})
+    target_compile_definitions(osqp_tester_custom_memory PRIVATE OSQP_CUSTOM_MEMORY_TEST=1)
 
     # Add testing
     include(CTest)

--- a/include/types.h
+++ b/include/types.h
@@ -97,20 +97,27 @@ typedef struct {
  * Polish structure
  */
 typedef struct {
-  csc *Ared;          ///< active rows of A
-  ///<    Ared = vstack[Alow, Aupp]
-  c_int    n_low;     ///< number of lower-active rows
-  c_int    n_upp;     ///< number of upper-active rows
-  c_int   *A_to_Alow; ///< Maps indices in A to indices in Alow
-  c_int   *A_to_Aupp; ///< Maps indices in A to indices in Aupp
-  c_int   *Alow_to_A; ///< Maps indices in Alow to indices in A
-  c_int   *Aupp_to_A; ///< Maps indices in Aupp to indices in A
-  c_float *x;         ///< optimal x-solution obtained by polish
-  c_float *z;         ///< optimal z-solution obtained by polish
-  c_float *y;         ///< optimal y-solution obtained by polish
-  c_float  obj_val;   ///< objective value at polished solution
-  c_float  pri_res;   ///< primal residual at polished solution
-  c_float  dua_res;   ///< dual residual at polished solution
+  csc          *Ared;           ///< fixed active-set matrix pattern
+  LinSysSolver *linsys_solver;  ///< fixed-size linear solver for polishing
+  c_int         n_low;          ///< number of lower-active rows
+  c_int         n_upp;          ///< number of upper-active rows
+  c_int        *A_to_Alow;      ///< Maps indices in A to active lower rows
+  c_int        *A_to_Aupp;      ///< Maps indices in A to active upper rows
+  c_int        *Alow_to_A;      ///< Maps active lower rows to A row indices
+  c_int        *Aupp_to_A;      ///< Maps active upper rows to A row indices
+  c_int        *A_to_Alow_elem; ///< Maps A nz entries to duplicated lower rows in Ared
+  c_int        *A_to_Aupp_elem; ///< Maps A nz entries to duplicated upper rows in Ared
+  c_float      *x;              ///< optimal x-solution obtained by polish
+  c_float      *z;              ///< optimal z-solution obtained by polish
+  c_float      *y;              ///< optimal y-solution obtained by polish
+  c_float      *rhs_red;        ///< fixed-size right-hand side
+  c_float      *rhs;            ///< iterative refinement workspace
+  c_float      *pol_sol;        ///< polished solution workspace
+  c_float      *rho_vec;        ///< linsys rho input; inverse stores delta
+  c_float       delta;          ///< delta value cached in linsys workspace
+  c_float       obj_val;        ///< objective value at polished solution
+  c_float       pri_res;        ///< primal residual at polished solution
+  c_float       dua_res;        ///< dual residual at polished solution
 } OSQPPolish;
 # endif // ifndef EMBEDDED
 

--- a/src/osqp.c
+++ b/src/osqp.c
@@ -212,21 +212,54 @@ c_int osqp_setup(OSQPWorkspace** workp, const OSQPData *data, const OSQPSettings
     return osqp_error(exitflag);
   }
 
-  // Initialize active constraints structure
-  work->pol = c_malloc(sizeof(OSQPPolish));
+  // Initialize active constraints structure and fixed polish workspace
+  work->pol = c_calloc(1, sizeof(OSQPPolish));
   if (!(work->pol)) return osqp_error(OSQP_MEM_ALLOC_ERROR);
-  work->pol->Alow_to_A = c_malloc(data->m * sizeof(c_int));
-  work->pol->Aupp_to_A = c_malloc(data->m * sizeof(c_int));
-  work->pol->A_to_Alow = c_malloc(data->m * sizeof(c_int));
-  work->pol->A_to_Aupp = c_malloc(data->m * sizeof(c_int));
-  work->pol->x         = c_malloc(data->n * sizeof(c_float));
-  work->pol->z         = c_malloc(data->m * sizeof(c_float));
-  work->pol->y         = c_malloc(data->m * sizeof(c_float));
-  if (!(work->pol->x)) return osqp_error(OSQP_MEM_ALLOC_ERROR);
-  if ( data->m && (!(work->pol->Alow_to_A) || !(work->pol->Aupp_to_A) ||
-      !(work->pol->A_to_Alow) || !(work->pol->A_to_Aupp) ||
-      !(work->pol->z) || !(work->pol->y)) )
+  work->pol->Alow_to_A    = c_malloc(data->m * sizeof(c_int));
+  work->pol->Aupp_to_A    = c_malloc(data->m * sizeof(c_int));
+  work->pol->A_to_Alow    = c_malloc(data->m * sizeof(c_int));
+  work->pol->A_to_Aupp    = c_malloc(data->m * sizeof(c_int));
+  work->pol->A_to_Alow_elem = c_malloc(data->A->p[data->A->n] * sizeof(c_int));
+  work->pol->A_to_Aupp_elem = c_malloc(data->A->p[data->A->n] * sizeof(c_int));
+  work->pol->x            = c_malloc(data->n * sizeof(c_float));
+  work->pol->z            = c_malloc(data->m * sizeof(c_float));
+  work->pol->y            = c_malloc(data->m * sizeof(c_float));
+  work->pol->rhs_red      = c_malloc((data->n + 2 * data->m) * sizeof(c_float));
+  work->pol->rhs          = c_malloc((data->n + 2 * data->m) * sizeof(c_float));
+  work->pol->pol_sol      = c_malloc((data->n + 2 * data->m) * sizeof(c_float));
+  work->pol->rho_vec      = c_malloc((2 * data->m) * sizeof(c_float));
+  work->pol->Ared         = csc_spalloc(2 * data->m, data->n, 2 * data->A->p[data->A->n], 1, 0);
+  if (!(work->pol->x) || !(work->pol->rhs_red) || !(work->pol->rhs) ||
+      !(work->pol->pol_sol) || !(work->pol->Ared))
     return osqp_error(OSQP_MEM_ALLOC_ERROR);
+  if (data->m && (!(work->pol->Alow_to_A) || !(work->pol->Aupp_to_A) ||
+      !(work->pol->A_to_Alow) || !(work->pol->A_to_Aupp) ||
+      !(work->pol->z) || !(work->pol->y) || !(work->pol->rho_vec)))
+    return osqp_error(OSQP_MEM_ALLOC_ERROR);
+  if (data->A->p[data->A->n] && (!(work->pol->A_to_Alow_elem) || !(work->pol->A_to_Aupp_elem)))
+    return osqp_error(OSQP_MEM_ALLOC_ERROR);
+  work->pol->delta = work->settings->delta;
+  vec_set_scalar(work->pol->Ared->x, 0., 2 * data->A->p[data->A->n]);
+  vec_set_scalar(work->pol->rho_vec, 1. / work->pol->delta, 2 * data->m);
+  {
+    c_int j, ptr, Ared_nnz = 0;
+    for (j = 0; j < data->n; j++) {
+      work->pol->Ared->p[j] = Ared_nnz;
+      for (ptr = data->A->p[j]; ptr < data->A->p[j + 1]; ptr++) {
+        work->pol->Ared->i[Ared_nnz] = data->A->i[ptr];
+        work->pol->A_to_Alow_elem[ptr] = Ared_nnz++;
+      }
+      for (ptr = data->A->p[j]; ptr < data->A->p[j + 1]; ptr++) {
+        work->pol->Ared->i[Ared_nnz] = data->A->i[ptr] + data->m;
+        work->pol->A_to_Aupp_elem[ptr] = Ared_nnz++;
+      }
+    }
+    work->pol->Ared->p[data->n] = Ared_nnz;
+  }
+  exitflag = init_linsys_solver(&(work->pol->linsys_solver), work->data->P, work->pol->Ared,
+                                work->pol->delta, work->pol->rho_vec,
+                                work->settings->linsys_solver, 0);
+  if (exitflag) return osqp_error(exitflag);
 
   // Allocate solution
   work->solution = c_calloc(1, sizeof(OSQPSolution));
@@ -699,13 +732,23 @@ c_int osqp_cleanup(OSQPWorkspace *work) {
 #ifndef EMBEDDED
     // Free active constraints structure
     if (work->pol) {
-      if (work->pol->Alow_to_A) c_free(work->pol->Alow_to_A);
-      if (work->pol->Aupp_to_A) c_free(work->pol->Aupp_to_A);
-      if (work->pol->A_to_Alow) c_free(work->pol->A_to_Alow);
-      if (work->pol->A_to_Aupp) c_free(work->pol->A_to_Aupp);
-      if (work->pol->x)         c_free(work->pol->x);
-      if (work->pol->z)         c_free(work->pol->z);
-      if (work->pol->y)         c_free(work->pol->y);
+      if (work->pol->linsys_solver && work->pol->linsys_solver->free) {
+        work->pol->linsys_solver->free(work->pol->linsys_solver);
+      }
+      if (work->pol->Ared)          csc_spfree(work->pol->Ared);
+      if (work->pol->Alow_to_A)     c_free(work->pol->Alow_to_A);
+      if (work->pol->Aupp_to_A)     c_free(work->pol->Aupp_to_A);
+      if (work->pol->A_to_Alow)     c_free(work->pol->A_to_Alow);
+      if (work->pol->A_to_Aupp)     c_free(work->pol->A_to_Aupp);
+      if (work->pol->A_to_Alow_elem) c_free(work->pol->A_to_Alow_elem);
+      if (work->pol->A_to_Aupp_elem) c_free(work->pol->A_to_Aupp_elem);
+      if (work->pol->x)             c_free(work->pol->x);
+      if (work->pol->z)             c_free(work->pol->z);
+      if (work->pol->y)             c_free(work->pol->y);
+      if (work->pol->rhs_red)       c_free(work->pol->rhs_red);
+      if (work->pol->rhs)           c_free(work->pol->rhs);
+      if (work->pol->pol_sol)       c_free(work->pol->pol_sol);
+      if (work->pol->rho_vec)       c_free(work->pol->rho_vec);
       c_free(work->pol);
     }
 #endif /* ifndef EMBEDDED */

--- a/src/polish.c
+++ b/src/polish.c
@@ -3,121 +3,131 @@
 #include "util.h"
 #include "auxil.h"
 #include "lin_sys.h"
-#include "kkt.h"
 #include "proj.h"
 #include "error.h"
+#include "qdldl_interface.h"
+#ifdef ENABLE_MKL_PARDISO
+#include "pardiso_interface.h"
+#endif
 
 /**
- * Form reduced matrix A that contains only rows that are active at the
- * solution.
- * Ared = vstack[Alow, Aupp]
- * Active constraints are guessed from the primal and dual solution returned by
- * the ADMM.
- * @param  work Workspace
- * @return      Number of rows in Ared, negative if error
+ * Update the fixed duplicated active-set matrix:
+ *   Ared = vstack[Alow, Aupp]
+ * Lower rows occupy [0, m), upper rows occupy [m, 2m).
  */
-static c_int form_Ared(OSQPWorkspace *work) {
+static void form_Ared(OSQPWorkspace *work) {
   c_int j, ptr;
-  c_int Ared_nnz = 0;
+  c_int nnzA = work->data->A->p[work->data->A->n];
 
-  // Initialize counters for active constraints
   work->pol->n_low = 0;
   work->pol->n_upp = 0;
 
-  /* Guess which linear constraints are lower-active, upper-active and free
-   *    A_to_Alow[j] = -1    (if j-th row of A is not inserted in Alow)
-   *    A_to_Alow[j] =  i    (if j-th row of A is inserted at i-th row of Alow)
-   * Aupp is formed in the equivalent way.
-   * Ared is formed by stacking vertically Alow and Aupp.
-   */
   for (j = 0; j < work->data->m; j++) {
-    if (work->z[j] - work->data->l[j] < -work->y[j]) { // lower-active
-      work->pol->Alow_to_A[work->pol->n_low] = j;
-      work->pol->A_to_Alow[j]                = work->pol->n_low++;
+    if (work->z[j] - work->data->l[j] < -work->y[j]) {
+      work->pol->Alow_to_A[work->pol->n_low++] = j;
+      work->pol->A_to_Alow[j] = j;
     } else {
       work->pol->A_to_Alow[j] = -1;
     }
-  }
 
-  for (j = 0; j < work->data->m; j++) {
-    if (work->data->u[j] - work->z[j] < work->y[j]) { // upper-active
-      work->pol->Aupp_to_A[work->pol->n_upp] = j;
-      work->pol->A_to_Aupp[j]                = work->pol->n_upp++;
+    if (work->data->u[j] - work->z[j] < work->y[j]) {
+      work->pol->Aupp_to_A[work->pol->n_upp++] = j;
+      work->pol->A_to_Aupp[j] = j;
     } else {
       work->pol->A_to_Aupp[j] = -1;
     }
   }
 
-  // Check if there are no active constraints
-  if (work->pol->n_low + work->pol->n_upp == 0) {
-    // Form empty Ared
-    work->pol->Ared = csc_spalloc(0, work->data->n, 0, 1, 0);
-    if (!(work->pol->Ared)) return -1;
-    int_vec_set_scalar(work->pol->Ared->p, 0, work->data->n + 1);
-    return 0; // mred = 0
-  }
+  vec_set_scalar(work->pol->Ared->x, 0., 2 * nnzA);
 
-  // Count number of elements in Ared
-  for (j = 0; j < work->data->A->p[work->data->A->n]; j++) {
-    if ((work->pol->A_to_Alow[work->data->A->i[j]] != -1) ||
-        (work->pol->A_to_Aupp[work->data->A->i[j]] != -1)) Ared_nnz++;
-  }
-
-  // Form Ared
-  // Ared = vstack[Alow, Aupp]
-  work->pol->Ared = csc_spalloc(work->pol->n_low + work->pol->n_upp,
-                                work->data->n, Ared_nnz, 1, 0);
-  if (!(work->pol->Ared)) return -1;
-  Ared_nnz = 0; // counter
-
-  for (j = 0; j < work->data->n; j++) { // Cycle over columns of A
-    work->pol->Ared->p[j] = Ared_nnz;
-
-    for (ptr = work->data->A->p[j]; ptr < work->data->A->p[j + 1]; ptr++) {
-      // Cycle over elements in j-th column
-      if (work->pol->A_to_Alow[work->data->A->i[ptr]] != -1) {
-        // Lower-active rows of A
-        work->pol->Ared->i[Ared_nnz] =
-          work->pol->A_to_Alow[work->data->A->i[ptr]];
-        work->pol->Ared->x[Ared_nnz++] = work->data->A->x[ptr];
-      } else if (work->pol->A_to_Aupp[work->data->A->i[ptr]] != -1) {
-        // Upper-active rows of A
-        work->pol->Ared->i[Ared_nnz] = work->pol->A_to_Aupp[work->data->A->i[ptr]] \
-                                       + work->pol->n_low;
-        work->pol->Ared->x[Ared_nnz++] = work->data->A->x[ptr];
-      }
+  for (ptr = 0; ptr < nnzA; ptr++) {
+    j = work->data->A->i[ptr];
+    if (work->pol->A_to_Alow[j] != -1) {
+      work->pol->Ared->x[work->pol->A_to_Alow_elem[ptr]] = work->data->A->x[ptr];
+    }
+    if (work->pol->A_to_Aupp[j] != -1) {
+      work->pol->Ared->x[work->pol->A_to_Aupp_elem[ptr]] = work->data->A->x[ptr];
     }
   }
-
-  // Update the last element in Ared->p
-  work->pol->Ared->p[work->data->n] = Ared_nnz;
-
-  // Return number of rows in Ared
-  return work->pol->n_low + work->pol->n_upp;
 }
 
 /**
- * Form reduced right-hand side rhs_red = vstack[-q, l_low, u_upp]
- * @param  work Workspace
- * @param  rhs  right-hand-side
- * @return      reduced rhs
+ * Form fixed-size right-hand side rhs_red = vstack[-q, l_low, u_upp].
+ * Inactive rows are left as zero.
  */
 static void form_rhs_red(OSQPWorkspace *work, c_float *rhs) {
   c_int j;
 
-  // Form the rhs of the reduced KKT linear system
-  for (j = 0; j < work->data->n; j++) { // -q
+  for (j = 0; j < work->data->n; j++) {
     rhs[j] = -work->data->q[j];
   }
 
-  for (j = 0; j < work->pol->n_low; j++) { // l_low
-    rhs[work->data->n + j] = work->data->l[work->pol->Alow_to_A[j]];
+  vec_set_scalar(rhs + work->data->n, 0., 2 * work->data->m);
+
+  for (j = 0; j < work->data->m; j++) {
+    if (work->pol->A_to_Alow[j] != -1) {
+      rhs[work->data->n + j] = work->data->l[j];
+    }
+    if (work->pol->A_to_Aupp[j] != -1) {
+      rhs[work->data->n + work->data->m + j] = work->data->u[j];
+    }
+  }
+}
+
+static c_int update_solver_sigma(OSQPWorkspace *work, c_float sigma) {
+  switch (work->settings->linsys_solver) {
+  case QDLDL_SOLVER:
+    ((qdldl_solver *)work->pol->linsys_solver)->sigma = sigma;
+    return 0;
+#ifdef ENABLE_MKL_PARDISO
+  case MKL_PARDISO_SOLVER:
+    ((pardiso_solver *)work->pol->linsys_solver)->sigma = sigma;
+    return 0;
+#endif
+  default:
+    return 1;
+  }
+}
+
+static c_int copy_linsys_solution(OSQPWorkspace *work, c_float *dst) {
+  c_int n = work->data->n + 2 * work->data->m;
+  switch (work->settings->linsys_solver) {
+  case QDLDL_SOLVER:
+    prea_vec_copy(((qdldl_solver *)work->pol->linsys_solver)->sol, dst, n);
+    return 0;
+#ifdef ENABLE_MKL_PARDISO
+  case MKL_PARDISO_SOLVER:
+    prea_vec_copy(((pardiso_solver *)work->pol->linsys_solver)->sol, dst, n);
+    return 0;
+#endif
+  default:
+    return 1;
+  }
+}
+
+static c_int update_polish_solver(OSQPWorkspace *work) {
+  c_int exitflag;
+
+  if (!work->pol->linsys_solver->update_matrices ||
+      !work->pol->linsys_solver->update_rho_vec) {
+    return 1;
   }
 
-  for (j = 0; j < work->pol->n_upp; j++) { // u_upp
-    rhs[work->data->n + work->pol->n_low + j] =
-      work->data->u[work->pol->Aupp_to_A[j]];
+  if (work->pol->delta != work->settings->delta) {
+    work->pol->delta = work->settings->delta;
+    vec_set_scalar(work->pol->rho_vec, 1. / work->pol->delta, 2 * work->data->m);
+
+    exitflag = update_solver_sigma(work, work->pol->delta);
+    if (exitflag) return exitflag;
+
+    exitflag = work->pol->linsys_solver->update_rho_vec(work->pol->linsys_solver,
+                                                        work->pol->rho_vec);
+    if (exitflag) return exitflag;
   }
+
+  return work->pol->linsys_solver->update_matrices(work->pol->linsys_solver,
+                                                   work->data->P,
+                                                   work->pol->Ared);
 }
 
 /**
@@ -125,11 +135,6 @@ static void form_rhs_red(OSQPWorkspace *work, c_float *rhs) {
  *    (repeat)
  *    1. (K + dK) * dz = b - K*z
  *    2. z <- z + dz
- * @param  work Solver workspace
- * @param  p    Private variable for solving linear system
- * @param  z    Initial z value
- * @param  b    RHS of the linear system
- * @return      Exitflag
  */
 static c_int iterative_refinement(OSQPWorkspace *work,
                                   LinSysSolver  *p,
@@ -138,213 +143,112 @@ static c_int iterative_refinement(OSQPWorkspace *work,
   c_int i, j, n;
   c_float *rhs;
 
-  if (work->settings->polish_refine_iter > 0) {
+  if (work->settings->polish_refine_iter <= 0) return 0;
 
-    // Assign dimension n
-    n = work->data->n + work->pol->Ared->m;
+  n   = work->data->n + 2 * work->data->m;
+  rhs = work->pol->rhs;
 
-    // Allocate rhs vector
-    rhs = (c_float *)c_malloc(sizeof(c_float) * n);
+  for (i = 0; i < work->settings->polish_refine_iter; i++) {
+    prea_vec_copy(b, rhs, n);
 
-    if (!rhs) {
-      return osqp_error(OSQP_MEM_ALLOC_ERROR);
-    } else {
-      for (i = 0; i < work->settings->polish_refine_iter; i++) {
-        // Form the RHS for the iterative refinement:  b - K*z
-        prea_vec_copy(b, rhs, n);
+    mat_vec(work->data->P, z, rhs, -1);
+    mat_tpose_vec(work->data->P, z, rhs, -1, 1);
+    mat_tpose_vec(work->pol->Ared, z + work->data->n, rhs, -1, 0);
+    mat_vec(work->pol->Ared, z, rhs + work->data->n, -1);
 
-        // Upper Part: R^{n}
-        // -= Px (upper triang)
-        mat_vec(work->data->P, z, rhs, -1);
+    if (p->solve(p, rhs) || copy_linsys_solution(work, rhs)) return 1;
 
-        // -= Px (lower triang)
-        mat_tpose_vec(work->data->P, z, rhs, -1, 1);
-
-        // -= Ared'*y_red
-        mat_tpose_vec(work->pol->Ared, z + work->data->n, rhs, -1, 0);
-
-        // Lower Part: R^{m}
-        mat_vec(work->pol->Ared, z, rhs + work->data->n, -1);
-
-        // Solve linear system. Store solution in rhs
-        p->solve(p, rhs);
-
-        // Update solution
-        for (j = 0; j < n; j++) {
-          z[j] += rhs[j];
-        }
-      }
+    for (j = 0; j < n; j++) {
+      z[j] += rhs[j];
     }
-    if (rhs) c_free(rhs);
   }
+
   return 0;
 }
 
 /**
- * Compute dual variable y from yred
- * @param work Workspace
- * @param yred Dual variables associated to active constraints
+ * Compute dual variable y from fixed-size yred = vstack[ylow, yupp].
  */
-static void get_ypol_from_yred(OSQPWorkspace *work, c_float *yred) {
+static void get_ypol_from_yred(OSQPWorkspace *work, const c_float *yred) {
   c_int j;
 
-  // If there are no active constraints
-  if (work->pol->n_low + work->pol->n_upp == 0) {
-    vec_set_scalar(work->pol->y, 0., work->data->m);
-    return;
-  }
-
-  // NB: yred = vstack[ylow, yupp]
   for (j = 0; j < work->data->m; j++) {
+    work->pol->y[j] = 0.0;
+
     if (work->pol->A_to_Alow[j] != -1) {
-      // lower-active
-      work->pol->y[j] = yred[work->pol->A_to_Alow[j]];
-    } else if (work->pol->A_to_Aupp[j] != -1) {
-      // upper-active
-      work->pol->y[j] = yred[work->pol->A_to_Aupp[j] + work->pol->n_low];
-    } else {
-      // inactive
-      work->pol->y[j] = 0.0;
+      work->pol->y[j] += yred[j];
+    }
+    if (work->pol->A_to_Aupp[j] != -1) {
+      work->pol->y[j] += yred[work->data->m + j];
     }
   }
 }
 
 c_int polish(OSQPWorkspace *work) {
-  c_int mred, polish_successful, exitflag;
-  c_float *rhs_red;
+  c_int exitflag;
+  c_int polish_successful;
   LinSysSolver *plsh;
-  c_float *pol_sol; // Polished solution
 
 #ifdef PROFILING
-  osqp_tic(work->timer); // Start timer
+  osqp_tic(work->timer);
 #endif /* ifdef PROFILING */
 
-  // Form Ared by assuming the active constraints and store in work->pol->Ared
-  mred = form_Ared(work);
-  if (mred < 0) { // work->pol->red = OSQP_NULL
-    // Polishing failed
-    work->info->status_polish = -1;
+  plsh = work->pol->linsys_solver;
 
-    return -1;
-  }
+  form_Ared(work);
+  form_rhs_red(work, work->pol->rhs_red);
+  prea_vec_copy(work->pol->rhs_red, work->pol->pol_sol,
+                work->data->n + 2 * work->data->m);
 
-  // Form and factorize reduced KKT
-  exitflag = init_linsys_solver(&plsh, work->data->P, work->pol->Ared,
-                                work->settings->delta, OSQP_NULL,
-                                work->settings->linsys_solver, 1);
-
+  exitflag = update_polish_solver(work);
   if (exitflag) {
-    // Polishing failed
     work->info->status_polish = -1;
-
-    // Memory clean-up
-    if (work->pol->Ared) csc_spfree(work->pol->Ared);
-
     return 1;
   }
 
-  // Form reduced right-hand side rhs_red
-  rhs_red = c_malloc(sizeof(c_float) * (work->data->n + mred));
-  if (!rhs_red) {
-    // Polishing failed
+  exitflag = plsh->solve(plsh, work->pol->pol_sol);
+  if (exitflag || copy_linsys_solution(work, work->pol->pol_sol)) {
     work->info->status_polish = -1;
-
-    // Memory clean-up
-    csc_spfree(work->pol->Ared);
-
-    return -1;
-  }
-  form_rhs_red(work, rhs_red);
-
-  pol_sol = vec_copy(rhs_red, work->data->n + mred);
-  if (!pol_sol) {
-    // Polishing failed
-    work->info->status_polish = -1;
-
-    // Memory clean-up
-    csc_spfree(work->pol->Ared);
-    c_free(rhs_red);
-  
-    return -1;
+    return 1;
   }
 
-  // Solve the reduced KKT system
-  plsh->solve(plsh, pol_sol);
-
-  // Perform iterative refinement to compensate for the regularization error
-  exitflag = iterative_refinement(work, plsh, pol_sol, rhs_red);
-
+  exitflag = iterative_refinement(work, plsh, work->pol->pol_sol, work->pol->rhs_red);
   if (exitflag) {
-    // Polishing failed
     work->info->status_polish = -1;
-
-    // Memory clean-up
-    csc_spfree(work->pol->Ared);
-    c_free(rhs_red);
-    c_free(pol_sol);
-  
     return -1;
   }
 
-  // Store the polished solution (x,z,y)
-  prea_vec_copy(pol_sol, work->pol->x, work->data->n);   // pol->x
-  mat_vec(work->data->A, work->pol->x, work->pol->z, 0); // pol->z
-  get_ypol_from_yred(work, pol_sol + work->data->n);     // pol->y
+  prea_vec_copy(work->pol->pol_sol, work->pol->x, work->data->n);
+  mat_vec(work->data->A, work->pol->x, work->pol->z, 0);
+  get_ypol_from_yred(work, work->pol->pol_sol + work->data->n);
 
-  // Ensure (z,y) satisfies normal cone constraint
   project_normalcone(work, work->pol->z, work->pol->y);
 
-  // Compute primal and dual residuals at the polished solution
   update_info(work, 0, 1, 1);
 
-  // Check if polish was successful
   polish_successful = (work->pol->pri_res < work->info->pri_res &&
-                       work->pol->dua_res < work->info->dua_res) || // Residuals
-                                                                    // are
-                                                                    // reduced
+                       work->pol->dua_res < work->info->dua_res) ||
                       (work->pol->pri_res < work->info->pri_res &&
-                       work->info->dua_res < 1e-10) ||              // Dual
-                                                                    // residual
-                                                                    // already
-                                                                    // tiny
+                       work->info->dua_res < 1e-10) ||
                       (work->pol->dua_res < work->info->dua_res &&
-                       work->info->pri_res < 1e-10);                // Primal
-                                                                    // residual
-                                                                    // already
-                                                                    // tiny
+                       work->info->pri_res < 1e-10);
 
   if (polish_successful) {
-    // Update solver information
     work->info->obj_val       = work->pol->obj_val;
     work->info->pri_res       = work->pol->pri_res;
     work->info->dua_res       = work->pol->dua_res;
     work->info->status_polish = 1;
 
-    // Update (x, z, y) in ADMM iterations
-    // NB: z needed for warm starting
     prea_vec_copy(work->pol->x, work->x, work->data->n);
     prea_vec_copy(work->pol->z, work->z, work->data->m);
     prea_vec_copy(work->pol->y, work->y, work->data->m);
 
-    // Print summary
 #ifdef PRINTING
-
     if (work->settings->verbose) print_polish(work);
 #endif /* ifdef PRINTING */
-  } else { // Polishing failed
+  } else {
     work->info->status_polish = -1;
-
-    // TODO: Try to find a better solution on the line connecting ADMM
-    //       and polished solution
   }
-
-  // Memory clean-up
-  plsh->free(plsh);
-
-  // Checks that they are not NULL are already performed earlier
-  csc_spfree(work->pol->Ared);
-  c_free(rhs_red);
-  c_free(pol_sol);
 
   return 0;
 }

--- a/tests/basic_qp/test_basic_qp.h
+++ b/tests/basic_qp/test_basic_qp.h
@@ -388,6 +388,64 @@ void test_basic_qp_solve()
   c_free(P_tmp);
 }
 
+#ifdef OSQP_CUSTOM_MEMORY_TEST
+#ifdef __cplusplus
+extern "C" {
+#endif
+extern long int alloc_counter;
+#ifdef __cplusplus
+}
+#endif
+
+void test_basic_qp_polish_no_alloc()
+{
+  c_int exitflag;
+  long int alloc_after_setup;
+
+  OSQPSettings *settings = (OSQPSettings *)c_malloc(sizeof(OSQPSettings));
+  OSQPWorkspace *work;
+  OSQPData *data;
+  basic_qp_sols_data *sols_data;
+
+  data = generate_problem_basic_qp();
+  sols_data = generate_problem_basic_qp_sols_data();
+
+  osqp_set_default_settings(settings);
+  settings->max_iter           = 2000;
+  settings->alpha              = 1.6;
+  settings->polish             = 1;
+  settings->polish_refine_iter = 3;
+  settings->scaling            = 0;
+  settings->verbose            = 0;
+  settings->warm_start         = 0;
+
+  exitflag = osqp_setup(&work, data, settings);
+  mu_assert("Basic QP custom memory test: Setup error!", exitflag == 0);
+
+  alloc_after_setup = alloc_counter;
+
+  exitflag = osqp_solve(work);
+  mu_assert("Basic QP custom memory test: Solve error!", exitflag == 0);
+  mu_assert("Basic QP custom memory test: Unexpected allocation during polish solve!",
+            alloc_counter == alloc_after_setup);
+  mu_assert("Basic QP custom memory test: Wrong solver status after polish solve!",
+            work->info->status_val == sols_data->status_test);
+
+  exitflag = osqp_update_delta(work, 1e-5);
+  mu_assert("Basic QP custom memory test: Delta update error!", exitflag == 0);
+
+  exitflag = osqp_solve(work);
+  mu_assert("Basic QP custom memory test: Solve error after delta update!", exitflag == 0);
+  mu_assert("Basic QP custom memory test: Unexpected allocation after delta update!",
+            alloc_counter == alloc_after_setup);
+
+  osqp_cleanup(work);
+  clean_problem_basic_qp(data);
+  clean_problem_basic_qp_sols_data(sols_data);
+  c_free(settings);
+}
+#endif
+
 #ifdef ENABLE_MKL_PARDISO
 void test_basic_qp_solve_pardiso()
 {

--- a/tests/osqp_tester.cpp
+++ b/tests/osqp_tester.cpp
@@ -67,6 +67,11 @@ TEST_CASE( "test_basic_qp", "[multi-file:4]" ) {
         test_basic_qp_solve_pardiso();
     }
 #endif
+#ifdef OSQP_CUSTOM_MEMORY_TEST
+    SECTION( "test_basic_qp_polish_no_alloc" ) {
+        test_basic_qp_polish_no_alloc();
+    }
+#endif
     SECTION( "test_basic_qp_update" ) {
         test_basic_qp_update();
     }

--- a/tests/primal_infeasibility/generate_problem.py
+++ b/tests/primal_infeasibility/generate_problem.py
@@ -14,10 +14,10 @@ m = 150
 Pt = sparse.random(n, n, random_state=rg)
 P = Pt.T.dot(Pt) + sparse.eye(n)
 P = sparse.triu(P, format='csc')
-q = sp.randn(n)
+q = rg.standard_normal(n)
 A = sparse.random(m, n, random_state=rg).tolil()  # Lil for efficiency
-u = 3 + sp.randn(m)
-l = -3 + sp.randn(m)
+u = 3 + rg.standard_normal(m)
+l = -3 + rg.standard_normal(m)
 
 # Make random problem primal infeasible
 A[int(n/2), :] = A[int(n/2)+1, :]


### PR DESCRIPTION
## Summary
- preallocate the polishing workspace and fixed duplicated active-set matrix during `osqp_setup`
- reuse a dedicated polish linear-system solver and scratch buffers so `polish()` does not allocate
- add a custom-memory regression test for no allocations after setup and fix the unit-test generator for current SciPy

## Verification
- `cmake -S . -B build-prealloc -DUNITTESTS=ON`
- `cmake --build build-prealloc --target osqp_tester`
- `cmd /c "build-prealloc\\out\\Debug\\osqp_tester.exe test_basic_qp -c test_basic_qp_solve"`
- `cmake -S . -B build-prealloc-custom2 -DUNITTESTS=ON -DOSQP_CUSTOM_MEMORY=C:/projects/coker/coker_runtime/crates/coker-osqp-ffi/osqp/tests/custom_memory/custom_memory.h`
- `cmake --build build-prealloc-custom2 --target osqp_tester_custom_memory`
- `cmd /c "build-prealloc-custom2\\out\\Debug\\osqp_tester_custom_memory.exe test_basic_qp -c test_basic_qp_polish_no_alloc"`